### PR TITLE
Focus search input when overlay opens

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';
 import {
   SearchProvider,
@@ -123,6 +123,13 @@ const SwiftypeSearch = ({ className }) => {
 
 const InputView = ({ getAutocomplete, getInputProps }) => {
   const inputProps = getInputProps();
+  const inputRef = useRef();
+  useEffect(() => {
+    // Use a timeout to wait until overlay transitions finish (~500ms) and ready to focus.
+    setTimeout(() => {
+      inputRef.current.focus();
+    }, 100);
+  }, []);
   return (
     <>
       <div
@@ -134,7 +141,11 @@ const InputView = ({ getAutocomplete, getInputProps }) => {
           }
         `}
       >
-        <SearchInput size={SearchInput.SIZE.LARGE} {...inputProps} />
+        <SearchInput
+          ref={inputRef}
+          size={SearchInput.SIZE.LARGE}
+          {...inputProps}
+        />
         {getAutocomplete()}
       </div>
     </>
@@ -143,6 +154,7 @@ const InputView = ({ getAutocomplete, getInputProps }) => {
 
 SwiftypeSearch.propTypes = {
   className: PropTypes.string,
+  isOpen: PropTypes.bool,
 };
 
 InputView.propTypes = {

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -154,7 +154,6 @@ const InputView = ({ getAutocomplete, getInputProps }) => {
 
 SwiftypeSearch.propTypes = {
   className: PropTypes.string,
-  isOpen: PropTypes.bool,
 };
 
 InputView.propTypes = {


### PR DESCRIPTION
Closes #84 

This fixes the issue described in issue linked above. When search overlay opens it focuses the search input so a user can start typing.

We had to put it in a `setTimeout()` in order to wait out whatever was happening with `<Overlay />` component rendering. The CSS transitions that run on open took ~500ms. 100ms seemed to do the trick for the timeout though ¯\_(ツ)_/¯