### PR TITLE
Fix typo in README doc re: Callout component

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -387,7 +387,7 @@ import { Callout } from '@newrelic/gatsby-theme-newrelic'`
 **Examples**
 
 ```js
-<Callout variant={Callout.VARIANT.CAUTION}>Be careful!</Button>
+<Callout variant={Callout.VARIANT.CAUTION}>Be careful!</Callout>
 ```
 
 ### `CodeBlock`


### PR DESCRIPTION
Replaced erroneous `</Button>` with `</Callout>` in Callout > Examples section