### PR TITLE
Added a `<SimpleFeedback />` Component

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -10,6 +10,7 @@ import {
   Layout,
   PageTools,
   SearchInput,
+  SimpleFeedback,
   Surface,
   Tag,
   TagList,
@@ -283,6 +284,17 @@ const IndexPage = () => {
                 console.log('comment', sentiment, comment);
               }}
             />
+          </div>
+        </section>
+
+        <section>
+          <h2>Simple Feedback</h2>
+          <div
+            css={css`
+              max-width: 350px;
+            `}
+          >
+            <SimpleFeedback title="Demo Site" />
           </div>
         </section>
 

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -294,7 +294,7 @@ const IndexPage = () => {
               max-width: 350px;
             `}
           >
-            <SimpleFeedback title="Demo Site" />
+            <SimpleFeedback title="Demo Site" slug="/demo/test-site" />
           </div>
         </section>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   ],
   "scripts": {
     "release": "lerna publish --conventional-commits --create-release github --no-private",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "yarn test --watch"
   },
   "devDependencies": {
     "@newrelic/eslint-plugin-newrelic": "^0.3.1",

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -51,6 +51,7 @@ websites](https://opensource.newrelic.com).
     - [`PageTools.Section`](#pagetoolssection)
     - [`PageTools.Title`](#pagetoolstitle)
   - [`SearchInput`](#searchinput)
+  - [`SimpleFeedback](#simplefeedback)
   - [`Spinner`](#spinner)
   - [`Surface`](#surface)
   - [`Table`](#table)
@@ -1438,6 +1439,26 @@ const Search = () => (
     />
   );
 );
+```
+
+### `SimpleFeedback`
+
+A simplified version of the [`Feedback`](#feedback) component.
+
+```js
+import { SimpleFeedback } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Props**
+| Prop | Type | Required | Default | Description |
+| ------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `title` | string | no | | The current page title, which will be added to the issue title, if supplied. |
+| `slug` | string | no | | The slug for the current page, which will be used to add a link to the page in the issue body, if supplied. |
+
+**Example**
+
+```jsx
+<SimpleFeedback title="My Cool Page" slug="/my-cool-page" />
 ```
 
 ### `Spinner`

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -51,7 +51,7 @@ websites](https://opensource.newrelic.com).
     - [`PageTools.Section`](#pagetoolssection)
     - [`PageTools.Title`](#pagetoolstitle)
   - [`SearchInput`](#searchinput)
-  - [`SimpleFeedback](#simplefeedback)
+  - [`SimpleFeedback`](#simplefeedback)
   - [`Spinner`](#spinner)
   - [`Surface`](#surface)
   - [`Table`](#table)
@@ -1454,6 +1454,7 @@ import { SimpleFeedback } from '@newrelic/gatsby-theme-newrelic';
 | ------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
 | `title` | string | no | | The current page title, which will be added to the issue title, if supplied. |
 | `slug` | string | no | | The slug for the current page, which will be used to add a link to the page in the issue body, if supplied. |
+| `labels` | array | no | `['feedback']` | An array of label string to be applied to the new issue, in addition to either`feedback-positive`or`feedback-negative`. |
 
 **Example**
 

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -21,6 +21,7 @@ export { default as Overlay } from './src/components/Overlay';
 export { default as PageTools } from './src/components/PageTools';
 export { default as Portal } from './src/components/Portal';
 export { default as SearchInput } from './src/components/SearchInput';
+export { default as SimpleFeedback } from './src/components/SimpleFeedback';
 export { default as Surface } from './src/components/Surface';
 export { default as Spinner } from './src/components/Spinner';
 export { default as Table } from './src/components/Table';

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -64,6 +64,7 @@ const SimpleFeedback = ({ title, slug }) => {
           href={positiveFeedback}
           variant={Button.VARIANT.NORMAL}
           target="_blank"
+          role="button"
         >
           <Icon
             size="0.75rem"
@@ -79,6 +80,7 @@ const SimpleFeedback = ({ title, slug }) => {
           href={negativeFeedback}
           variant={Button.VARIANT.NORMAL}
           target="_blank"
+          role="button"
         >
           <Icon
             size="0.75rem"

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -63,13 +63,16 @@ const SimpleFeedback = ({ title, slug, labels }) => {
           margin-top: 0.5rem;
           justify-content: center;
           align-items: flex-start;
+          gap: 0.5rem;
 
           a {
             flex-grow: 1;
           }
 
-          > *:first-child {
-            margin-right: 0.5rem;
+          @supports not (gap: 0.5rem) {
+            a:first-of-type {
+              margin-right: 0.5rem;
+            }
           }
         `}
       >

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -7,14 +7,14 @@ import Button from './Button';
 import Icon from './Icon';
 import PageTools from './PageTools';
 
-const getParams = (title, labels, sentiment, body) => {
+const getParams = (title, labels, sentiment, slug, site) => {
   const params = new URLSearchParams();
 
   params.set('labels', [...labels, sentiment].join(','));
   params.set('title', title ? `Feedback: ${title}` : 'Website Feedback');
 
-  if (body !== '') {
-    params.set('body', body);
+  if (title && slug) {
+    params.set('body', `Page: [${title}](${site}${slug})`);
   }
 
   return params.toString();
@@ -35,21 +35,15 @@ const SimpleFeedback = ({ title, slug, labels }) => {
   const { repository, siteUrl } = site.siteMetadata;
   const issueUrl = `${repository}/issues/new`;
 
-  const body = title && slug ? `Page: [${title}](${siteUrl}${slug})` : '';
+  const positiveFeedback = [
+    issueUrl,
+    getParams(title, labels, 'feedback-positive', slug, siteUrl),
+  ].join('?');
 
-  const positiveFeedback = `${issueUrl}?${getParams(
-    title,
-    labels,
-    'feedback-positive',
-    body
-  )}`;
-
-  const negativeFeedback = `${issueUrl}?${getParams(
-    title,
-    labels,
-    'feedback-negative',
-    body
-  )}`;
+  const negativeFeedback = [
+    issueUrl,
+    getParams(title, labels, 'feedback-negative', slug, siteUrl),
+  ].join('?');
 
   return (
     <PageTools.Section>

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { graphql, useStaticQuery } from 'gatsby';
+import { css } from '@emotion/core';
+
+import Button from './Button';
+import Icon from './Icon';
+import PageTools from './PageTools';
+
+const SimpleFeedback = ({ title, slug }) => {
+  const { site } = useStaticQuery(graphql`
+    query FeedbackQuery {
+      site {
+        siteMetadata {
+          siteUrl
+          repository
+        }
+      }
+    }
+  `);
+
+  const { repository, siteUrl } = site.siteMetadata;
+  const issueUrl = `${repository}/issues/new`;
+  const labels = ['content', 'feedback'].join(',');
+
+  const issueTitle = title
+    ? `Feedback:+${title.replace(' ', '+')}`
+    : 'Website Feedback';
+
+  const body =
+    title && slug ? `&body=Page:%20[${title}](${siteUrl}${slug})` : '';
+
+  const positiveFeedback = `${issueUrl}?labels=${labels},feedback-positive&title=${issueTitle}${body}`;
+  const negativeFeedback = `${issueUrl}?labels=${labels},feedback-negative&title=${issueTitle}${body}`;
+
+  return (
+    <PageTools.Section>
+      <PageTools.Title>Feedback</PageTools.Title>
+      <div
+        css={css`
+          font-size: 0.875rem;
+        `}
+      >
+        Was this page helpful?
+      </div>
+      <div
+        css={css`
+          display: flex;
+          margin-top: 0.5rem;
+          justify-content: center;
+          align-items: flex-start;
+
+          a {
+            flex-grow: 1;
+          }
+
+          > *:first-child {
+            margin-right: 0.5rem;
+          }
+        `}
+      >
+        <Button
+          as="a"
+          href={positiveFeedback}
+          variant={Button.VARIANT.NORMAL}
+          target="_blank"
+        >
+          <Icon
+            size="0.75rem"
+            name={Icon.TYPE.THUMBSUP}
+            css={css`
+              margin-right: 0.5rem;
+            `}
+          />
+          Yes
+        </Button>
+        <Button
+          as="a"
+          href={negativeFeedback}
+          variant={Button.VARIANT.NORMAL}
+          target="_blank"
+        >
+          <Icon
+            size="0.75rem"
+            name={Icon.TYPE.THUMBSDOWN}
+            css={css`
+              margin-right: 0.5rem;
+            `}
+          />
+          No
+        </Button>
+      </div>
+    </PageTools.Section>
+  );
+};
+
+SimpleFeedback.propTypes = {
+  title: PropTypes.string,
+  slug: PropTypes.string,
+};
+
+export default SimpleFeedback;

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -29,12 +29,23 @@ const SimpleFeedback = ({ title, slug, labels }) => {
   const body =
     title && slug ? `&body=Page:%20[${title}](${siteUrl}${slug})` : '';
 
-  const positiveFeedback = `${issueUrl}?labels=${labels.join(
-    ','
-  )},feedback-positive&title=${issueTitle}${body}`;
-  const negativeFeedback = `${issueUrl}?labels=${labels.join(
-    ','
-  )},feedback-negative&title=${issueTitle}${body}`;
+  const positiveFeedback = [
+    issueUrl,
+    '?labels=',
+    [...labels, 'feedback-positive'].join(','),
+    '&title=',
+    issueTitle,
+    body,
+  ].join('');
+
+  const negativeFeedback = [
+    issueUrl,
+    '?labels=',
+    [...labels, 'feedback-negative'].join(','),
+    '&title=',
+    issueTitle,
+    body,
+  ].join('');
 
   return (
     <PageTools.Section>

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -7,7 +7,7 @@ import Button from './Button';
 import Icon from './Icon';
 import PageTools from './PageTools';
 
-const SimpleFeedback = ({ title, slug }) => {
+const SimpleFeedback = ({ title, slug, labels }) => {
   const { site } = useStaticQuery(graphql`
     query FeedbackQuery {
       site {
@@ -21,7 +21,6 @@ const SimpleFeedback = ({ title, slug }) => {
 
   const { repository, siteUrl } = site.siteMetadata;
   const issueUrl = `${repository}/issues/new`;
-  const labels = ['content', 'feedback'].join(',');
 
   const issueTitle = title
     ? `Feedback:+${title.replace(' ', '+')}`
@@ -30,8 +29,12 @@ const SimpleFeedback = ({ title, slug }) => {
   const body =
     title && slug ? `&body=Page:%20[${title}](${siteUrl}${slug})` : '';
 
-  const positiveFeedback = `${issueUrl}?labels=${labels},feedback-positive&title=${issueTitle}${body}`;
-  const negativeFeedback = `${issueUrl}?labels=${labels},feedback-negative&title=${issueTitle}${body}`;
+  const positiveFeedback = `${issueUrl}?labels=${labels.join(
+    ','
+  )},feedback-positive&title=${issueTitle}${body}`;
+  const negativeFeedback = `${issueUrl}?labels=${labels.join(
+    ','
+  )},feedback-negative&title=${issueTitle}${body}`;
 
   return (
     <PageTools.Section>
@@ -99,6 +102,11 @@ const SimpleFeedback = ({ title, slug }) => {
 SimpleFeedback.propTypes = {
   title: PropTypes.string,
   slug: PropTypes.string,
+  labels: PropTypes.arrayOf(PropTypes.string),
+};
+
+SimpleFeedback.defaultProps = {
+  labels: ['feedback'],
 };
 
 export default SimpleFeedback;

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -7,6 +7,19 @@ import Button from './Button';
 import Icon from './Icon';
 import PageTools from './PageTools';
 
+const getParams = (title, labels, sentiment, body) => {
+  const params = new URLSearchParams();
+
+  params.set('labels', [...labels, sentiment].join(','));
+  params.set('title', title ? `Feedback: ${title}` : 'Website Feedback');
+
+  if (body !== '') {
+    params.set('body', body);
+  }
+
+  return params.toString();
+};
+
 const SimpleFeedback = ({ title, slug, labels }) => {
   const { site } = useStaticQuery(graphql`
     query FeedbackQuery {
@@ -22,30 +35,21 @@ const SimpleFeedback = ({ title, slug, labels }) => {
   const { repository, siteUrl } = site.siteMetadata;
   const issueUrl = `${repository}/issues/new`;
 
-  const issueTitle = title
-    ? `Feedback:+${title.replace(' ', '+')}`
-    : 'Website Feedback';
+  const body = title && slug ? `Page: [${title}](${siteUrl}${slug})` : '';
 
-  const body =
-    title && slug ? `&body=Page:%20[${title}](${siteUrl}${slug})` : '';
+  const positiveFeedback = `${issueUrl}?${getParams(
+    title,
+    labels,
+    'feedback-positive',
+    body
+  )}`;
 
-  const positiveFeedback = [
-    issueUrl,
-    '?labels=',
-    [...labels, 'feedback-positive'].join(','),
-    '&title=',
-    issueTitle,
-    body,
-  ].join('');
-
-  const negativeFeedback = [
-    issueUrl,
-    '?labels=',
-    [...labels, 'feedback-negative'].join(','),
-    '&title=',
-    issueTitle,
-    body,
-  ].join('');
+  const negativeFeedback = `${issueUrl}?${getParams(
+    title,
+    labels,
+    'feedback-negative',
+    body
+  )}`;
 
   return (
     <PageTools.Section>

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -6,7 +6,7 @@ import SimpleFeedback from '../SimpleFeedback';
 // https://github.com/facebook/jest/issues/2567
 const SITE = 'https://github.com/foo/bar';
 const REPO = 'https://foobar.net';
-const ISSUE_URL = `${REPO}/issues/new?`;
+const ISSUE_URL = `${REPO}/issues/new`;
 
 jest.mock('gatsby', () => ({
   __esModule: true,
@@ -38,12 +38,10 @@ describe('SimpleFeedback Component', () => {
     const { getAllByRole } = render(<SimpleFeedback labels={labels} />);
     const [yes] = getAllByRole('button');
 
-    const url = [
-      ISSUE_URL,
-      'labels=',
-      labels.join(','),
-      ',feedback-positive&title=Website Feedback',
-    ].join('');
+    const params = new URLSearchParams();
+    params.set('labels', [...labels, 'feedback-positive'].join(','));
+    params.set('title', 'Website Feedback');
+    const url = `${ISSUE_URL}?${params.toString()}`;
 
     expect(yes.getAttribute('href')).toBe(url);
   });
@@ -52,10 +50,15 @@ describe('SimpleFeedback Component', () => {
     const { getAllByRole } = render(<SimpleFeedback />);
     const [yes, no] = getAllByRole('button');
 
-    const title = 'Website Feedback';
-    const labels = `labels=feedback`;
-    const positiveUrl = `${ISSUE_URL}${labels},feedback-positive&title=${title}`;
-    const negativeUrl = `${ISSUE_URL}${labels},feedback-negative&title=${title}`;
+    const yesParams = new URLSearchParams();
+    yesParams.set('labels', ['feedback', 'feedback-positive'].join(','));
+    yesParams.set('title', 'Website Feedback');
+    const positiveUrl = `${ISSUE_URL}?${yesParams.toString()}`;
+
+    const noParams = new URLSearchParams();
+    noParams.set('labels', ['feedback', 'feedback-negative'].join(','));
+    noParams.set('title', 'Website Feedback');
+    const negativeUrl = `${ISSUE_URL}?${noParams.toString()}`;
 
     expect(yes.getAttribute('href')).toBe(positiveUrl);
     expect(no.getAttribute('href')).toBe(negativeUrl);
@@ -66,8 +69,10 @@ describe('SimpleFeedback Component', () => {
     const { getAllByRole } = render(<SimpleFeedback title={title} />);
     const [yes] = getAllByRole('button');
 
-    const labels = `labels=feedback`;
-    const url = `${ISSUE_URL}${labels},feedback-positive&title=Feedback:+${title}`;
+    const params = new URLSearchParams();
+    params.set('labels', ['feedback', 'feedback-positive'].join(','));
+    params.set('title', `Feedback: ${title}`);
+    const url = `${ISSUE_URL}?${params.toString()}`;
 
     expect(yes.getAttribute('href')).toBe(url);
   });
@@ -80,12 +85,11 @@ describe('SimpleFeedback Component', () => {
     );
     const [yes] = getAllByRole('button');
 
-    const url = [
-      ISSUE_URL,
-      'labels=feedback,feedback-positive&title=Feedback:+',
-      title,
-      `&body=Page:%20[${title}](${SITE}${slug})`,
-    ].join('');
+    const params = new URLSearchParams();
+    params.set('labels', ['feedback', 'feedback-positive'].join(','));
+    params.set('title', `Feedback: ${title}`);
+    params.set('body', `Page: [${title}](${SITE}${slug})`);
+    const url = `${ISSUE_URL}?${params.toString()}`;
 
     expect(yes.getAttribute('href')).toBe(url);
   });

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -33,7 +33,7 @@ describe('SimpleFeedback Component', () => {
     expect(getByText('No')).toBeInTheDocument();
   });
 
-  it('should render with default custom labels', () => {
+  it('should render links with custom issue labels', () => {
     const labels = ['food-feedback', 'tuesday'];
     const { getAllByRole } = render(<SimpleFeedback labels={labels} />);
     const [yes] = getAllByRole('button');
@@ -48,7 +48,7 @@ describe('SimpleFeedback Component', () => {
     expect(yes.getAttribute('href')).toBe(url);
   });
 
-  it('should render links with default issue titles', () => {
+  it('should render links with default issue title', () => {
     const { getAllByRole } = render(<SimpleFeedback />);
     const [yes, no] = getAllByRole('button');
 
@@ -72,7 +72,7 @@ describe('SimpleFeedback Component', () => {
     expect(yes.getAttribute('href')).toBe(url);
   });
 
-  it('should render alinks with page URL in the issue body', () => {
+  it('should render links with page URL in the issue body', () => {
     const title = 'tacos';
     const slug = '/food';
     const { getAllByRole } = render(

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -6,9 +6,7 @@ import SimpleFeedback from '../SimpleFeedback';
 // https://github.com/facebook/jest/issues/2567
 const SITE = 'https://github.com/foo/bar';
 const REPO = 'https://foobar.net';
-
 const ISSUE_URL = `${REPO}/issues/new?`;
-const LABELS = `labels=content,feedback`;
 
 jest.mock('gatsby', () => ({
   __esModule: true,
@@ -35,13 +33,29 @@ describe('SimpleFeedback Component', () => {
     expect(getByText('No')).toBeInTheDocument();
   });
 
+  it('should render with default custom labels', () => {
+    const labels = ['food-feedback', 'tuesday'];
+    const { getAllByRole } = render(<SimpleFeedback labels={labels} />);
+    const [yes] = getAllByRole('button');
+
+    const url = [
+      ISSUE_URL,
+      'labels=',
+      labels.join(','),
+      ',feedback-positive&title=Website Feedback',
+    ].join('');
+
+    expect(yes.getAttribute('href')).toBe(url);
+  });
+
   it('should render links with default issue titles', () => {
     const { getAllByRole } = render(<SimpleFeedback />);
     const [yes, no] = getAllByRole('button');
 
     const title = 'Website Feedback';
-    const positiveUrl = `${ISSUE_URL}${LABELS},feedback-positive&title=${title}`;
-    const negativeUrl = `${ISSUE_URL}${LABELS},feedback-negative&title=${title}`;
+    const labels = `labels=feedback`;
+    const positiveUrl = `${ISSUE_URL}${labels},feedback-positive&title=${title}`;
+    const negativeUrl = `${ISSUE_URL}${labels},feedback-negative&title=${title}`;
 
     expect(yes.getAttribute('href')).toBe(positiveUrl);
     expect(no.getAttribute('href')).toBe(negativeUrl);
@@ -52,7 +66,8 @@ describe('SimpleFeedback Component', () => {
     const { getAllByRole } = render(<SimpleFeedback title={title} />);
     const [yes] = getAllByRole('button');
 
-    const url = `${ISSUE_URL}${LABELS},feedback-positive&title=Feedback:+${title}`;
+    const labels = `labels=feedback`;
+    const url = `${ISSUE_URL}${labels},feedback-positive&title=Feedback:+${title}`;
 
     expect(yes.getAttribute('href')).toBe(url);
   });
@@ -67,8 +82,7 @@ describe('SimpleFeedback Component', () => {
 
     const url = [
       ISSUE_URL,
-      LABELS,
-      ',feedback-positive&title=Feedback:+',
+      'labels=feedback,feedback-positive&title=Feedback:+',
       title,
       `&body=Page:%20[${title}](${SITE}${slug})`,
     ].join('');

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SimpleFeedback from '../SimpleFeedback';
+
+// Defining these here AND in the mock due to a limitation with jest
+// https://github.com/facebook/jest/issues/2567
+const SITE = 'https://github.com/foo/bar';
+const REPO = 'https://foobar.net';
+
+const ISSUE_URL = `${REPO}/issues/new?`;
+const LABELS = `labels=content,feedback`;
+
+jest.mock('gatsby', () => ({
+  __esModule: true,
+  graphql: () => {},
+  useStaticQuery: () => ({
+    site: {
+      siteMetadata: {
+        siteUrl: 'https://github.com/foo/bar',
+        repository: 'https://foobar.net',
+      },
+    },
+  }),
+}));
+
+describe('SimpleFeedback Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with two feedback buttons', () => {
+    const { getByText } = render(<SimpleFeedback />);
+
+    expect(getByText('Yes')).toBeInTheDocument();
+    expect(getByText('No')).toBeInTheDocument();
+  });
+
+  it('should render links with default issue titles', () => {
+    const { getAllByRole } = render(<SimpleFeedback />);
+    const [yes, no] = getAllByRole('button');
+
+    const title = 'Website Feedback';
+    const positiveUrl = `${ISSUE_URL}${LABELS},feedback-positive&title=${title}`;
+    const negativeUrl = `${ISSUE_URL}${LABELS},feedback-negative&title=${title}`;
+
+    expect(yes.getAttribute('href')).toBe(positiveUrl);
+    expect(no.getAttribute('href')).toBe(negativeUrl);
+  });
+
+  it('should render links with the page title in the issue title', () => {
+    const title = 'tacos';
+    const { getAllByRole } = render(<SimpleFeedback title={title} />);
+    const [yes] = getAllByRole('button');
+
+    const url = `${ISSUE_URL}${LABELS},feedback-positive&title=Feedback:+${title}`;
+
+    expect(yes.getAttribute('href')).toBe(url);
+  });
+
+  it('should render alinks with page URL in the issue body', () => {
+    const title = 'tacos';
+    const slug = '/food';
+    const { getAllByRole } = render(
+      <SimpleFeedback title={title} slug={slug} />
+    );
+    const [yes] = getAllByRole('button');
+
+    const url = [
+      ISSUE_URL,
+      LABELS,
+      ',feedback-positive&title=Feedback:+',
+      title,
+      `&body=Page:%20[${title}](${SITE}${slug})`,
+    ].join('');
+
+    expect(yes.getAttribute('href')).toBe(url);
+  });
+});


### PR DESCRIPTION
## Description
Adds the [`<SimpleFeedback />`](https://github.com/newrelic/docs-website/pull/412) component to the theme so that multiple sites can make use of it. Clicking one of the sentiment buttons will open up a new browser tab and take the user to the new issue screen. Depending on the props provided, different elements will be pre-filled and special labels are applied.

I also added some tests for this component, since there are a few different states the component can be in that are easily testable. I also wanted to provide us with an example of how to mock `useStaticQuery` and `graphql` from Gatsby.

## Screenshot(s)
![Screen Shot 2020-12-15 at 10 00 00 AM](https://user-images.githubusercontent.com/1946433/102271853-bffdc400-3ed4-11eb-929e-c6dd78f8de5b.png)