### PR TITLE
Add support link to explorers hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,13 @@ Available themes:
 We're currently developing this package, and will provide test information as
 we build out the library.
 
-<!--
 ## Support
 
 New Relic hosts and moderates an online forum where customers can interact with
 New Relic employees as well as other customers to get help and share best
 practices. Like all official New Relic open source projects, there's a related
-Community topic in the New Relic Explorers Hub. You can find this project's
-topic/threads here:
--->
+[Community topic](https://discuss.newrelic.com/t/announcing-a-new-relic-gatsby-site-theme/109814)
+in the New Relic Explorers Hub.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Adds the support link to Explorer's hub for the project to the README

[Rendered](https://github.com/newrelic/gatsby-theme-newrelic/blob/jerel/support-thread/README.md)