### PR TITLE
Add a fileRelativePath field to MarkdownRemark nodes

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -107,7 +107,7 @@ exports.onCreateBabelConfig = ({ actions }, themeOptions) => {
 };
 
 exports.onCreateNode = ({ node, actions }) => {
-  if (node.internal.type === 'Mdx') {
+  if (['Mdx', 'MarkdownRemark'].includes(node.internal.type)) {
     const { createNodeField } = actions;
 
     createNodeField({


### PR DESCRIPTION
## Description

When sourcing nodes, add a `fileRelativePath` to `MarkdownRemark` nodes in addition to `Mdx` nodes.
