### PR TITLE
Automatically add fileRelativePath to mdx nodes and pages

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -92,3 +92,28 @@ exports.onCreateBabelConfig = ({ actions }, themeOptions) => {
     },
   });
 };
+
+exports.onCreateNode = ({ node, actions }) => {
+  if (node.internal.type === 'Mdx') {
+    const { createNodeField } = actions;
+
+    createNodeField({
+      node,
+      name: 'fileRelativePath',
+      value: getFileRelativePath(node.fileAbsolutePath),
+    });
+  }
+};
+
+exports.onCreatePage = ({ page, actions }) => {
+  const { createPage } = actions;
+
+  if (!page.context.fileRelativePath) {
+    page.context.fileRelativePath = getFileRelativePath(page.componentPath);
+
+    createPage(page);
+  }
+};
+
+const getFileRelativePath = (absolutePath) =>
+  absolutePath.replace(`${process.cwd()}/`, '');


### PR DESCRIPTION
## Description

In all of our sites, we configure an "edit this page" link using a file relative path field. This PR adds that logic to the theme so that each site does not have to implement it.
