### PR TITLE
Fix issues when pressing "enter" key while searching

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -35,6 +35,7 @@ websites](https://opensource.newrelic.com).
 - [Hooks](#hooks)
   - [`useClipboard`](#useclipboard)
   - [`useFormattedCode`](#useformattedcode)
+  - [`useQueryParams`](#usequeryparams)
   - [`useTimeout`](#usetimeout)
 - [Utils](#utils)
   - [`formatCode`](#formatcode)
@@ -960,6 +961,44 @@ With formatting options:
 
 ```js
 const formattedCode = useFormattedCode(code, { printWidth: 100 });
+```
+
+### `useQueryParams`
+
+A hook that gets the URL's query params and allows you to set them.
+
+```js
+import { useQueryParams } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Arguments**
+
+There are no arguments for this hook.
+
+**Returns**
+
+`Object`
+
+- `queryParams` - an instance of [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)
+- `setQueryParam` - a function to update a query parameter in the URL.
+  Anologous to `queryParams.set(...)` but this will also navigate for you.
+
+**Examples**
+
+```js
+const SearchInput = () => {
+  const { queryParams, setQueryParam } = useQueryParams();
+
+  return (
+    <input
+      type="text"
+      value={queryParams.get('q')}
+      onChange={(e) => {
+        setQueryParam('q', e.target.value);
+      }}
+    />
+  );
+};
 ```
 
 ### `useTimeout`

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -18,4 +18,5 @@ export { default as Video } from './src/components/Video';
 export { default as formatCode } from './src/utils/formatCode';
 export { default as useClipboard } from './src/hooks/useClipboard';
 export { default as useFormattedCode } from './src/hooks/useFormattedCode';
+export { default as useQueryParams } from './src/hooks/useQueryParams';
 export { default as useTimeout } from './src/hooks/useTimeout';

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -55,7 +55,6 @@
     "polished": "^3.6.5",
     "prism-react-renderer": "^1.1.1",
     "prismjs": "^1.20.0",
-    "query-string": "^6.13.1",
     "react-live": "^2.2.2",
     "react-middle-ellipsis": "^1.1.0",
     "react-simple-code-editor": "^0.11.0",

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -90,8 +90,11 @@ const GlobalHeader = ({ editUrl, className, search }) => {
           >
             <SwiftypeSearch
               css={css`
+                display: flex;
+                flex-direction: column;
                 width: 950px;
                 margin: 3rem auto;
+                height: calc(100vh - 6rem);
               `}
             />
           </Overlay>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
-import { graphql, useStaticQuery } from 'gatsby';
+import { graphql, useStaticQuery, Link } from 'gatsby';
 import DarkModeToggle from './DarkModeToggle';
 import ExternalLink from './ExternalLink';
 import NewRelicLogo from './NewRelicLogo';
@@ -10,7 +10,8 @@ import SwiftypeSearch from './SwiftypeSearch';
 import Overlay from './Overlay';
 import GlobalNavLink from './GlobalNavLink';
 import useMedia from 'use-media';
-import { useLocation, navigate } from '@reach/router';
+import { useLocation, useNavigate } from '@reach/router';
+import useQueryParams from '../hooks/useQueryParams';
 
 const styles = {
   actionLink: css`
@@ -30,18 +31,8 @@ const styles = {
 
 const GlobalHeader = ({ editUrl, className, search }) => {
   const location = useLocation();
-  const query = new URLSearchParams(location.search);
-  const [isOverlayOpen, setIsOverlayOpen] = useState(query.has('q'));
-
-  useEffect(() => {
-    if (isOverlayOpen && !new URLSearchParams(location.search).has('q')) {
-      navigate(`${location.pathname}?q=`);
-    }
-
-    if (!isOverlayOpen) {
-      navigate(location.pathname);
-    }
-  }, [isOverlayOpen, location.pathname, location.search]);
+  const navigate = useNavigate();
+  const { queryParams } = useQueryParams();
 
   const { site } = useStaticQuery(graphql`
     query GlobalHeaderQuery {
@@ -94,8 +85,8 @@ const GlobalHeader = ({ editUrl, className, search }) => {
       >
         {search && (
           <Overlay
-            isOpen={isOverlayOpen}
-            onCloseOverlay={() => setIsOverlayOpen(false)}
+            isOpen={queryParams.has('q')}
+            onCloseOverlay={() => navigate(location.pathname)}
           >
             <SwiftypeSearch
               css={css`
@@ -198,12 +189,13 @@ const GlobalHeader = ({ editUrl, className, search }) => {
           )}
           {search && !hideMenuLinks && (
             <li>
-              <Icon
-                css={styles.actionIcon}
-                name={Icon.TYPE.SEARCH}
-                size="0.875rem"
-                onClick={() => setIsOverlayOpen(true)}
-              />
+              <Link to="?q=" css={styles.actionLink}>
+                <Icon
+                  css={styles.actionIcon}
+                  name={Icon.TYPE.SEARCH}
+                  size="0.875rem"
+                />
+              </Link>
             </li>
           )}
           <li>

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -16,8 +16,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import styles from '../styles/SwiftypeSearchStyles';
-import { navigate, useLocation } from '@reach/router';
-import qs from 'query-string';
+import useQueryParams from '../hooks/useQueryParams';
 
 const connector = new SiteSearchAPIConnector({
   documentType: 'page',
@@ -51,7 +50,8 @@ const configOptions = {
 };
 
 const SwiftypeSearch = ({ className }) => {
-  const location = useLocation();
+  const { setQueryParam } = useQueryParams();
+
   return (
     <div css={styles} className={className}>
       <SearchProvider config={configOptions}>
@@ -72,10 +72,7 @@ const SwiftypeSearch = ({ className }) => {
                   debounceLength={500}
                   inputView={InputView}
                   onSubmit={(searchTerm) => {
-                    const queryString = qs.parse(location.search);
-
-                    queryString.q = searchTerm;
-                    navigate(location.pathname + qs.stringify(queryString));
+                    setQueryParam('q', searchTerm);
                   }}
                 />
                 {isLoading && (

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -12,7 +12,6 @@ import ResultView from './ResultView';
 import PagingInfoView from './PagingInfoView';
 import SearchInput from './SearchInput';
 import Icon from './Icon';
-import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import PropTypes from 'prop-types';
 import styles from '../styles/SwiftypeSearchStyles';
@@ -89,14 +88,14 @@ const SwiftypeSearch = ({ className }) => {
                     <PagingInfo view={PagingInfoView} />
 
                     {hasResults && (
-                      <StyledResultsContainer>
+                      <>
                         <Results
                           resultView={ResultView}
                           titleField="title"
                           urlField="url"
                         />
                         <Paging />
-                      </StyledResultsContainer>
+                      </>
                     )}
                   </>
                 )}
@@ -138,10 +137,5 @@ InputView.propTypes = {
   getAutocomplete: PropTypes.func,
   getInputProps: PropTypes.func,
 };
-
-const StyledResultsContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
 
 export default SwiftypeSearch;

--- a/packages/gatsby-theme-newrelic/src/hooks/useQueryParams.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useQueryParams.js
@@ -1,0 +1,24 @@
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from '@reach/router';
+
+const useQueryParams = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const queryParams = useMemo(() => new URLSearchParams(location.search), [
+    location.search,
+  ]);
+
+  const setQueryParam = useCallback(
+    (key, value) => {
+      queryParams.set(key, value);
+
+      navigate(`?${queryParams}`);
+    },
+    [queryParams, navigate]
+  );
+
+  return { queryParams, setQueryParam };
+};
+
+export default useQueryParams;

--- a/packages/gatsby-theme-newrelic/src/styles/SwiftypeSearchStyles.js
+++ b/packages/gatsby-theme-newrelic/src/styles/SwiftypeSearchStyles.js
@@ -869,8 +869,8 @@ export default css`
   .sui-results-container {
     padding: 0;
     list-style: none;
-    height: 100vh;
     overflow-y: auto;
+    flex: 1;
   }
   .sui-results-per-page {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,


### PR DESCRIPTION
## Description

This PR addresses the issue where pressing the "enter" key after searching would result in a 404 page due to how the page would navigate. This PR also fixes the double scroll issue in the search overlay when looking at a page of results.