### PR TITLE
Minor callout adjustments

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -118,6 +118,12 @@ const IndexPage = ({ data }) => {
             Important! I said, this is important.
           </Callout>
           <Callout variant={Callout.VARIANT.TIP}>Here's a tip.</Callout>
+          <Callout variant={Callout.VARIANT.TIP} title="Hello">
+            Here's a tip with a custom title
+          </Callout>
+          <Callout variant={Callout.VARIANT.TIP} title={null}>
+            Here's a tip with no title
+          </Callout>
         </section>
         <section>
           <h2>A code block</h2>

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -382,12 +382,20 @@ import { Callout } from '@newrelic/gatsby-theme-newrelic'`
 | Prop    | Type | Required | Default | Description                                                                                                                         |
 | ------- | ---- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | variant | enum | yes      |         | Configures the variant of the callout. Must be one of `Callout.VARIANT.CAUTION`, `Callout.VARIANT.IMPORTANT`, `Callout.VARIANT.TIP` |
-| title   | enum | no       |         | Set the title text. Defaults to variant name.                                                                                       |
+| title   | enum | no       |         | Set the title text. Defaults to variant name. You may hide the title by passing `null` as the value.                                |
 
 **Examples**
 
 ```js
 <Callout variant={Callout.VARIANT.CAUTION}>Be careful!</Callout>
+```
+
+Hide the title
+
+```js
+<Callout variant={Callout.VARIANT.CAUTION} title={null}>
+  Be careful!
+</Callout>
 ```
 
 ### `CodeBlock`

--- a/packages/gatsby-theme-newrelic/src/components/Callout.js
+++ b/packages/gatsby-theme-newrelic/src/components/Callout.js
@@ -41,16 +41,18 @@ const Callout = ({ title, variant, children }) => {
         ${styles.variant[variant]}
       `}
     >
-      <h4
-        css={css`
-          font-size: 0.75rem !important;
-          text-transform: uppercase;
-          color: var(--heading-text-color);
-          margin-top: 0 !important;
-        `}
-      >
-        {title || DEFAULT_TITLES[variant]}
-      </h4>
+      {title !== null && (
+        <h4
+          css={css`
+            font-size: 0.75rem !important;
+            text-transform: uppercase;
+            color: var(--heading-text-color);
+            margin-top: 0 !important;
+          `}
+        >
+          {title || DEFAULT_TITLES[variant]}
+        </h4>
+      )}
       {children}
     </div>
   );

--- a/packages/gatsby-theme-newrelic/src/components/Callout.js
+++ b/packages/gatsby-theme-newrelic/src/components/Callout.js
@@ -35,8 +35,8 @@ const Callout = ({ title, variant, children }) => {
   return (
     <div
       css={css`
-        padding: 1.25rem 0.25rem 1.25rem 1.25rem;
-        margin: 1.5rem 3rem 1.5rem 1.25rem;
+        padding: 1.25rem;
+        margin: 1.5rem 0;
         color: var(--primary-text-color);
         ${styles.variant[variant]}
       `}
@@ -46,6 +46,7 @@ const Callout = ({ title, variant, children }) => {
           font-size: 0.75rem !important;
           text-transform: uppercase;
           color: var(--heading-text-color);
+          margin-top: 0 !important;
         `}
       >
         {title || DEFAULT_TITLES[variant]}


### PR DESCRIPTION
## Description

* Adjusts the spacing on the callout by removing the horizontal spacing. 
* Ensure the title's top-margin is always removed
* Allow the user to disable the title completely

## Screenshots

<img width="1117" alt="Screen Shot 2020-10-23 at 5 12 07 PM" src="https://user-images.githubusercontent.com/565661/97063159-e6e1ee80-1552-11eb-8749-b22261516317.png">
