### PR TITLE
"Right rail" component

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -14,7 +14,7 @@ module.exports = {
       options: {
         layout: {
           contentPadding: '2rem',
-          maxWidth: '1080px',
+          maxWidth: '1480px',
         },
         newrelic: {
           configs: {

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -7,6 +7,7 @@ module.exports = {
     repository: 'https://github.com/newrelic/gatsby-theme-newrelic',
     siteUrl: 'https://developer.newrelic.com',
     utmSource: 'demo-site',
+    branch: 'develop',
   },
   plugins: [
     {
@@ -32,7 +33,7 @@ module.exports = {
             authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
           },
         },
-        gaTrackingId: 'UA-3047412-33'
+        gaTrackingId: 'UA-3047412-33',
       },
     },
     'gatsby-plugin-mdx',

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -7,11 +7,13 @@ import {
   Button,
   CodeBlock,
   Callout,
+  ContributingGuidelines,
   CookieConsentDialog,
   Feedback,
   GlobalFooter,
   GlobalHeader,
   HamburgerMenu,
+  PageTools,
   NewRelicLogo,
   SearchInput,
   Surface,
@@ -74,243 +76,260 @@ const IndexPage = ({ data }) => {
           margin: 0 auto;
           padding: ${layout.contentPadding};
           max-width: ${layout.maxWidth};
-
-          section {
-            margin-bottom: 4rem;
-          }
-
-          h2 {
-            margin-bottom: 1rem;
-
-            &:not(:first-child) {
-              margin-top: 1rem;
-            }
-          }
+          display: grid;
+          grid-template-columns: minmax(0, 1fr) 320px;
+          grid-gap: ${layout.contentPadding};
         `}
       >
-        <h1>Hello, demo</h1>
-        <p>
-          This is a demo site that can be used to preview features of the New
-          Relic Gatsby theme. Feel free to add examples to this site to showcase
-          features.
-        </p>
-        <section>
-          <h2>Search inputs</h2>
-          <SearchInput
-            style={{ margin: '1rem 0', maxWidth: '500px' }}
-            placeholder="Test out a medium search"
-            onClear={() => setSearchTerm('')}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            value={searchTerm}
-            iconName={SearchInput.ICONS.SEARCH}
-          />
-          <SearchInput
-            style={{ marginBottom: '1rem', maxWidth: '500px' }}
-            placeholder="Test out a large search"
-            onClear={() => setSearchTerm('')}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            value={searchTerm}
-            size={SearchInput.SIZE.LARGE}
-            iconName={SearchInput.ICONS.SEARCH}
-          />
-        </section>
-        <section>
-          <Callout variant={Callout.VARIANT.CAUTION}>
-            Danger! Exercise extreme caution.
-          </Callout>
-          <Callout variant={Callout.VARIANT.IMPORTANT}>
-            Important! I said, this is important.
-          </Callout>
-          <Callout variant={Callout.VARIANT.TIP}>Here's a tip.</Callout>
-          <Callout variant={Callout.VARIANT.TIP} title="Hello">
-            Here's a tip with a custom title
-          </Callout>
-          <Callout variant={Callout.VARIANT.TIP} title={null}>
-            Here's a tip with no title
-          </Callout>
-        </section>
-        <section>
-          <h2>A code block</h2>
-          <CodeBlock
-            copyable
-            lineNumbers
-            highlightedLines="5-7,11"
-            fileName="src/components/Button.js"
-            language="jsx"
-            css={css`
-              margin-bottom: 2rem;
-            `}
-          >
-            {codeSample}
-          </CodeBlock>
-          <h2>A live editable code block w/ preview</h2>
-          <CodeBlock
-            copyable
-            lineNumbers
-            live
-            preview
-            fileName="src/components/Button.js"
-            language="jsx"
-            scope={{ Button }}
-            css={css`
-              margin-bottom: 2rem;
-            `}
-          >
-            {liveCodeSample}
-          </CodeBlock>
-        </section>
-        <section>
-          <h2>Buttons</h2>
-          <h3>Variants</h3>
-          <div
-            css={css`
-              display: flex;
-              gap: 1rem;
-              margin-bottom: 2rem;
-              align-items: start;
-            `}
-          >
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.PRIMARY}
-            >
-              Primary
-            </Button>
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.NORMAL}
-            >
-              Normal
-            </Button>
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.OUTLINE}
-            >
-              Outline
-            </Button>
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.LINK}
-            >
-              Link
-            </Button>
-          </div>
-          <h3>Sizes</h3>
-          <div
-            css={css`
-              display: flex;
-              align-items: flex-start;
-              gap: 1rem;
-            `}
-          >
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.PRIMARY}
-            >
-              Default
-            </Button>
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.PRIMARY}
-              size={Button.SIZE.SMALL}
-            >
-              Small
-            </Button>
-            <Button
-              onClick={() => alert('Hello!')}
-              variant={Button.VARIANT.PRIMARY}
-              size={Button.SIZE.EXTRA_SMALL}
-            >
-              Extra small
-            </Button>
-          </div>
-        </section>
-        <section>
-          <h2>Primary surfaces</h2>
-          <div
-            css={css`
-              display: grid;
-              grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-              grid-gap: 2rem;
-              margin-bottom: 2rem;
-            `}
-          >
-            <Surface
-              base={Surface.BASE.PRIMARY}
-              css={css`
-                padding: 2rem;
-              `}
-            >
-              Non-interactive
-            </Surface>
-            <Surface
-              interactive
-              base={Surface.BASE.PRIMARY}
-              css={css`
-                padding: 2rem;
-              `}
-            >
-              Interactive
-            </Surface>
-          </div>
-          <h2>Secondary surfaces</h2>
-          <div
-            css={css`
-              display: grid;
-              grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-              grid-gap: 2rem;
-              padding: 1rem;
-              border-radius: 4px;
-              background: var(--secondary-background-color);
-            `}
-          >
-            <Surface
-              base={Surface.BASE.SECONDARY}
-              css={css`
-                padding: 2rem;
-              `}
-            >
-              Non-interactive
-            </Surface>
-            <Surface
-              interactive
-              base={Surface.BASE.SECONDARY}
-              css={css`
-                padding: 2rem;
-              `}
-            >
-              Interactive
-            </Surface>
-          </div>
-        </section>
-        <section>
-          <h2>Wistia video</h2>
-          <Video id="inyshp3m7r" type={Video.TYPE.WISTIA} width="500px" />
-          <h2>YouTube video</h2>
-          <Video id="ZagZfNQYJEU" type={Video.TYPE.YOUTUBE} width="500px" />
-        </section>
+        <div
+          css={css`
+            section {
+              margin-bottom: 4rem;
+            }
 
-        <section>
-          <h2>Feedback</h2>
-          <div
-            css={css`
-              max-width: 350px;
-            `}
-          >
-            <Feedback
-              onSubmit={({ sentiment, comment }) => {
-                console.log('comment', sentiment, comment);
-              }}
+            h2 {
+              margin-bottom: 1rem;
+
+              &:not(:first-child) {
+                margin-top: 1rem;
+              }
+            }
+          `}
+        >
+          <h1>Hello, demo</h1>
+          <p>
+            This is a demo site that can be used to preview features of the New
+            Relic Gatsby theme. Feel free to add examples to this site to
+            showcase features.
+          </p>
+          <section>
+            <h2>Search inputs</h2>
+            <SearchInput
+              style={{ margin: '1rem 0', maxWidth: '500px' }}
+              placeholder="Test out a medium search"
+              onClear={() => setSearchTerm('')}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              value={searchTerm}
+              iconName={SearchInput.ICONS.SEARCH}
             />
-          </div>
-        </section>
+            <SearchInput
+              style={{ marginBottom: '1rem', maxWidth: '500px' }}
+              placeholder="Test out a large search"
+              onClear={() => setSearchTerm('')}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              value={searchTerm}
+              size={SearchInput.SIZE.LARGE}
+              iconName={SearchInput.ICONS.SEARCH}
+            />
+          </section>
+          <section>
+            <Callout variant={Callout.VARIANT.CAUTION}>
+              Danger! Exercise extreme caution.
+            </Callout>
+            <Callout variant={Callout.VARIANT.IMPORTANT}>
+              Important! I said, this is important.
+            </Callout>
+            <Callout variant={Callout.VARIANT.TIP}>Here's a tip.</Callout>
+            <Callout variant={Callout.VARIANT.TIP} title="Hello">
+              Here's a tip with a custom title
+            </Callout>
+            <Callout variant={Callout.VARIANT.TIP} title={null}>
+              Here's a tip with no title
+            </Callout>
+          </section>
+          <section>
+            <h2>A code block</h2>
+            <CodeBlock
+              copyable
+              lineNumbers
+              highlightedLines="5-7,11"
+              fileName="src/components/Button.js"
+              language="jsx"
+              css={css`
+                margin-bottom: 2rem;
+              `}
+            >
+              {codeSample}
+            </CodeBlock>
+            <h2>A live editable code block w/ preview</h2>
+            <CodeBlock
+              copyable
+              lineNumbers
+              live
+              preview
+              fileName="src/components/Button.js"
+              language="jsx"
+              scope={{ Button }}
+              css={css`
+                margin-bottom: 2rem;
+              `}
+            >
+              {liveCodeSample}
+            </CodeBlock>
+          </section>
+          <section>
+            <h2>Buttons</h2>
+            <h3>Variants</h3>
+            <div
+              css={css`
+                display: flex;
+                gap: 1rem;
+                margin-bottom: 2rem;
+                align-items: start;
+              `}
+            >
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.PRIMARY}
+              >
+                Primary
+              </Button>
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.NORMAL}
+              >
+                Normal
+              </Button>
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.OUTLINE}
+              >
+                Outline
+              </Button>
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.LINK}
+              >
+                Link
+              </Button>
+            </div>
+            <h3>Sizes</h3>
+            <div
+              css={css`
+                display: flex;
+                align-items: flex-start;
+                gap: 1rem;
+              `}
+            >
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.PRIMARY}
+              >
+                Default
+              </Button>
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.PRIMARY}
+                size={Button.SIZE.SMALL}
+              >
+                Small
+              </Button>
+              <Button
+                onClick={() => alert('Hello!')}
+                variant={Button.VARIANT.PRIMARY}
+                size={Button.SIZE.EXTRA_SMALL}
+              >
+                Extra small
+              </Button>
+            </div>
+          </section>
+          <section>
+            <h2>Primary surfaces</h2>
+            <div
+              css={css`
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+                grid-gap: 2rem;
+                margin-bottom: 2rem;
+              `}
+            >
+              <Surface
+                base={Surface.BASE.PRIMARY}
+                css={css`
+                  padding: 2rem;
+                `}
+              >
+                Non-interactive
+              </Surface>
+              <Surface
+                interactive
+                base={Surface.BASE.PRIMARY}
+                css={css`
+                  padding: 2rem;
+                `}
+              >
+                Interactive
+              </Surface>
+            </div>
+            <h2>Secondary surfaces</h2>
+            <div
+              css={css`
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+                grid-gap: 2rem;
+                padding: 1rem;
+                border-radius: 4px;
+                background: var(--secondary-background-color);
+              `}
+            >
+              <Surface
+                base={Surface.BASE.SECONDARY}
+                css={css`
+                  padding: 2rem;
+                `}
+              >
+                Non-interactive
+              </Surface>
+              <Surface
+                interactive
+                base={Surface.BASE.SECONDARY}
+                css={css`
+                  padding: 2rem;
+                `}
+              >
+                Interactive
+              </Surface>
+            </div>
+          </section>
+          <section>
+            <h2>Wistia video</h2>
+            <Video id="inyshp3m7r" type={Video.TYPE.WISTIA} width="500px" />
+            <h2>YouTube video</h2>
+            <Video id="ZagZfNQYJEU" type={Video.TYPE.YOUTUBE} width="500px" />
+          </section>
 
-        <section>
-          <TagList>
-            <Tag>React</Tag>
-            <Tag interactive>Agent</Tag>
-          </TagList>
-        </section>
+          <section>
+            <h2>Feedback</h2>
+            <div
+              css={css`
+                max-width: 350px;
+              `}
+            >
+              <Feedback
+                onSubmit={({ sentiment, comment }) => {
+                  console.log('comment', sentiment, comment);
+                }}
+              />
+            </div>
+          </section>
+
+          <section>
+            <TagList>
+              <Tag>React</Tag>
+              <Tag interactive>Agent</Tag>
+            </TagList>
+          </section>
+        </div>
+        <PageTools>
+          <ContributingGuidelines fileRelativePath="demo/src/pages/index.js" />
+          <PageTools.Section>
+            <PageTools.Title>How to use</PageTools.Title>
+            <p>
+              The <code>PageTools</code> component is great for use as a sidebar
+              to give page-specific context to a user
+            </p>
+          </PageTools.Section>
+        </PageTools>
       </div>
       <GlobalFooter fileRelativePath="src/content/foobar.md" />
       <CookieConsentDialog />

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -580,14 +580,14 @@ Used to display contributing information for the current page. This is meant to
 be used as a section inside of the [`PageTools`](#pagetools) component.
 
 To ensure this component leverages its full potential, please ensure the
-following [`siteMetadata`](#sitemetadata) fields are configured:
+following [`siteMetadata`](#site-metadata) fields are configured:
 
 - `branch`
 - `contributingUrl`
 - `repository`
 
-**NOTE:** If the `contributingUrl` is not configured, it will use the default value as
-specified in the [`siteMetadata`](#sitemetadata) section.
+**NOTE:** If the `contributingUrl` is not configured, it will use the default
+value as specified in the [`siteMetadata`](#site-metadata) section.
 
 ```js
 import { ContributingGuidelines } from '@newrelic/gatsby-theme-newrelic'`

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -17,6 +17,7 @@ websites](https://opensource.newrelic.com).
     - [`robots`](#robots)
     - [`layout`](#layout)
     - [`prism`](#prism)
+    - [`gdprTracking`](#gdprtracking)
     - [`splitio`](#splitio)
       - [Environment-specific configuration](#environment-specific-configuration)
 - [Components](#components)
@@ -46,6 +47,7 @@ websites](https://opensource.newrelic.com).
   - [`useQueryParams`](#usequeryparams)
   - [`useTimeout`](#usetimeout)
   - [`useUserId`](#useuserid)
+  - [`usePrevious`](#useprevious)
 - [Announcements](#announcements)
 - [Utils](#utils)
   - [`formatCode`](#formatcode)
@@ -140,6 +142,10 @@ are optional, they are highly recommended.
 - `branch`: The mainline branch for use when constructing "Edit this page" links (defaults to `main`).
 - `utmSource`: Name of the site that will be used as the UTM source when linking
   to various mediums within New Relic.
+- `contributingUrl`: The URL where a user can find contributing guidelines for
+  the site. If this is not specified, it defaults to the `CONTRIBUTING.md` file
+  in the repo and branch specified in the `siteMetadata`. If the `repository` is
+  not specified, this will return `null`.
 
 ### Options
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -150,7 +150,8 @@ are optional, they are highly recommended.
 - `contributingUrl`: The URL where a user can find contributing guidelines for
   the site. If this is not specified, it defaults to the `CONTRIBUTING.md` file
   in the repo and branch specified in the `siteMetadata`. If the `repository` is
-  not specified, this will return `null`.
+  not specified, this will return `null`. Set this value to `null` to disable
+  the default behavior.
 
 ### Options
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -25,6 +25,7 @@ websites](https://opensource.newrelic.com).
   - [`Button`](#button)
   - [`Callout`](#callout)
   - [`CodeBlock`](#codeblock)
+  - [`ContributingGuidelines`](#contributingguidelines)
   - [`CookieConsentDialog`](#cookieconsentdialog)
   - [`ExternalLink`](#externallink)
   - [`Feedback`](#feedback)
@@ -570,6 +571,39 @@ const Documentation = () => (
     {codeSample}
   </CodeBlock>
 );
+```
+
+### `ContributingGuidelines`
+
+Used to display contributing information for the current page. This is meant to
+be used as a section inside of the [`PageTools`](#pagetools) component.
+
+To ensure this component leverages its full potential, please ensure the
+following [`siteMetadata`](#sitemetadata) fields are configured:
+
+- `branch`
+- `contributingUrl`
+- `repository`
+
+**NOTE:** If the `contributingUrl` is not configured, it will use the default value as
+specified in the [`siteMetadata`](#sitemetadata) section.
+
+```js
+import { ContributingGuidelines } from '@newrelic/gatsby-theme-newrelic'`
+```
+
+**Props**
+
+| Prop               | Type   | Required | Default | Description                                                                                 |
+| ------------------ | ------ | -------- | ------- | ------------------------------------------------------------------------------------------- |
+| `fileRelativePath` | string | no       |         | The relative file path of the current page. This will be used by the "Edit this page" link. |
+
+**Examples**
+
+```js
+<PageTools>
+  <ContributingGuidelines fileRelativePath="src/pages/index.js" />
+</PageTools>
 ```
 
 ### `CookieConsentDialog`

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -34,6 +34,9 @@ websites](https://opensource.newrelic.com).
   - [`Icon`](#icon)
   - [`MDXCodeBlock`](#mdxcodeblock)
   - [`NewRelicLogo`](#newreliclogo)
+  - [`PageTools`](#pagetools)
+  - [`PageTools.Section`](#pagetoolssection)
+  - [`PageTools.Title`](#pagetoolstitle)
   - [`SearchInput`](#searchinput)
   - [`Spinner`](#spinner)
   - [`Surface`](#surface)
@@ -946,6 +949,85 @@ import { NewRelicLogo } from '@newrelic/gatsby-theme-newrelic';
 ```js
 <NewRelicLogo />
 ```
+
+### `PageTools`
+
+Used as a "right rail" container to display content related to the current page.
+To build modules contained inside this component, see the
+[`PageTools.Section`](#pagetoolssection) and [`PageTools.Title`](#pagetoolstitle)
+documentation.
+
+```js
+import { PageTools } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Props**
+
+| Prop        | Type   | Required | Default | Description                                          |
+| ----------- | ------ | -------- | ------- | ---------------------------------------------------- |
+| `className` | string | no       |         | Additional `className` for the component.            |
+| `children`  | node   | no       |         | Content to be displayed in the `PageTools` component |
+
+**Example**
+
+```jsx
+<PageTools>
+  <PageTools.Section>
+    <PageTools.Title>How to use</PageTools.Title>
+    <p>
+      Use the `PageTools` component to render content related to the current
+      page.
+    </p>
+  </PageTools.Section>
+</PageTools>
+```
+
+### `PageTools.Section`
+
+A component used as a building block for creating content displayed inside of
+the [`PageTools`](#pagetools) component. This is a container for the content
+inside a section of the `PageTools`.
+
+**Props**
+
+| Prop        | Type   | Required | Default | Description                                                  |
+| ----------- | ------ | -------- | ------- | ------------------------------------------------------------ |
+| `className` | string | no       |         | Additional `className` for the component.                    |
+| `children`  | node   | no       |         | Content to be displayed in the `PageTools.Section` component |
+
+**Example**
+
+```jsx
+<PageTools>
+  <PageTools.Section>
+    Use the `PageTools.Section` component as a container around content to be
+    displayed in a section of the `PageTools`.
+  </PageTools.Section>
+  <PageTools.Section>
+    This will be displayed as its own section inside `PageTools`
+  </PageTools.Section>
+</PageTools>
+```
+
+### `PageTools.Title`
+
+A component used as a building block for creating content displayed inside of
+the [`PageTools`](#pagetools) component. This is used to display a title for the
+section of content inside of `PageTools`. Render this inside of a
+[`PageTools.Section`](#pagetoolssection) component.
+
+```jsx
+<PageTools.Section>
+  <PageTools.Title>Related resources</PageTools.Title>
+</PageTools.Section>
+```
+
+**Props**
+
+| Prop        | Type   | Required | Default | Description                                              |
+| ----------- | ------ | -------- | ------- | -------------------------------------------------------- |
+| `className` | string | no       |         | Additional `className` for the component.                |
+| `children`  | node   | no       |         | Title to be displayed in the `PageTools.Title` component |
 
 ### `SearchInput`
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -36,6 +36,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
 
     type SiteSiteMetadata {
+      repository: String
       utmSource: String
       branch: String!
       contributingUrl: String

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -38,6 +38,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type SiteSiteMetadata {
       utmSource: String
       branch: String!
+      contributingUrl: String
     }
   `);
 };
@@ -65,6 +66,17 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
       },
       branch: {
         resolve: ({ branch }) => branch || DEFAULT_BRANCH,
+      },
+      contributingUrl: {
+        resolve: ({ branch, repository }) => {
+          if (!repository) {
+            return;
+          }
+
+          return `${repository}/blob/${
+            branch || DEFAULT_BRANCH
+          }/CONTRIBUTING.md`;
+        },
       },
     },
   });

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -70,7 +70,7 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
       },
       contributingUrl: {
         resolve: ({ contributingUrl, branch, repository }) => {
-          if (contributingUrl) {
+          if (contributingUrl !== undefined) {
             return contributingUrl;
           }
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -69,14 +69,14 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
         resolve: ({ branch }) => branch || DEFAULT_BRANCH,
       },
       contributingUrl: {
-        resolve: ({ branch, repository }) => {
-          if (!repository) {
-            return;
+        resolve: ({ contributingUrl, branch, repository }) => {
+          if (contributingUrl) {
+            return contributingUrl;
           }
 
-          return `${repository}/blob/${
-            branch || DEFAULT_BRANCH
-          }/CONTRIBUTING.md`;
+          return repository
+            ? `${repository}/blob/${branch || DEFAULT_BRANCH}/CONTRIBUTING.md`
+            : null;
         },
       },
     },

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -13,6 +13,7 @@ export { default as Logo } from './src/components/Logo';
 export { default as MDXCodeBlock } from './src/components/MDXCodeBlock';
 export { default as NewRelicLogo } from './src/components/NewRelicLogo';
 export { default as Overlay } from './src/components/Overlay';
+export { default as PageTools } from './src/components/PageTools';
 export { default as Portal } from './src/components/Portal';
 export { default as SearchInput } from './src/components/SearchInput';
 export { default as Surface } from './src/components/Surface';

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -2,6 +2,7 @@ export { default as Banner } from './src/components/Banner';
 export { default as Button } from './src/components/Button';
 export { default as Callout } from './src/components/Callout';
 export { default as CodeBlock } from './src/components/CodeBlock';
+export { default as ContributingGuidelines } from './src/components/ContributingGuidelines';
 export { default as CookieConsentDialog } from './src/components/CookieConsentDialog';
 export { default as ExternalLink } from './src/components/ExternalLink';
 export { default as Feedback } from './src/components/Feedback';

--- a/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
+++ b/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import Button from './Button';
+import ExternalLink from './ExternalLink';
+import Icon from './Icon';
+import PageTools from './PageTools';
+import { graphql, useStaticQuery } from 'gatsby';
+
+const ContributingGuidelines = ({ fileRelativePath }) => {
+  const {
+    site: {
+      siteMetadata: { repository, branch, contributingUrl },
+    },
+  } = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          repository
+          branch
+          contributingUrl
+        }
+      }
+    }
+  `);
+
+  return (
+    <PageTools.Section
+      css={css`
+        background-color: var(--divider-color);
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          gap: 0.5rem;
+          flex-wrap: wrap;
+          justify-content: center;
+          margin-bottom: 0.5rem;
+
+          @supports not (gap: 1rem) {
+            > :first-child {
+              margin-right: 0.5rem;
+            }
+          }
+        `}
+      >
+        <Button
+          as={ExternalLink}
+          href={`${repository}/issues/new/choose`}
+          variant={Button.VARIANT.OUTLINE}
+          size={Button.SIZE.SMALL}
+        >
+          <Icon
+            name={Icon.TYPE.GITHUB}
+            css={css`
+              margin-right: 0.5rem;
+            `}
+          />
+          Create an issue
+        </Button>
+
+        {fileRelativePath && (
+          <Button
+            as={ExternalLink}
+            href={`${repository}/blob/${branch}/${fileRelativePath}`}
+            variant={Button.VARIANT.OUTLINE}
+            size={Button.SIZE.SMALL}
+          >
+            <Icon
+              name={Icon.TYPE.EDIT}
+              css={css`
+                margin-right: 0.5rem;
+              `}
+            />
+            Edit this page
+          </Button>
+        )}
+      </div>
+      {contributingUrl && (
+        <p
+          css={css`
+            margin-bottom: 0 !important;
+            font-size: 0.75rem;
+            text-align: center;
+          `}
+        >
+          Read our <ExternalLink href={contributingUrl}>guide</ExternalLink> on
+          how to contribute
+        </p>
+      )}
+    </PageTools.Section>
+  );
+};
+
+ContributingGuidelines.propTypes = {
+  fileRelativePath: PropTypes.string,
+};
+
+export default ContributingGuidelines;

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -98,7 +98,7 @@ const GlobalHeader = ({ className }) => {
       >
         <div
           css={css`
-            height: 36px;
+            height: var(--global-header-height);
             display: flex;
             justify-content: space-between;
             max-width: ${layout.maxWidth};

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -245,7 +245,7 @@ const GlobalHeader = ({ className }) => {
               ) : (
                 <SearchInput
                   ref={searchRef}
-                  placeholder="Search Docs, Developer, Opensource"
+                  placeholder="Search Docs, Developer, Open Source"
                   size={SearchInput.SIZE.SMALL}
                   onClear={() => setSearchQuery('')}
                   onChange={(e) => setSearchQuery(e.target.value)}

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles.js
@@ -242,6 +242,8 @@ const GlobalStyles = () => (
       ${normalize()}
 
       :root {
+        --global-header-height: 36px;
+
         ${colors};
         ${fonts};
       }

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/PageTools.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/PageTools.js
@@ -1,0 +1,64 @@
+import React, { Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import { graphql, useStaticQuery } from 'gatsby';
+import { css, ClassNames } from '@emotion/core';
+import { borderRadius } from 'polished';
+import Section from './Section';
+import Title from './Title';
+
+const PageTools = ({ className, children }) => {
+  const {
+    site: { layout },
+  } = useStaticQuery(graphql`
+    query {
+      site {
+        layout {
+          contentPadding
+        }
+      }
+    }
+  `);
+
+  return (
+    <aside
+      data-swiftype-index={false}
+      className={className}
+      css={css`
+        align-self: start;
+        position: sticky;
+        top: calc(var(--global-header-height) + ${layout.contentPadding});
+        border: 1px solid var(--divider-color);
+        border-radius: 0.25rem;
+        overflow-y: auto;
+        max-height: calc(
+          100vh - (var(--global-header-height) + ${layout.contentPadding} * 2)
+        );
+      `}
+    >
+      {Children.map(children, (child, idx) => (
+        <ClassNames>
+          {({ cx, css }) =>
+            cloneElement(child, {
+              className: cx(
+                child.props?.className,
+                idx === 0 && css(borderRadius('top', '0.25rem')),
+                idx === Children.count(children) - 1 &&
+                  css(borderRadius('bottom', '0.25rem'))
+              ),
+            })
+          }
+        </ClassNames>
+      ))}
+    </aside>
+  );
+};
+
+PageTools.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+PageTools.Section = Section;
+PageTools.Title = Title;
+
+export default PageTools;

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/PageTools.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/PageTools.js
@@ -1,8 +1,7 @@
-import React, { Children, cloneElement } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql, useStaticQuery } from 'gatsby';
-import { css, ClassNames } from '@emotion/core';
-import { borderRadius } from 'polished';
+import { css } from '@emotion/core';
 import Section from './Section';
 import Title from './Title';
 
@@ -35,20 +34,7 @@ const PageTools = ({ className, children }) => {
         );
       `}
     >
-      {Children.map(children, (child, idx) => (
-        <ClassNames>
-          {({ cx, css }) =>
-            cloneElement(child, {
-              className: cx(
-                child.props?.className,
-                idx === 0 && css(borderRadius('top', '0.25rem')),
-                idx === Children.count(children) - 1 &&
-                  css(borderRadius('bottom', '0.25rem'))
-              ),
-            })
-          }
-        </ClassNames>
-      ))}
+      {children}
     </aside>
   );
 };

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const Section = ({ children, className }) => (
+  <section
+    className={className}
+    css={css`
+      padding: 1rem;
+    `}
+  >
+    {children}
+  </section>
+);
+
+Section.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default Section;

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
@@ -1,12 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
+import { borderRadius } from 'polished';
 
 const Section = ({ children, className }) => (
   <section
     className={className}
     css={css`
       padding: 1rem;
+
+      &:first-child {
+        ${borderRadius('top', '0.25rem')};
+      }
+
+      &:last-child {
+        ${borderRadius('top', '0.25rem')};
+      }
     `}
   >
     {children}

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
@@ -14,7 +14,7 @@ const Section = ({ children, className }) => (
       }
 
       &:last-child {
-        ${borderRadius('top', '0.25rem')};
+        ${borderRadius('bottom', '0.25rem')};
       }
     `}
   >

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
@@ -16,6 +16,10 @@ const Section = ({ children, className }) => (
       &:last-child {
         ${borderRadius('bottom', '0.25rem')};
       }
+
+      > :last-child {
+        margin-bottom: 0;
+      }
     `}
   >
     {children}

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/Title.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/Title.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const Title = ({ children, className }) => (
+  <h4
+    className={className}
+    css={css`
+      margin-top: 0 !important;
+      margin-bottom: 0.5rem !important;
+      font-size: 1rem;
+    `}
+  >
+    {children}
+  </h4>
+);
+
+Title.propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string,
+};
+
+export default Title;

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/index.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/index.js
@@ -1,0 +1,1 @@
+export { default } from './PageTools';


### PR DESCRIPTION
Closes #144 

## Description

Adds a `PageTools` component that can be leveraged to show content as a "right rail" for each Gatsby site. This also includes some building blocks as well as a `ContributingGuidelines` component that can be used to display information on how to edit the current page/file an issue/link to contributing guidelines.

