### PR TITLE
Document interactive prop

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -755,9 +755,10 @@ import { Surface } from '@newrelic/gatsby-theme-newrelic';
 
 **Props**
 
-| Prop   | Type | Required | Description                                                                                                                                                                                                                                    |
-| ------ | ---- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `base` | enum | yes      | Tells the `Surface` what kind of base element the surface is rendered on. For example, a primary base means the surface is rendered on an element with a primary background. Must be one of `Surface.BASE.PRIMARY` or `Surface.BASE.SECONDARY` |
+| Prop          | Type    | Required | Default | Description                                                                                                                                                                                                                                    |
+| ------------- | ------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `base`        | enum    | yes      |         | Tells the `Surface` what kind of base element the surface is rendered on. For example, a primary base means the surface is rendered on an element with a primary background. Must be one of `Surface.BASE.PRIMARY` or `Surface.BASE.SECONDARY` |
+| `interactive` | boolean | no       | `false` | Determines whether the surface is interactive (e.g. if the entire surface is a link).                                                                                                                                                          |
 
 **Example**
 

--- a/packages/gatsby-theme-newrelic/src/components/Surface.js
+++ b/packages/gatsby-theme-newrelic/src/components/Surface.js
@@ -58,6 +58,11 @@ const Surface = styled.div`
 
 Surface.propTypes = {
   base: PropTypes.oneOf(Object.values(BASES)).isRequired,
+  interactive: PropTypes.boolean,
+};
+
+Surface.defaultProps = {
+  interactive: false,
 };
 
 Surface.BASE = BASES;


### PR DESCRIPTION
## Description

The `Surface` component has an `interactive` prop that can be toggled to add interactive styling to the surface. This PR adds the documentation and prop type for that prop.

[Rendered](https://github.com/newrelic/gatsby-theme-newrelic/tree/jerel/document-interactive-prop/packages/gatsby-theme-newrelic)