### PR TITLE
Temporarily disable branch protection rules when the bot commits code

### DIFF
--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -72,9 +72,50 @@ jobs:
             echo "No change in package.json, not regenerating third-party notices"
           fi
 
+      - name: Temporarily disable "required_pull_request_reviews" branch protection
+        id: disable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'develop',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: null,
+              required_pull_request_reviews: null
+            })
+            console.log("Result:", result)
+
       - name: Push Commit
         if: steps.generate-notices.outputs.commit == 'true'
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
           branch: develop
+
+      - name: Re-enable "required_pull_request_reviews" branch protection
+        id: enable-branch-protection
+        if: always()
+        uses: actions/github-script@v1
+        with:
+          github-token: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          previews: luke-cage-preview
+          script: |
+            const result = await github.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'develop',
+              required_status_checks: null,
+              restrictions: null,
+              enforce_admins: true,
+              required_pull_request_reviews: {
+                dismiss_stale_reviews: true,
+                required_approving_review_count: 1
+              }
+            })
+            console.log("Result:", result)


### PR DESCRIPTION
Closes #28 

## Description

Using the GitHub API, temporarily disable branch protection rules to allow the bot to commit and push code. Once done, re-enable the branch protection rules.

Original source: https://github.com/newrelic/template-nerdpack/blob/main/.github/workflows/release.yml#L189-L238