### PR TITLE
Update GitHub token env var name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,5 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ env.BOT_EMAIL }}
           GIT_COMMITTER_NAME: ${{ env.BOT_NAME }}
           GIT_COMMITTER_EMAIL: ${{ env.BOT_EMAIL }}
-          GITHUB_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
         run: yarn release


### PR DESCRIPTION
## Description

Fixes [failing lerna publish action](https://github.com/newrelic/gatsby-theme-newrelic/runs/919890194?check_suite_focus=true) which expects a `GH_TOKEN` environment variable.