### PR TITLE
fix: added career link to global footer

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -168,6 +168,9 @@ const GlobalFooter = ({ fileRelativePath, className }) => {
               }
             `}
           >
+            <ExternalLink href="https://newrelic.com/about/careers">
+              Careers
+            </ExternalLink>
             {sitePage ? (
               <Link to="/terms">Terms of Service</Link>
             ) : (


### PR DESCRIPTION
This PR adds the careers link to the global footer

![Screen Shot 2020-12-04 at 5 53 10 PM](https://user-images.githubusercontent.com/1395158/101228709-19a2fa80-365a-11eb-869d-4af7edfd64b6.png)
