### PR TITLE
Add login link to global header

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -197,6 +197,11 @@ const GlobalHeader = ({ className, editUrl }) => {
               `}
             >
               <li>
+                <GlobalNavLink href="https://docs.newrelic.com/">
+                  Documentation
+                </GlobalNavLink>
+              </li>
+              <li>
                 <GlobalNavLink href="https://developer.newrelic.com/">
                   Developers
                 </GlobalNavLink>
@@ -204,11 +209,6 @@ const GlobalHeader = ({ className, editUrl }) => {
               <li>
                 <GlobalNavLink href="https://opensource.newrelic.com/">
                   Open Source
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://docs.newrelic.com/">
-                  Documentation
                 </GlobalNavLink>
               </li>
               <li>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -16,8 +16,6 @@ import { useLocation } from '@reach/router';
 import useQueryParams from '../hooks/useQueryParams';
 import useKeyPress from '../hooks/useKeyPress';
 import { rgba } from 'polished';
-import { useTreatments, useTrack } from '@splitsoftware/splitio-react';
-import { SPLITS, SPLIT_TRACKING_EVENTS } from '../utils/constants';
 
 const UTM_SOURCES = {
   'https://developer.newrelic.com': 'developer-site',
@@ -46,7 +44,7 @@ const actionIcon = css`
   cursor: pointer;
 `;
 
-const GlobalHeader = ({ className, editUrl }) => {
+const GlobalHeader = ({ className }) => {
   const location = useLocation();
   const { queryParams } = useQueryParams();
 
@@ -54,7 +52,6 @@ const GlobalHeader = ({ className, editUrl }) => {
     query GlobalHeaderQuery {
       site {
         siteMetadata {
-          repository
           siteUrl
         }
         layout {
@@ -65,12 +62,9 @@ const GlobalHeader = ({ className, editUrl }) => {
     }
   `);
 
-  const utmSource = UTM_SOURCES[site.siteMetadata.siteUrl];
-  const treatments = useTreatments([SPLITS.GLOBAL_HEADER_GITHUB_BUTTONS]);
-  const track = useTrack();
+  const { siteMetadata, layout } = site;
 
-  const shouldShowGithubActions =
-    treatments[SPLITS.GLOBAL_HEADER_GITHUB_BUTTONS].treatment === 'on';
+  const utmSource = UTM_SOURCES[siteMetadata.siteUrl];
 
   useKeyPress('/', (e) => {
     // Don't trigger overlay when typing in an input or textarea
@@ -86,11 +80,6 @@ const GlobalHeader = ({ className, editUrl }) => {
   });
 
   const hideLogoText = useMedia({ maxWidth: '655px' });
-
-  const {
-    layout,
-    siteMetadata: { repository },
-  } = site;
 
   return (
     <>
@@ -235,19 +224,7 @@ const GlobalHeader = ({ className, editUrl }) => {
             `}
           >
             <li>
-              <Link
-                to="?q="
-                css={actionLink}
-                onClick={() =>
-                  track(
-                    SPLIT_TRACKING_EVENTS.GLOBAL_HEADER_CLICK_ACTION,
-                    null,
-                    {
-                      action: 'search',
-                    }
-                  )
-                }
-              >
+              <Link to="?q=" css={actionLink}>
                 <Icon
                   css={actionIcon}
                   name={Icon.TYPE.SEARCH}
@@ -256,70 +233,8 @@ const GlobalHeader = ({ className, editUrl }) => {
               </Link>
             </li>
             <li>
-              <DarkModeToggle
-                css={[actionIcon, action]}
-                size="0.875rem"
-                onClick={() =>
-                  track(
-                    SPLIT_TRACKING_EVENTS.GLOBAL_HEADER_CLICK_ACTION,
-                    null,
-                    {
-                      action: 'dark_mode',
-                    }
-                  )
-                }
-              />
+              <DarkModeToggle css={[actionIcon, action]} size="0.875rem" />
             </li>
-            {shouldShowGithubActions && (
-              <>
-                {editUrl && (
-                  <li>
-                    <ExternalLink
-                      css={actionLink}
-                      href={editUrl}
-                      onClick={() =>
-                        track(
-                          SPLIT_TRACKING_EVENTS.GLOBAL_HEADER_CLICK_ACTION,
-                          null,
-                          {
-                            action: 'edit_page',
-                          }
-                        )
-                      }
-                    >
-                      <Icon
-                        css={actionIcon}
-                        name={Icon.TYPE.EDIT}
-                        size="0.875rem"
-                      />
-                    </ExternalLink>
-                  </li>
-                )}
-                {repository && (
-                  <li>
-                    <ExternalLink
-                      css={actionLink}
-                      href={`${repository}/issues/new/choose`}
-                      onClick={() =>
-                        track(
-                          SPLIT_TRACKING_EVENTS.GLOBAL_HEADER_CLICK_ACTION,
-                          null,
-                          {
-                            action: 'issues',
-                          }
-                        )
-                      }
-                    >
-                      <Icon
-                        css={actionIcon}
-                        name={Icon.TYPE.GITHUB}
-                        size="0.875rem"
-                      />
-                    </ExternalLink>
-                  </li>
-                )}
-              </>
-            )}
             <li
               css={css`
                 display: flex;

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -238,6 +238,21 @@ const GlobalHeader = ({ className }) => {
             <li
               css={css`
                 display: flex;
+                align-items: center;
+              `}
+            >
+              <ExternalLink
+                href="https://one.newrelic.com"
+                css={css`
+                  font-size: 0.675rem;
+                `}
+              >
+                Log in
+              </ExternalLink>
+            </li>
+            <li
+              css={css`
+                display: flex;
               `}
             >
               <Button

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -245,6 +245,7 @@ const GlobalHeader = ({ className }) => {
                 href="https://one.newrelic.com"
                 css={css`
                   font-size: 0.675rem;
+                  font-weight: 600;
                 `}
               >
                 Log in

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,10 +3506,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@wry/equality@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
-  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
+"@wry/equality@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.3.0.tgz#4b022a0907f01f32c07a1a665d9430155a59ea06"
+  integrity sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==
   dependencies:
     tslib "^1.9.3"
 


### PR DESCRIPTION
Closes https://github.com/newrelic/docs-website/issues/171

## Description

Adds a login link to the global header. Reorders the nav links to correspond to the suggested order. Removes split.io links from the header. 

## Screenshots

<img width="1052" alt="Screen Shot 2020-10-26 at 2 48 21 PM" src="https://user-images.githubusercontent.com/565661/97232653-c4daad00-179a-11eb-9cc6-defe7b79e249.png">

