### PR TITLE
Don't index the global header with swiftype

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -50,6 +50,7 @@ const GlobalHeader = ({ editUrl, className }) => {
 
   return (
     <div
+      data-swiftype-index={false}
       className={className}
       css={css`
         background-color: var(--color-neutrals-100);


### PR DESCRIPTION
## Description

Prevent Swiftype from indexing the global header content as part of the page content.