### PR TITLE
fix: make spacing between sign up and dark mode uniform

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -239,10 +239,6 @@ const GlobalHeader = ({ className, search }) => {
           <li
             css={css`
               display: flex;
-
-              && {
-                margin-left: 1.5rem;
-              }
             `}
           >
             <Button


### PR DESCRIPTION
Spacing between the search, dark mode, and sign up buttons should be a uniform 16px.

Issue: https://github.com/newrelic/developer-website/issues/629

Before:

![Screen Shot 2020-08-18 at 10 11 21 AM](https://user-images.githubusercontent.com/186715/90544144-922d8c00-e13b-11ea-8ace-b3aee5a7c4bf.png)

After:

![Screen Shot 2020-08-18 at 10 11 35 AM](https://user-images.githubusercontent.com/186715/90544154-9659a980-e13b-11ea-86eb-89f4ec83c55b.png)
