### PR TITLE
Add keywords to package.json

### DIFF
--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -11,6 +11,8 @@
     "clean": "gatsby clean",
     "develop": "gatsby develop"
   },
+  "homepage": "https://github.com/newrelic/gatsby-theme-newrelic/tree/develop/packages/gatsby-theme-newrelic",
+  "repository": "https://github.com/newrelic/gatsby-theme-newrelic",
   "keywords": [
     "gatsby",
     "gatsby-theme",

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -17,7 +17,8 @@
     "gatsby",
     "gatsby-theme",
     "gatsby-plugin",
-    "react"
+    "react",
+    "newrelic"
   ],
   "peerDependencies": {
     "@emotion/core": "^10.0.28",

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -11,6 +11,12 @@
     "clean": "gatsby clean",
     "develop": "gatsby develop"
   },
+  "keywords": [
+    "gatsby",
+    "gatsby-theme",
+    "gatsby-plugin",
+    "react"
+  ],
   "peerDependencies": {
     "@emotion/core": "^10.0.28",
     "@emotion/styled": "^10.0.27",


### PR DESCRIPTION
## Description

Add the `keywords` field to `package.json` to make it more discoverable, and prepare the package for sharing on Gatsby's website.