### PR TITLE
Add an "outline" button variant

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -163,6 +163,12 @@ const IndexPage = ({ data }) => {
             </Button>
             <Button
               onClick={() => alert('Hello!')}
+              variant={Button.VARIANT.OUTLINE}
+            >
+              Outline
+            </Button>
+            <Button
+              onClick={() => alert('Hello!')}
               variant={Button.VARIANT.LINK}
             >
               Link

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -309,11 +309,11 @@ import { Button } from '@newrelic/gatsby-theme-newrelic'`
 
 **Props**
 
-| Prop    | Type          | Required | Default  | Description                                                                                                                      |
-| ------- | ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| variant | enum          | yes      |          | Configures the variant of the button. Must be one of `Button.VARIANT.LINK`, `Button.VARIANT.PRIMARY`, or `Button.VARIANT.NORMAL` |
-| size    | enum          | no       |          | Configures the size of the button. Can be configured to `Button.SIZE.SMALL`                                                      |
-| as      | React element | no       | `button` | Render the button as a different base element. Useful when you want to style links as buttons.                                   |
+| Prop    | Type          | Required | Default  | Description                                                                                                                                        |
+| ------- | ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| variant | enum          | yes      |          | Configures the variant of the button. Must be one of `Button.VARIANT.LINK`, `Button.VARIANT.PRIMARY`, `Button.OUTLINE`, or `Button.VARIANT.NORMAL` |
+| size    | enum          | no       |          | Configures the size of the button. Can be configured to `Button.SIZE.SMALL`                                                                        |
+| as      | React element | no       | `button` | Render the button as a different base element. Useful when you want to style links as buttons.                                                     |
 
 Additional props are forwarded to the underlying element specified by the `as`
 prop.

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -67,6 +67,7 @@ const styles = {
       }
     `,
     [VARIANTS.OUTLINE]: css`
+      color: var(--color-neutrals-700);
       border: 1px solid var(--border-color);
       background-color: transparent;
 

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -7,6 +7,7 @@ const VARIANTS = {
   PRIMARY: 'primary',
   NORMAL: 'normal',
   LINK: 'link',
+  OUTLINE: 'outline',
 };
 
 const SIZES = {
@@ -62,6 +63,24 @@ const styles = {
         &:hover {
           color: var(--color-brand-200);
           background-color: ${rgba('#70ccd2', 0.17)};
+        }
+      }
+    `,
+    [VARIANTS.OUTLINE]: css`
+      border: 1px solid var(--border-color);
+      background-color: transparent;
+
+      &:hover {
+        color: var(--color-brand-600);
+        border-color: var(--color-brand-500);
+      }
+
+      .dark-mode & {
+        color: var(--color-dark-700);
+
+        &:hover {
+          color: var(--color-brand-200);
+          border-color: ${rgba('#70ccd2', 0.17)};
         }
       }
     `,

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -85,7 +85,7 @@ const Button = styled.button`
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  transition: all 0.09s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: all 0.15s ease-out;
   white-space: nowrap;
 
   &:hover {

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/GlobalHeader.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/GlobalHeader.test.js.snap
@@ -1716,8 +1716,8 @@ exports[`Matches snapshot 1`] = `
   cursor: pointer;
   border-width: 1px;
   border-style: solid;
-  -webkit-transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
-  transition: all 0.09s cubic-bezier(0.25,0.46,0.45,0.94);
+  -webkit-transition: all 0.15s ease-out;
+  transition: all 0.15s ease-out;
   white-space: nowrap;
   border: 0;
   color: var(--color-white);


### PR DESCRIPTION
## Description

Adds an `outline` button variant

## Screenshots

<img width="476" alt="Screen Shot 2020-09-02 at 2 28 22 PM" src="https://user-images.githubusercontent.com/565661/92038643-960b0200-ed28-11ea-860a-7eac153bfb53.png">
