### PR TITLE
Fix issue with banners not dismissing

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
+++ b/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
@@ -30,7 +30,7 @@ const createContentHash = (announcement) => {
 
   return btoa(
     [
-      announcement.id,
+      announcement.slug,
       announcement.frontmatter.startDate,
       announcement.frontmatter.endDate,
     ].join(':')
@@ -49,7 +49,7 @@ const AnnouncementBanner = () => {
         filter: { fileAbsolutePath: { regex: "/src/announcements/" } }
       ) {
         nodes {
-          id
+          slug
           body
           frontmatter {
             startDate(formatString: "YYYY-MM-DD")


### PR DESCRIPTION
## Description
When the user dismisses an announcement banner, a hash is stored in local storage that tracks that it was the last banner dismissed. If a user comes back to the site, it _should_ not be displayed.

Here's an example of the current banner hash in my browser and it's contents:

```js
const hash = "M2I3MjgzMDItYjZiNC01YWI5LWIzOWUtMDk5YWEyYTdjZTRiOjIwMjAtMDktMTU6MjAyMC0xMC0wMg==";

console.log(atob(hash));
// "3b728302-b6b4-5ab9-b39e-099aa2a7ce4b:2020-09-15:2020-10-02"
// format -> id:start:end
```

This was not working. I suspect this is because part of the hash is the banner `id` and that may be changing when we rebuild the site. This change updates that logic to use the banner `slug` instead (the filename without extension). I think this should resolve the issue.