### PR TITLE
Add a sign up button + other minor global header improvements

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -245,7 +245,7 @@ const IndexPage = ({ data }) => {
           <h2>Feedback</h2>
           <div
             css={css`
-              width: 350px;
+              max-width: 350px;
             `}
           >
             <Feedback

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -8,6 +8,8 @@ import {
   CodeBlock,
   Feedback,
   GlobalHeader,
+  HamburgerMenu,
+  NewRelicLogo,
   SearchInput,
   Surface,
   Tag,
@@ -37,6 +39,7 @@ const liveCodeSample = `
 const IndexPage = ({ data }) => {
   const { layout, siteMetadata } = data.site;
   const [searchTerm, setSearchTerm] = useState('');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
     <>
@@ -44,6 +47,25 @@ const IndexPage = ({ data }) => {
         editUrl={`${siteMetadata.repository}/tree/develop/demo/src/pages/index.js`}
         search
       />
+      <header
+        css={css`
+          display: none;
+          padding: 1rem ${layout.contentPadding};
+          justify-content: space-between;
+          align-items: center;
+
+          @media screen and (max-width: 400px) {
+            display: flex;
+          }
+        `}
+      >
+        <NewRelicLogo />
+        <HamburgerMenu
+          onToggle={() => setIsMenuOpen((isOpen) => !isOpen)}
+          isOpen={isMenuOpen}
+        />
+      </header>
+
       <div
         css={css`
           margin: 0 auto;

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -12,7 +12,6 @@ import {
   Surface,
   Tag,
   TagList,
-  HamburgerMenu,
   Video,
 } from '@newrelic/gatsby-theme-newrelic';
 
@@ -38,7 +37,6 @@ const liveCodeSample = `
 const IndexPage = ({ data }) => {
   const { layout, siteMetadata } = data.site;
   const [searchTerm, setSearchTerm] = useState('');
-  const [isHamburgerOpen, setIsHamburgerOpen] = useState(false);
 
   return (
     <>

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -72,20 +72,18 @@ const IndexPage = ({ data }) => {
         <section>
           <h2>Search inputs</h2>
           <SearchInput
-            style={{ margin: '1rem 0' }}
+            style={{ margin: '1rem 0', maxWidth: '500px' }}
             placeholder="Test out a medium search"
             onClear={() => setSearchTerm('')}
             onChange={(e) => setSearchTerm(e.target.value)}
             value={searchTerm}
-            width="500px"
           />
           <SearchInput
-            style={{ marginBottom: '1rem' }}
+            style={{ marginBottom: '1rem', maxWidth: '500px' }}
             placeholder="Test out a large search"
             onClear={() => setSearchTerm('')}
             onChange={(e) => setSearchTerm(e.target.value)}
             value={searchTerm}
-            width="500px"
             size={SearchInput.SIZE.LARGE}
           />
         </section>

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -122,14 +122,63 @@ const IndexPage = ({ data }) => {
           </CodeBlock>
         </section>
         <section>
-          <h2>A button</h2>
-          <Button
-            onClick={() => alert('Hello!')}
-            variant={Button.VARIANT.PRIMARY}
-            size={Button.SIZE.LARGE}
+          <h2>Buttons</h2>
+          <h3>Variants</h3>
+          <div
+            css={css`
+              display: flex;
+              gap: 1rem;
+              margin-bottom: 2rem;
+            `}
           >
-            Click me
-          </Button>
+            <Button
+              onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.PRIMARY}
+            >
+              Primary
+            </Button>
+            <Button
+              onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.NORMAL}
+            >
+              Normal
+            </Button>
+            <Button
+              onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.LINK}
+            >
+              Link
+            </Button>
+          </div>
+          <h3>Sizes</h3>
+          <div
+            css={css`
+              display: flex;
+              align-items: flex-start;
+              gap: 1rem;
+            `}
+          >
+            <Button
+              onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.PRIMARY}
+            >
+              Default
+            </Button>
+            <Button
+              onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.PRIMARY}
+              size={Button.SIZE.SMALL}
+            >
+              Small
+            </Button>
+            <Button
+              onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.PRIMARY}
+              size={Button.SIZE.EXTRA_SMALL}
+            >
+              Extra small
+            </Button>
+          </div>
         </section>
         <section>
           <h2>Primary surfaces</h2>

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -46,26 +46,6 @@ const IndexPage = ({ data }) => {
         editUrl={`${siteMetadata.repository}/tree/develop/demo/src/pages/index.js`}
         search
       />
-      <header
-        css={css`
-          position: relative;
-          border-bottom: 1px solid var(--divider-color);
-          padding: 0 2rem;
-          width: 100vw;
-        `}
-      >
-        <div
-          css={css`
-            display: flex;
-            justify-content: flex-end;
-          `}
-        >
-          <HamburgerMenu
-            isOpen={isHamburgerOpen}
-            onToggle={() => setIsHamburgerOpen(!isHamburgerOpen)}
-          />
-        </div>
-      </header>
       <div
         css={css`
           margin: 0 auto;

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -221,11 +221,11 @@ import { Button } from '@newrelic/gatsby-theme-newrelic'`
 
 **Props**
 
-| Prop    | Type          | Required | Default  | Description                                                                                                                       |
-| ------- | ------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| variant | enum          | yes      |          | Configures the variant of the button. Must be one of `Button.VARIANT.PLAIN`, `Button.VARIANT.PRIMARY`, or `Button.VARIANT.NORMAL` |
-| size    | enum          | no       |          | Configures the size of the button. Can be configured to `Button.SIZE.SMALL`                                                       |
-| as      | React element | no       | `button` | Render the button as a different base element. Useful when you want to style links as buttons.                                    |
+| Prop    | Type          | Required | Default  | Description                                                                                                                      |
+| ------- | ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| variant | enum          | yes      |          | Configures the variant of the button. Must be one of `Button.VARIANT.LINK`, `Button.VARIANT.PRIMARY`, or `Button.VARIANT.NORMAL` |
+| size    | enum          | no       |          | Configures the size of the button. Can be configured to `Button.SIZE.SMALL`                                                      |
+| as      | React element | no       | `button` | Render the button as a different base element. Useful when you want to style links as buttons.                                   |
 
 Additional props are forwarded to the underlying element specified by the `as`
 prop.

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -32,6 +32,7 @@ const styles = {
       background-color: var(--color-brand-600);
 
       &:hover {
+        color: var(--color-white);
         background-color: var(--color-brand-500);
       }
     `,

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -9,6 +9,7 @@ const VARIANTS = {
 };
 
 const SIZES = {
+  EXTRA_SMALL: 'extraSmall',
   SMALL: 'small',
 };
 
@@ -16,6 +17,11 @@ const styles = {
   size: {
     [SIZES.SMALL]: css`
       font-size: 0.75rem;
+    `,
+    [SIZES.EXTRA_SMALL]: css`
+      font-size: 0.675rem;
+      padding: 0.25rem 0.625rem;
+      border-radius: 0.125rem;
     `,
   },
   variant: {

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -20,7 +20,7 @@ const styles = {
       font-size: 0.75rem;
     `,
     [SIZES.EXTRA_SMALL]: css`
-      font-size: 0.675rem;
+      font-size: 0.75rem;
       padding: 0.25rem 0.625rem;
       border-radius: 0.125rem;
     `,

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -86,6 +86,7 @@ const Button = styled.button`
   border-width: 1px;
   border-style: solid;
   transition: all 0.09s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  white-space: nowrap;
 
   &:hover {
     transform: translate3d(0, -1px, 0);

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -20,8 +20,8 @@ const styles = {
       font-size: 0.75rem;
     `,
     [SIZES.EXTRA_SMALL]: css`
-      font-size: 0.75rem;
-      padding: 0.25rem 0.625rem;
+      font-size: 0.625rem;
+      padding: 0.375rem 0.625rem;
       border-radius: 0.125rem;
     `,
   },

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import styled from '@emotion/styled';
+import { rgba } from 'polished';
 
 const VARIANTS = {
-  PLAIN: 'plain',
   PRIMARY: 'primary',
   NORMAL: 'normal',
+  LINK: 'link',
 };
 
 const SIZES = {
@@ -26,31 +27,41 @@ const styles = {
   },
   variant: {
     [VARIANTS.PRIMARY]: css`
+      border: 0;
       color: var(--color-white);
-      border-color: var(--color-brand-800);
-      background-color: var(--color-brand-800);
-      .dark-mode & {
-        color: var(--primary-background-color);
-        background-color: var(--color-brand-400);
-        border-color: var(--color-brand-400);
+      background-color: var(--color-brand-600);
+
+      &:hover {
+        background-color: var(--color-brand-500);
+      }
+    `,
+    [VARIANTS.LINK]: css`
+      border: 0;
+      color: var(--link-color);
+      background: transparent;
+
+      &:hover {
+        color: var(--link-hover-color);
       }
     `,
     [VARIANTS.NORMAL]: css`
-      color: var(--color-neutrals-800);
-      border-color: var(--color-neutrals-100);
+      border: 0;
+      color: var(--color-neutrals-700);
       background-color: var(--color-neutrals-100);
-      .dark-mode & {
-        color: var(--color-white);
-        border-color: var(--color-dark-100);
-        background-color: var(--color-dark-100);
+
+      &:hover {
+        color: var(--color-brand-600);
+        background: ${rgba('#70ccd2', 0.17)};
       }
-    `,
-    [VARIANTS.PLAIN]: css`
-      color: var(--color-brand-800);
-      border-color: transparent;
-      background-color: transparent;
+
       .dark-mode & {
-        color: var(--color-brand-400);
+        color: var(--color-dark-700);
+        background-color: var(--color-dark-200);
+
+        &:hover {
+          color: var(--color-brand-200);
+          background-color: ${rgba('#70ccd2', 0.17)};
+        }
       }
     `,
   },
@@ -73,6 +84,12 @@ const Button = styled.button`
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
+  transition: all 0.09s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  &:hover {
+    transform: translateY(-1px);
+  }
+
   ${({ variant }) => styles.variant[variant]}
   ${({ size }) => styles.size[size]}
   ${({ disabled }) => disabled && styles.disabled}

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -87,7 +87,7 @@ const Button = styled.button`
   transition: all 0.09s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 
   &:hover {
-    transform: translateY(-1px);
+    transform: translate3d(0, -1px, 0);
   }
 
   ${({ variant }) => styles.variant[variant]}

--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -126,7 +126,7 @@ const CodeBlock = ({
               </div>
               <Button
                 type="button"
-                variant={Button.VARIANT.PLAIN}
+                variant={Button.VARIANT.LINK}
                 onClick={() => copy(code)}
                 size={Button.SIZE.SMALL}
                 css={css`

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/core';
 import { graphql, useStaticQuery, Link } from 'gatsby';
 import DarkModeToggle from './DarkModeToggle';
 import ExternalLink from './ExternalLink';
+import Button from './Button';
 import NewRelicLogo from './NewRelicLogo';
 import Icon from './Icon';
 import SwiftypeSearch from './SwiftypeSearch';
@@ -33,7 +34,7 @@ const actionIcon = css`
   cursor: pointer;
 `;
 
-const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
+const GlobalHeader = ({ className, search, utmSource }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { queryParams } = useQueryParams();
@@ -45,21 +46,14 @@ const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
           contentPadding
           maxWidth
         }
-        siteMetadata {
-          repository
-          siteUrl
-        }
       }
     }
   `);
 
   const hideLogoText = useMedia({ maxWidth: '600px' });
-  const hideMenuLinks = useMedia({ maxWidth: '530px' });
+  const hideMenuLinks = useMedia({ maxWidth: '650px' });
 
-  const {
-    layout,
-    siteMetadata: { repository },
-  } = site;
+  const { layout } = site;
 
   return (
     <div
@@ -121,37 +115,39 @@ const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
             <NewRelicLogo omitText={hideLogoText} />
           </ExternalLink>
 
-          <ul
-            css={css`
-              height: 100%;
-              margin: 0;
-              padding: 0;
-              display: flex;
-              list-style-type: none;
-              white-space: nowrap;
-            `}
-          >
-            <li>
-              <GlobalNavLink href="https://developer.newrelic.com/">
-                Developers
-              </GlobalNavLink>
-            </li>
-            <li>
-              <GlobalNavLink href="https://opensource.newrelic.com/">
-                Open Source
-              </GlobalNavLink>
-            </li>
-            <li>
-              <GlobalNavLink href="https://docs.newrelic.com/">
-                Documentation
-              </GlobalNavLink>
-            </li>
-            <li>
-              <GlobalNavLink href="https://discuss.newrelic.com/">
-                Community
-              </GlobalNavLink>
-            </li>
-          </ul>
+          {!hideMenuLinks && (
+            <ul
+              css={css`
+                height: 100%;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                list-style-type: none;
+                white-space: nowrap;
+              `}
+            >
+              <li>
+                <GlobalNavLink href="https://developer.newrelic.com/">
+                  Developers
+                </GlobalNavLink>
+              </li>
+              <li>
+                <GlobalNavLink href="https://opensource.newrelic.com/">
+                  Open Source
+                </GlobalNavLink>
+              </li>
+              <li>
+                <GlobalNavLink href="https://docs.newrelic.com/">
+                  Documentation
+                </GlobalNavLink>
+              </li>
+              <li>
+                <GlobalNavLink href="https://discuss.newrelic.com/">
+                  Community
+                </GlobalNavLink>
+              </li>
+            </ul>
+          )}
         </nav>
 
         <ul
@@ -169,28 +165,7 @@ const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
             }
           `}
         >
-          {editUrl && !hideMenuLinks && (
-            <li>
-              <ExternalLink css={actionLink} href={editUrl}>
-                <Icon css={actionIcon} name={Icon.TYPE.EDIT} size="0.875rem" />
-              </ExternalLink>
-            </li>
-          )}
-          {repository && !hideMenuLinks && (
-            <li>
-              <ExternalLink
-                css={actionLink}
-                href={`${repository}/issues/new/choose`}
-              >
-                <Icon
-                  css={actionIcon}
-                  name={Icon.TYPE.GITHUB}
-                  size="0.875rem"
-                />
-              </ExternalLink>
-            </li>
-          )}
-          {search && !hideMenuLinks && (
+          {search && (
             <li>
               <Link to="?q=" css={actionLink}>
                 <Icon
@@ -205,10 +180,18 @@ const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
             <DarkModeToggle css={[actionIcon, action]} size="0.875rem" />
           </li>
           <li>
-            <ExternalLink
+            <Button
+              as={ExternalLink}
               href="https://newrelic.com/signup"
+              size={Button.SIZE.EXTRA_SMALL}
+              variant={Button.VARIANT.PRIMARY}
               css={css`
-                ${actionLink};
+                display: block;
+                .dark-mode & {
+                  color: white;
+                  border-color: var(--color-brand-800);
+                  background-color: var(--color-brand-800);
+                }
               `}
             >
               <Icon
@@ -217,16 +200,9 @@ const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
                   margin-right: 0.25rem;
                 `}
                 name={Icon.TYPE.CLOUD}
-                size="0.875rem"
               />
-              <span
-                css={css`
-                  font-size: 0.75rem;
-                `}
-              >
-                Sign up
-              </span>
-            </ExternalLink>
+              <span>Sign up</span>
+            </Button>
           </li>
         </ul>
       </div>
@@ -236,7 +212,6 @@ const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
 
 GlobalHeader.propTypes = {
   className: PropTypes.string,
-  editUrl: PropTypes.string,
   search: PropTypes.bool,
 };
 

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -196,6 +196,10 @@ const GlobalHeader = ({ className, search }) => {
           <li
             css={css`
               display: flex;
+
+              && {
+                margin-left: 1.5rem;
+              }
             `}
           >
             <Button

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -14,6 +14,7 @@ import useMedia from 'use-media';
 import { useLocation } from '@reach/router';
 import useQueryParams from '../hooks/useQueryParams';
 import useKeyPress from '../hooks/useKeyPress';
+import { rgba } from 'polished';
 
 const UTM_SOURCES = {
   'https://developer.newrelic.com': 'developer-site',
@@ -75,8 +76,7 @@ const GlobalHeader = ({ className, search }) => {
     }
   });
 
-  const hideLogoText = useMedia({ maxWidth: '600px' });
-  const hideMenuLinks = useMedia({ maxWidth: '650px' });
+  const hideLogoText = useMedia({ maxWidth: '655px' });
 
   const { layout } = site;
 
@@ -127,6 +127,32 @@ const GlobalHeader = ({ className, search }) => {
             display: flex;
             align-items: center;
             height: 100%;
+            overflow: hidden;
+            position: relative;
+
+            @media screen and (max-width: 585px) {
+              &::after {
+                content: '';
+                position: absolute;
+                right: 0;
+                height: 100%;
+                width: 2rem;
+                pointer-events: none;
+                background: linear-gradient(
+                  to right,
+                  ${rgba('#f4f5f5', 0)},
+                  var(--color-neutrals-100)
+                );
+
+                .dark-mode & {
+                  background: linear-gradient(
+                    to right,
+                    ${rgba('#22353c', 0)},
+                    var(--color-dark-100)
+                  );
+                }
+              }
+            }
           `}
         >
           <ExternalLink
@@ -140,39 +166,45 @@ const GlobalHeader = ({ className, search }) => {
             <NewRelicLogo omitText={hideLogoText} />
           </ExternalLink>
 
-          {!hideMenuLinks && (
-            <ul
-              css={css`
-                height: 100%;
-                margin: 0;
-                padding: 0;
-                display: flex;
-                list-style-type: none;
-                white-space: nowrap;
-              `}
-            >
-              <li>
-                <GlobalNavLink href="https://developer.newrelic.com/">
-                  Developers
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://opensource.newrelic.com/">
-                  Open Source
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://docs.newrelic.com/">
-                  Documentation
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://discuss.newrelic.com/">
-                  Community
-                </GlobalNavLink>
-              </li>
-            </ul>
-          )}
+          <ul
+            css={css`
+              height: 100%;
+              margin: 0;
+              padding: 0;
+              display: flex;
+              list-style-type: none;
+              white-space: nowrap;
+              overflow-x: auto;
+              position: relative;
+              -webkit-overflow-scrolling: touch;
+              -ms-overflow-style: -ms-autohiding-scrollbar;
+
+              > li {
+                flex: 0 0 auto;
+              }
+            `}
+          >
+            <li>
+              <GlobalNavLink href="https://developer.newrelic.com/">
+                Developers
+              </GlobalNavLink>
+            </li>
+            <li>
+              <GlobalNavLink href="https://opensource.newrelic.com/">
+                Open Source
+              </GlobalNavLink>
+            </li>
+            <li>
+              <GlobalNavLink href="https://docs.newrelic.com/">
+                Documentation
+              </GlobalNavLink>
+            </li>
+            <li>
+              <GlobalNavLink href="https://discuss.newrelic.com/">
+                Community
+              </GlobalNavLink>
+            </li>
+          </ul>
         </nav>
 
         <ul

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -13,23 +13,27 @@ import useMedia from 'use-media';
 import { useLocation, useNavigate } from '@reach/router';
 import useQueryParams from '../hooks/useQueryParams';
 
-const styles = {
-  actionLink: css`
-    display: flex;
-    align-items: center;
-  `,
-  actionIcon: css`
-    cursor: pointer;
-    transition: all 0.2s ease-out;
-    color: var(--secondary-text-color);
+const action = css`
+  color: var(--secondary-text-color);
+  transition: all 0.2s ease-out;
 
-    &:hover {
-      color: var(--secondary-text-hover-color);
-    }
-  `,
-};
+  &:hover {
+    color: var(--secondary-text-hover-color);
+  }
+`;
 
-const GlobalHeader = ({ editUrl, className, search }) => {
+const actionLink = css`
+  ${action};
+
+  display: flex;
+  align-items: center;
+`;
+
+const actionIcon = css`
+  cursor: pointer;
+`;
+
+const GlobalHeader = ({ editUrl, className, search, utmSource }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { queryParams } = useQueryParams();
@@ -167,23 +171,19 @@ const GlobalHeader = ({ editUrl, className, search }) => {
         >
           {editUrl && !hideMenuLinks && (
             <li>
-              <ExternalLink css={styles.actionLink} href={editUrl}>
-                <Icon
-                  css={styles.actionIcon}
-                  name={Icon.TYPE.EDIT}
-                  size="0.875rem"
-                />
+              <ExternalLink css={actionLink} href={editUrl}>
+                <Icon css={actionIcon} name={Icon.TYPE.EDIT} size="0.875rem" />
               </ExternalLink>
             </li>
           )}
           {repository && !hideMenuLinks && (
             <li>
               <ExternalLink
-                css={styles.actionLink}
+                css={actionLink}
                 href={`${repository}/issues/new/choose`}
               >
                 <Icon
-                  css={styles.actionIcon}
+                  css={actionIcon}
                   name={Icon.TYPE.GITHUB}
                   size="0.875rem"
                 />
@@ -192,9 +192,9 @@ const GlobalHeader = ({ editUrl, className, search }) => {
           )}
           {search && !hideMenuLinks && (
             <li>
-              <Link to="?q=" css={styles.actionLink}>
+              <Link to="?q=" css={actionLink}>
                 <Icon
-                  css={styles.actionIcon}
+                  css={actionIcon}
                   name={Icon.TYPE.SEARCH}
                   size="0.875rem"
                 />
@@ -202,7 +202,31 @@ const GlobalHeader = ({ editUrl, className, search }) => {
             </li>
           )}
           <li>
-            <DarkModeToggle css={styles.actionIcon} size="0.875rem" />
+            <DarkModeToggle css={[actionIcon, action]} size="0.875rem" />
+          </li>
+          <li>
+            <ExternalLink
+              href="https://newrelic.com/signup"
+              css={css`
+                ${actionLink};
+              `}
+            >
+              <Icon
+                css={css`
+                  ${actionIcon}
+                  margin-right: 0.25rem;
+                `}
+                name={Icon.TYPE.CLOUD}
+                size="0.875rem"
+              />
+              <span
+                css={css`
+                  font-size: 0.75rem;
+                `}
+              >
+                Sign up
+              </span>
+            </ExternalLink>
           </li>
         </ul>
       </div>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -98,7 +98,7 @@ const GlobalHeader = ({ className, search }) => {
     >
       <div
         css={css`
-          height: 30px;
+          height: 36px;
           display: flex;
           justify-content: space-between;
           max-width: ${layout.maxWidth};

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -198,16 +198,6 @@ const GlobalHeader = ({ className, search, utmSource }) => {
               href="https://newrelic.com/signup"
               size={Button.SIZE.EXTRA_SMALL}
               variant={Button.VARIANT.PRIMARY}
-              css={css`
-                display: flex;
-                align-items: center;
-
-                .dark-mode & {
-                  color: white;
-                  border-color: var(--color-brand-800);
-                  background-color: var(--color-brand-800);
-                }
-              `}
             >
               <Icon
                 css={css`

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -32,10 +32,11 @@ const actionLink = css`
 `;
 
 const actionIcon = css`
+  display: block;
   cursor: pointer;
 `;
 
-const GlobalHeader = ({ className, search, utmSource }) => {
+const GlobalHeader = ({ className, search }) => {
   const location = useLocation();
   const { queryParams } = useQueryParams();
 
@@ -192,7 +193,11 @@ const GlobalHeader = ({ className, search, utmSource }) => {
           <li>
             <DarkModeToggle css={[actionIcon, action]} size="0.875rem" />
           </li>
-          <li>
+          <li
+            css={css`
+              display: flex;
+            `}
+          >
             <Button
               as={ExternalLink}
               href="https://newrelic.com/signup"
@@ -201,8 +206,7 @@ const GlobalHeader = ({ className, search, utmSource }) => {
             >
               <Icon
                 css={css`
-                  ${actionIcon}
-                  margin-right: 0.25rem;
+                  margin-right: 0.5rem;
                 `}
                 name={Icon.TYPE.CLOUD}
               />

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -199,7 +199,9 @@ const GlobalHeader = ({ className, search, utmSource }) => {
               size={Button.SIZE.EXTRA_SMALL}
               variant={Button.VARIANT.PRIMARY}
               css={css`
-                display: block;
+                display: flex;
+                align-items: center;
+
                 .dark-mode & {
                   color: white;
                   border-color: var(--color-brand-800);

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -15,6 +15,12 @@ import { useLocation } from '@reach/router';
 import useQueryParams from '../hooks/useQueryParams';
 import useKeyPress from '../hooks/useKeyPress';
 
+const UTM_SOURCES = {
+  'https://developer.newrelic.com': 'developer-site',
+  'https://opensource.newrelic.com': 'opensource-site',
+  'https://docs.newrelic.com': 'docs-site',
+};
+
 const action = css`
   color: var(--secondary-text-color);
   transition: all 0.2s ease-out;
@@ -43,6 +49,9 @@ const GlobalHeader = ({ className, search }) => {
   const { site } = useStaticQuery(graphql`
     query GlobalHeaderQuery {
       site {
+        siteMetadata {
+          siteUrl
+        }
         layout {
           contentPadding
           maxWidth
@@ -50,6 +59,8 @@ const GlobalHeader = ({ className, search }) => {
       }
     }
   `);
+
+  const utmSource = UTM_SOURCES[site.siteMetadata.siteUrl];
 
   useKeyPress('/', (e) => {
     // Don't trigger overlay when typing in an input or textarea
@@ -204,7 +215,9 @@ const GlobalHeader = ({ className, search }) => {
           >
             <Button
               as={ExternalLink}
-              href="https://newrelic.com/signup"
+              href={`https://newrelic.com/signup${
+                utmSource ? `?utm_source=${utmSource}` : ''
+              }`}
               size={Button.SIZE.EXTRA_SMALL}
               variant={Button.VARIANT.PRIMARY}
             >

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles.js
@@ -114,7 +114,8 @@ const lightMode = css`
     --tertiary-background-color: var(--color-neutrals-200);
 
     --accent-text-color: var(--color-neutrals-500);
-    --link-color: var(--color-brand-800);
+    --link-color: var(--color-brand-600);
+    --link-hover-color: var(--color-brand-500);
     --border-color: var(--color-neutrals-400);
     --border-hover-color: var(--color-neutrals-500);
     --divider-color: var(--color-neutrals-100);
@@ -135,7 +136,8 @@ const darkMode = css`
     --tertiary-background-color: var(--color-dark-100);
 
     --accent-text-color: var(--color-dark-600);
-    --link-color: var(--color-brand-400);
+    --link-color: var(--color-brand-300);
+    --link-hover-color: var(--color-brand-050);
     --border-color: var(--color-dark-400);
     --border-hover-color: var(--color-dark-500);
     --divider-color: var(--color-dark-200);
@@ -177,6 +179,10 @@ const reset = css`
     cursor: pointer;
     text-decoration: none;
     color: var(--link-color);
+
+    &:hover {
+      color: var(--link-hover-color);
+    }
   }
 
   p {

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles.js
@@ -27,11 +27,16 @@ const colors = css`
   --color-dark-800: #cedede;
   --color-dark-900: #e8eaea;
 
-  --color-brand-050: #f7ffff;
-  --color-brand-100: #edffff;
-  --color-brand-400: #70ccd2;
-  --color-brand-800: #007e8a;
-  --color-brand-900: #005054;
+  --color-brand-050: #f1fbfc;
+  --color-brand-100: #d2f3f6;
+  --color-brand-200: #85e0e7;
+  --color-brand-300: #70ccd3;
+  --color-brand-400: #00b3c3;
+  --color-brand-500: #008c99;
+  --color-brand-600: #006c75;
+  --color-brand-700: #00484e;
+  --color-brand-800: #003539;
+  --color-brand-900: #002123;
 
   --color-red-050: #fcf3f3;
   --color-red-100: #fce9e9;

--- a/packages/gatsby-theme-newrelic/src/components/HamburgerMenu.js
+++ b/packages/gatsby-theme-newrelic/src/components/HamburgerMenu.js
@@ -5,7 +5,7 @@ import { css } from '@emotion/core';
 const menuLine = (isOpen) => css`
   width: 100%;
   height: 2px;
-  background-color: var(--color-brand-800);
+  background-color: var(--color-brand-600);
   margin: 4px 0;
   border-radius: 5px;
   transition: 0.18s;
@@ -15,7 +15,7 @@ const menuLine = (isOpen) => css`
   }
 
   ${isOpen &&
-  ` 
+  `
   :nth-child(1) {
     transform: rotate(-45deg) translate(-2px, 6.25px);
   }

--- a/packages/gatsby-theme-newrelic/src/components/Surface.js
+++ b/packages/gatsby-theme-newrelic/src/components/Surface.js
@@ -67,7 +67,7 @@ const Surface = styled.div`
 
 Surface.propTypes = {
   base: PropTypes.oneOf(Object.values(BASES)).isRequired,
-  interactive: PropTypes.boolean,
+  interactive: PropTypes.bool,
 };
 
 Surface.defaultProps = {

--- a/packages/gatsby-theme-newrelic/src/components/Tag.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tag.js
@@ -26,12 +26,12 @@ const Tag = styled.span`
     css`
       &:hover {
         cursor: pointer;
-        color: var(--color-brand-800);
+        color: var(--color-brand-600);
         background: ${rgba('#70ccd2', 0.17)};
         transform: translateY(-1px);
 
         .dark-mode & {
-          color: var(--color-brand-400);
+          color: var(--color-brand-200);
         }
       }
     `}

--- a/packages/gatsby-theme-newrelic/src/icons/feather.js
+++ b/packages/gatsby-theme-newrelic/src/icons/feather.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export default {
+  cloud: <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />,
   copy: (
     <>
       <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />


### PR DESCRIPTION
Closes https://github.com/newrelic/developer-website/issues/536
Closes #75 
Closes #79 

## Description

Adds a sign up button to the global header. Also addresses the following:

* Improves the mobile view of the global header by adding a horizontal scroll to the site links
* Adds a full brand color palette
* Adds hover states to buttons
* Deprecates the `Plain` button in favor of a `Link` style button

## Screenshots

![Image from iOS (1)](https://user-images.githubusercontent.com/565661/90303732-5b1e5880-de65-11ea-8e4b-e805d4c6dfa5.jpg)

<img width="1094" alt="Screen Shot 2020-08-14 at 7 36 05 PM" src="https://user-images.githubusercontent.com/565661/90303742-6f625580-de65-11ea-8cb8-4679a163b38d.png">
