### PR TITLE
Minor footer improvements

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -17,6 +17,7 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
         }
         layout {
           contentPadding
+          maxWidth
         }
       }
       sitePage(path: { eq: "/terms" }) {
@@ -53,6 +54,8 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
           justify-content: space-between;
           display: flex;
           padding: 1rem ${layout.contentPadding};
+          max-width: ${layout.maxWidth};
+          margin: 0 auto;
 
           @media screen and (max-width: 550px) {
             flex-direction: column;
@@ -113,72 +116,79 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
       <div
         css={css`
           background-color: rgba(0, 0, 0, 0.05);
-          font-size: 0.75rem;
-          align-items: center;
-          justify-content: space-between;
-          display: grid;
-          grid-template-columns: auto auto;
-          grid-template-areas: 'copyright legal';
-          padding: 0.5rem ${layout.contentPadding};
 
           .dark-mode & {
             background-color: rgba(0, 0, 0, 0.2);
-          }
-
-          @media screen and (max-width: 760px) {
-            justify-content: center;
-            text-align: center;
-            grid-template-columns: auto;
-            grid-gap: 0.5rem;
-            grid-template-areas:
-              'legal'
-              'copyright';
           }
         `}
       >
         <div
           css={css`
-            grid-area: copyright;
-            text-transform: uppercase;
-            font-size: 0.5rem;
-            letter-spacing: 0.1rem;
-          `}
-        >
-          Copyright &copy; 2020 New Relic Inc.
-        </div>
-        <div
-          css={css`
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-            grid-area: legal;
+            font-size: 0.75rem;
+            align-items: center;
+            justify-content: space-between;
+            display: grid;
+            grid-template-columns: auto auto;
+            grid-template-areas: 'copyright legal';
+            padding: 0.5rem ${layout.contentPadding};
+            max-width: ${layout.maxWidth};
+            margin: 0 auto;
 
-            a {
-              margin-left: 0.75rem;
-              white-space: nowrap;
+            @media screen and (max-width: 760px) {
+              justify-content: center;
+              text-align: center;
+              grid-template-columns: auto;
+              grid-gap: 0.5rem;
+              grid-template-areas:
+                'legal'
+                'copyright';
             }
           `}
         >
-          {sitePage ? (
-            <Link to="/terms">Terms of Service</Link>
-          ) : (
-            <ExternalLink href="https://newrelic.com/termsandconditions/terms">
-              Terms of Service
-            </ExternalLink>
-          )}
+          <div
+            css={css`
+              grid-area: copyright;
+              text-transform: uppercase;
+              font-size: 0.5rem;
+              letter-spacing: 0.1rem;
+            `}
+          >
+            Copyright &copy; 2020 New Relic Inc.
+          </div>
+          <div
+            css={css`
+              display: flex;
+              flex-wrap: wrap;
+              justify-content: center;
+              grid-area: legal;
 
-          <ExternalLink href="https://newrelic.com/termsandconditions/dmca">
-            DCMA Policy
-          </ExternalLink>
-          <ExternalLink href="https://newrelic.com/termsandconditions/services-notices">
-            Privacy Notice
-          </ExternalLink>
-          <ExternalLink href="https://newrelic.com/termsandconditions/cookie-policy">
-            Cookie Policy
-          </ExternalLink>
-          <ExternalLink href="https://newrelic.com/termsandconditions/uk-slavery-act">
-            UK Slavery Act
-          </ExternalLink>
+              a {
+                margin-left: 0.75rem;
+                white-space: nowrap;
+              }
+            `}
+          >
+            {sitePage ? (
+              <Link to="/terms">Terms of Service</Link>
+            ) : (
+              <ExternalLink href="https://newrelic.com/termsandconditions/terms">
+                Terms of Service
+              </ExternalLink>
+            )}
+
+            <ExternalLink href="https://newrelic.com/termsandconditions/dmca">
+              DCMA Policy
+            </ExternalLink>
+            <ExternalLink href="https://newrelic.com/termsandconditions/services-notices">
+              Privacy Notice
+            </ExternalLink>
+            <ExternalLink href="https://newrelic.com/termsandconditions/cookie-policy">
+              Cookie Policy
+            </ExternalLink>
+            <ExternalLink href="https://newrelic.com/termsandconditions/uk-slavery-act">
+              UK Slavery Act
+            </ExternalLink>
+          </div>
         </div>
       </div>
     </footer>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -53,11 +53,25 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
           align-items: center;
           justify-content: space-between;
           display: flex;
-          padding: ${layout.contentPadding};
+          padding: 1rem ${layout.contentPadding};
+
+          @media screen and (max-width: 550px) {
+            flex-direction: column;
+            justify-content: center;
+          }
         `}
       >
         <Link to="/">
-          <Logo />
+          <Logo
+            width="150px"
+            css={css`
+              display: block;
+
+              @media screen and (max-width: 550px) {
+                margin-bottom: 1rem;
+              }
+            `}
+          />
         </Link>
         <div>
           {fileRelativePath && (
@@ -72,7 +86,6 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
             >
               <Icon
                 name="edit"
-                size="1rem"
                 css={css`
                   margin-right: 0.5rem;
                 `}
@@ -89,7 +102,6 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
           >
             <Icon
               name="github"
-              size="1rem"
               css={css`
                 margin-right: 0.5rem;
               `}
@@ -105,16 +117,29 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
           font-size: 0.75rem;
           align-items: center;
           justify-content: space-between;
-          display: flex;
+          display: grid;
+          grid-template-columns: auto auto;
+          grid-template-areas: 'copyright legal';
           padding: 0.5rem ${layout.contentPadding};
 
           .dark-mode & {
             background-color: rgba(0, 0, 0, 0.2);
           }
+
+          @media screen and (max-width: 760px) {
+            justify-content: center;
+            text-align: center;
+            grid-template-columns: auto;
+            grid-gap: 0.5rem;
+            grid-template-areas:
+              'legal'
+              'copyright';
+          }
         `}
       >
         <div
           css={css`
+            grid-area: copyright;
             text-transform: uppercase;
             font-size: 0.5rem;
             letter-spacing: 0.1rem;
@@ -124,8 +149,14 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
         </div>
         <div
           css={css`
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            grid-area: legal;
+
             a {
               margin-left: 0.75rem;
+              white-space: nowrap;
             }
           `}
         >

--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -35,7 +35,6 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
       css={css`
         color: var(--secondary-text-color);
         background-color: var(--color-neutrals-050);
-        grid-area: footer;
         z-index: 1;
 
         .dark-mode & {

--- a/packages/gatsby-theme-newrelic/src/components/Logo.js
+++ b/packages/gatsby-theme-newrelic/src/components/Logo.js
@@ -1,18 +1,14 @@
 import React from 'react';
-import { css } from '@emotion/core';
+import PropTypes from 'prop-types';
+import NewRelicLogo from './NewRelicLogo';
 
-const Logo = () => (
-  <div
-    css={css`
-      font-size: 1.6rem;
-
-      &:hover {
-        color: var(--secondary-text-hover-color);
-      }
-    `}
-  >
-    New Relic
-  </div>
+const Logo = ({ className, width }) => (
+  <NewRelicLogo className={className} size={width} />
 );
+
+Logo.propTypes = {
+  className: PropTypes.string,
+  width: PropTypes.string,
+};
 
 export default Logo;


### PR DESCRIPTION
# Description

Use the New Relic Logo as the default logo implementation. Add responsive styles for the footer and ensure the width is set on the logo.

## Screenshots

<img width="500" alt="Screen Shot 2020-10-28 at 3 11 24 PM" src="https://user-images.githubusercontent.com/565661/97502366-3861f300-1930-11eb-9796-77298cebf37e.png">
<img width="869" alt="Screen Shot 2020-10-28 at 3 11 30 PM" src="https://user-images.githubusercontent.com/565661/97502369-39932000-1930-11eb-9b0e-ec0d33c0e78c.png">

