### PR TITLE
Doesn't return banner with swifttype index when not visible

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
+++ b/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
@@ -71,7 +71,7 @@ const AnnouncementBanner = () => {
     lastAnnouncementDismissed !== announcementId
   );
 
-  return announcement ? (
+  return announcement && visible ? (
     <Banner
       data-swiftype-index={false}
       visible={visible}


### PR DESCRIPTION
I believe that this is happening because there is a swifttype index on the Banner for the annoucement banner and we're returning that, even though there is null being returned from the actual Banner. 

By adding this conditional, I think we will solve the problem and fully remove the banner and it's index 