### PR TITLE
Filter out menu pages for docs results

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -48,6 +48,11 @@ const configOptions = {
         values: ['docs', 'developer', 'opensource'],
         type: 'any',
       },
+      {
+        field: 'document_type',
+        values: ['!views_page_menu'],
+        type: 'any',
+      },
     ],
   },
   initialState: {


### PR DESCRIPTION
We filter out menu pages by default because they're just lists of links to other pages, so they add a lot of noise to docs search results.

We add each docs page's content type in the swiftype field `document_type`

Example of a menu page: https://docs.newrelic.com/docs/apm/apm-ui-pages/monitoring