### PR TITLE
Do not fall back to development settings when resolving split.io env options

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/getSplitConfig.js
+++ b/packages/gatsby-theme-newrelic/src/utils/getSplitConfig.js
@@ -13,10 +13,11 @@ const getSplitConfig = (pluginOptions) => {
 
   const {
     env = {},
-    resolveEnv = () => process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV,
+    resolveEnv = () =>
+      process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || DEFAULT_ENV,
   } = splitio;
 
-  const envOptions = env[resolveEnv()] || env[DEFAULT_ENV] || {};
+  const envOptions = env[resolveEnv()] || {};
 
   return merge(
     DEFAULT_CONFIG,


### PR DESCRIPTION
## Description

Environment-specific options were being resolved to `development` incorrectly when configuration for an environment was not specified. This PR ensures that the resolved configuration for an environment does not fall back to `development` if environment-specific settings are not specified for the given environment.