### PR TITLE
Only renders the announcement banner after the component has mounted

### DIFF
--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -23,3 +23,4 @@ export { default as useKeyPress } from './src/hooks/useKeyPress';
 export { default as useQueryParams } from './src/hooks/useQueryParams';
 export { default as useTimeout } from './src/hooks/useTimeout';
 export { default as useUserId } from './src/hooks/useUserId';
+export { default as useHasMounted } from './src/hooks/useHasMounted';

--- a/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
+++ b/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
@@ -7,6 +7,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
 import { STORAGE_KEYS } from '../utils/constants';
 import { parseISO, endOfDay, isBefore, isAfter } from 'date-fns';
+import useHasMounted from '../hooks/useHasMounted';
 
 const useLastAnnouncementDismissed = createPersistedState(
   STORAGE_KEYS.LAST_ANNOUNCEMENT_DISMISSED
@@ -70,6 +71,12 @@ const AnnouncementBanner = () => {
   const [visible, setVisible] = useState(
     lastAnnouncementDismissed !== announcementId
   );
+
+  const hasMounted = useHasMounted();
+
+  if (!hasMounted) {
+    return null;
+  }
 
   return announcement && visible ? (
     <Banner

--- a/packages/gatsby-theme-newrelic/src/hooks/useHasMounted.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useHasMounted.js
@@ -1,0 +1,11 @@
+import { useState, useEffect } from 'react';
+
+const useHasMounted = () => {
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+  return hasMounted;
+};
+
+export default useHasMounted;


### PR DESCRIPTION
Read more about [this solution](https://joshwcomeau.com/react/the-perils-of-rehydration/) here. 

Our conditional rendering of the announcement banner was causing a rehydration issue that was leading to a mismatch between our client side rendering and SSR.