### PR TITLE
Add ability to specify icon defs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@newrelic/eslint-plugin-newrelic": "^0.3.1",
+    "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^10.4.8",
     "@testing-library/react-hooks": "^3.4.1",
     "babel-jest": "^26.3.0",

--- a/packages/gatsby-theme-newrelic/src/components/FeatherSVG.js
+++ b/packages/gatsby-theme-newrelic/src/components/FeatherSVG.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import SVG from './SVG';
 
 const FeatherSVG = ({ children, ...props }) => (
-  <svg
+  <SVG
     {...props}
-    xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     css={css`
       fill: none;
@@ -16,11 +16,12 @@ const FeatherSVG = ({ children, ...props }) => (
     `}
   >
     {children}
-  </svg>
+  </SVG>
 );
 
 FeatherSVG.propTypes = {
-  children: PropTypes.node.isRequired,
+  ...SVG.propTypes,
+  children: PropTypes.node,
 };
 
 export default FeatherSVG;

--- a/packages/gatsby-theme-newrelic/src/components/Icon.js
+++ b/packages/gatsby-theme-newrelic/src/components/Icon.js
@@ -13,7 +13,7 @@ const TYPES = transformKeys(
   constantize
 );
 
-const Icon = ({ name, size, ...props }) => {
+const Icon = ({ name, size, defs, ...props }) => {
   const featherIcon = featherIcons[name];
 
   if (featherIcon) {
@@ -25,6 +25,7 @@ const Icon = ({ name, size, ...props }) => {
         `}
         {...props}
       >
+        {defs && <defs>{defs}</defs>}
         {featherIcon}
       </FeatherSVG>
     );
@@ -34,6 +35,7 @@ const Icon = ({ name, size, ...props }) => {
 };
 
 Icon.propTypes = {
+  defs: PropTypes.node,
   name: PropTypes.oneOf(Object.values(TYPES)).isRequired,
   size: PropTypes.string,
 };

--- a/packages/gatsby-theme-newrelic/src/components/Icon.js
+++ b/packages/gatsby-theme-newrelic/src/components/Icon.js
@@ -13,7 +13,7 @@ const TYPES = transformKeys(
   constantize
 );
 
-const Icon = ({ name, size, defs, ...props }) => {
+const Icon = ({ name, size, ...props }) => {
   const featherIcon = featherIcons[name];
 
   if (featherIcon) {
@@ -25,7 +25,6 @@ const Icon = ({ name, size, defs, ...props }) => {
         `}
         {...props}
       >
-        {defs && <defs>{defs}</defs>}
         {featherIcon}
       </FeatherSVG>
     );
@@ -35,7 +34,7 @@ const Icon = ({ name, size, defs, ...props }) => {
 };
 
 Icon.propTypes = {
-  defs: PropTypes.node,
+  ...FeatherSVG.propTypes,
   name: PropTypes.oneOf(Object.values(TYPES)).isRequired,
   size: PropTypes.string,
 };

--- a/packages/gatsby-theme-newrelic/src/components/SVG.js
+++ b/packages/gatsby-theme-newrelic/src/components/SVG.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SVG = ({ children, title, defs, ...props }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" {...props}>
+    {title && <title>{title}</title>}
+    {defs && <defs>{defs}</defs>}
+    {children}
+  </svg>
+);
+
+SVG.propTypes = {
+  defs: PropTypes.node,
+  children: PropTypes.node,
+  title: PropTypes.string,
+};
+
+export default SVG;

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/Icon.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/Icon.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import Icon from '../Icon';
+import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
+
+const defaultIcon = Icon.TYPE[Object.keys(Icon.TYPE)[0]];
+
+Object.keys(Icon.TYPE).forEach((name) => {
+  test(`${name} icon matches its snapshot`, () => {
+    const tree = TestRenderer.create(<Icon name={Icon.TYPE[name]} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+test('raises when an icon does not exist', () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  expect(() => render(<Icon name="this icon does not exist" />)).toThrow(
+    'Icon: this icon does not exist did not match a known icon'
+  );
+});
+
+test('matches the size passed in from the prop', () => {
+  const { container } = render(<Icon name={defaultIcon} size="2rem" />);
+
+  const icon = container.firstChild;
+
+  expect(icon).toHaveStyleRule('width', '2rem');
+  expect(icon).toHaveStyleRule('height', '2rem');
+});
+
+test('allows for defs defined for the icon', () => {
+  const { container } = render(
+    <Icon
+      name={defaultIcon}
+      defs={
+        <linearGradient id="gradient">
+          <stop offset="0%" stopColor="#0FB7C9" />
+          <stop offset="150%" stopColor="#0069CE" />
+        </linearGradient>
+      }
+    />
+  );
+
+  expect(container.querySelector('defs')).toBeInTheDocument();
+});

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/GlobalHeader.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/GlobalHeader.test.js.snap
@@ -1714,12 +1714,10 @@ exports[`Matches snapshot 1`] = `
   font-family: var(--primary-font-family);
   line-height: 1;
   cursor: pointer;
-  border-width: 1px;
-  border-style: solid;
+  border: 1px solid transparent;
   -webkit-transition: all 0.15s ease-out;
   transition: all 0.15s ease-out;
   white-space: nowrap;
-  border: 0;
   color: var(--color-white);
   background-color: var(--color-brand-600);
   font-size: 0.625rem;
@@ -1956,6 +1954,7 @@ exports[`Matches snapshot 1`] = `
         <a
           className="emotion-58"
           href="?q="
+          onClick={[Function]}
         >
           <svg
             className="emotion-57"

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/Icon.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/Icon.test.js.snap
@@ -1,0 +1,397 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CLOUD icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"
+  />
+</svg>
+`;
+
+exports[`COPY icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect
+    height="13"
+    rx="2"
+    ry="2"
+    width="13"
+    x="9"
+    y="9"
+  />
+  <path
+    d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+  />
+</svg>
+`;
+
+exports[`EDIT icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"
+  />
+  <path
+    d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"
+  />
+</svg>
+`;
+
+exports[`EXTERNAL_LINK icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+  />
+  <polyline
+    points="15 3 21 3 21 9"
+  />
+  <line
+    x1="10"
+    x2="21"
+    y1="14"
+    y2="3"
+  />
+</svg>
+`;
+
+exports[`GITHUB icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
+  />
+</svg>
+`;
+
+exports[`LOADER icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <line
+    x1="12"
+    x2="12"
+    y1="2"
+    y2="6"
+  />
+  <line
+    x1="12"
+    x2="12"
+    y1="18"
+    y2="22"
+  />
+  <line
+    x1="4.93"
+    x2="7.76"
+    y1="4.93"
+    y2="7.76"
+  />
+  <line
+    x1="16.24"
+    x2="19.07"
+    y1="16.24"
+    y2="19.07"
+  />
+  <line
+    x1="2"
+    x2="6"
+    y1="12"
+    y2="12"
+  />
+  <line
+    x1="18"
+    x2="22"
+    y1="12"
+    y2="12"
+  />
+  <line
+    x1="4.93"
+    x2="7.76"
+    y1="19.07"
+    y2="16.24"
+  />
+  <line
+    x1="16.24"
+    x2="19.07"
+    y1="7.76"
+    y2="4.93"
+  />
+</svg>
+`;
+
+exports[`MOON icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"
+  />
+</svg>
+`;
+
+exports[`SEARCH icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    cx="11"
+    cy="11"
+    r="8"
+  />
+  <line
+    x1="21"
+    x2="16.65"
+    y1="21"
+    y2="16.65"
+  />
+</svg>
+`;
+
+exports[`SUN icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    cx="12"
+    cy="12"
+    r="5"
+  />
+  <line
+    x1="12"
+    x2="12"
+    y1="1"
+    y2="3"
+  />
+  <line
+    x1="12"
+    x2="12"
+    y1="21"
+    y2="23"
+  />
+  <line
+    x1="4.22"
+    x2="5.64"
+    y1="4.22"
+    y2="5.64"
+  />
+  <line
+    x1="18.36"
+    x2="19.78"
+    y1="18.36"
+    y2="19.78"
+  />
+  <line
+    x1="1"
+    x2="3"
+    y1="12"
+    y2="12"
+  />
+  <line
+    x1="21"
+    x2="23"
+    y1="12"
+    y2="12"
+  />
+  <line
+    x1="4.22"
+    x2="5.64"
+    y1="19.78"
+    y2="18.36"
+  />
+  <line
+    x1="18.36"
+    x2="19.78"
+    y1="5.64"
+    y2="4.22"
+  />
+</svg>
+`;
+
+exports[`THUMBSDOWN icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M10 15v4a3 3 0 0 0 3 3l4-9V2H5.72a2 2 0 0 0-2 1.7l-1.38 9a2 2 0 0 0 2 2.3zm7-13h2.67A2.31 2.31 0 0 1 22 4v7a2.31 2.31 0 0 1-2.33 2H17"
+  />
+</svg>
+`;
+
+exports[`THUMBSUP icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3"
+  />
+</svg>
+`;
+
+exports[`X icon matches its snapshot 1`] = `
+.emotion-0 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  width: 1em;
+  height: 1em;
+}
+
+<svg
+  className="emotion-0"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <line
+    x1="18"
+    x2="6"
+    y1="6"
+    y2="18"
+  />
+  <line
+    x1="6"
+    x2="18"
+    y1="6"
+    y2="18"
+  />
+</svg>
+`;

--- a/setup-test-env.js
+++ b/setup-test-env.js
@@ -1,6 +1,7 @@
 /* global expect */
 import { createSerializer, matchers } from 'jest-emotion';
 import * as emotion from '@emotion/core';
+import '@testing-library/jest-dom';
 
 expect.extend(matchers);
 expect.addSnapshotSerializer(createSerializer(emotion));

--- a/setup-test-env.js
+++ b/setup-test-env.js
@@ -1,5 +1,6 @@
 /* global expect */
-import { createSerializer } from 'jest-emotion';
+import { createSerializer, matchers } from 'jest-emotion';
 import * as emotion from '@emotion/core';
 
+expect.extend(matchers);
 expect.addSnapshotSerializer(createSerializer(emotion));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,6 +2877,20 @@
     dom-accessibility-api "^0.5.0"
     pretty-format "^25.5.0"
 
+"@testing-library/jest-dom@^5.11.4":
+  version "5.11.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.4.tgz#f325c600db352afb92995c2576022b35621ddc99"
+  integrity sha512-6RRn3epuweBODDIv3dAlWjOEHQLpGJHB2i912VS3JQtsD22+ENInhdDNl4ZZQiViLlIfFinkSET/J736ytV9sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react-hooks@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz#1f8ccd21208086ec228d9743fe40b69d0efcd7e5"
@@ -3041,6 +3055,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@*":
+  version "26.0.13"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.13.tgz#5a7b9d5312f5dd521a38329c38ee9d3802a0b85e"
+  integrity sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
 "@types/jest@^23.0.2":
   version "23.3.14"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
@@ -3165,6 +3187,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz#59e4771a1cf87d51e89a5cc8195cd3b647cba322"
+  integrity sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/testing-library__react-hooks@^3.3.0":
   version "3.4.0"
@@ -5959,6 +5988,11 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
   integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 css@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -5968,6 +6002,15 @@ css@^2.2.1:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -10603,7 +10646,7 @@ jest-config@^26.4.0:
     micromatch "^4.0.2"
     pretty-format "^26.4.0"
 
-jest-diff@^25.5.0:
+jest-diff@^25.2.1, jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
   integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
@@ -13908,7 +13951,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^25.5.0:
+pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
   integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
@@ -15755,6 +15798,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"


### PR DESCRIPTION
## Description

In some cases, we may want to render icons with a gradient for its stroke, for example with the icons on the new Nerd Days event page. This adds the ability to specify `<defs />` on the svg that can be used to define gradients.