### PR TITLE
Fixes for Gatsby Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > .npmrc
 
+      - name: Test Build
+        run: yarn workspace demo build
+
       - name: Lerna Publish
         env:
           GIT_AUTHOR_NAME: ${{ env.BOT_NAME }}

--- a/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
+++ b/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
@@ -22,14 +22,19 @@ const findCurrentAnnouncement = (announcements) => {
   );
 };
 
-const createContentHash = (announcement) =>
-  btoa(
+const createContentHash = (announcement) => {
+  // Since bota is not available at build time, this will provide a
+  // fallback so that this function simply joins the items.
+  const btoa = global.btoa || ((arr) => arr);
+
+  return btoa(
     [
       announcement.id,
       announcement.frontmatter.startDate,
       announcement.frontmatter.endDate,
     ].join(':')
   );
+};
 
 const components = {
   Icon,


### PR DESCRIPTION
## Description
This PR fixes an issue where `btoa` is not available when Gatsby builds a site using this theme.

Additionally, this adds a step to our `release` workflow that attempts to build the site. This allows us to catch any issues in the theme that would break a build for a site that uses it.