### PR TITLE
fix: remove cloud icon from sign up button

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -249,12 +249,6 @@ const GlobalHeader = ({ className, search }) => {
               size={Button.SIZE.EXTRA_SMALL}
               variant={Button.VARIANT.PRIMARY}
             >
-              <Icon
-                css={css`
-                  margin-right: 0.5rem;
-                `}
-                name={Icon.TYPE.CLOUD}
-              />
               <span>Sign up</span>
             </Button>
           </li>


### PR DESCRIPTION
Issue: https://github.com/newrelic/developer-website/issues/629

@jpvajda and I agree that the icon doesn't really add a lot to the sign up button so we're nixing it for now.