### PR TITLE
Fix missing key warning on head element

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby/on-pre-render-html.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-pre-render-html.js
@@ -19,6 +19,7 @@ const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) => {
       href="https://fonts.googleapis.com/css2?family=Ovo&display=swap"
     />,
     <script
+      key="bizible"
       type="text/javascript"
       src="//cdn.bizible.com/scripts/bizible.js"
       async=""


### PR DESCRIPTION
## Description

Fix the missing key warning on the head element when starting up a gatsby site
