### PR TITLE
Add the terminal component + code block improvements

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -14,6 +14,7 @@ import {
   Surface,
   Tag,
   TagList,
+  Terminal,
   Video,
   useLayout,
 } from '@newrelic/gatsby-theme-newrelic';
@@ -140,6 +141,19 @@ const IndexPage = () => {
           >
             {liveCodeSample}
           </CodeBlock>
+        </section>
+        <section>
+          <h2>Terminal</h2>
+          <Terminal>cd packages/gatsby-theme-newrelic</Terminal>
+
+          <h2>Animated terminal</h2>
+          <Terminal animate>
+            {`
+nr1 create --type nerdpack --name pageviews-app
+[output] {success}✔  {plain}Component created successfully!
+[output]    {purple}nerdpack {blue}pageviews-app {plain}is available at {green}"./pageviews-app"
+            `}
+          </Terminal>
         </section>
         <section>
           <h2>Buttons</h2>

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -449,20 +449,40 @@ import { CodeBlock } from '@newrelic/gatsby-theme-newrelic';
 
 **Props**
 
-| Prop               | Type    | Required | Default | Description                                                                                                                                                                                                                                                                |
-| ------------------ | ------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`         | string  | yes      |         | The code to be rendered in the code block                                                                                                                                                                                                                                  |
-| `className`        | string  | no       |         | Adds a `className` to the outer container of the code block. Useful if you need to position the code block within its parent element.                                                                                                                                      |
-| `components`       | object  | no       |         | Swap out the elements used when rendering various elements of the code block. See the "Configurable components" guide below to learn more about this prop.                                                                                                                 |
-| `copyable`         | boolean | no       | `true`  | Determines whether to render a copy button for the content inside the code block.                                                                                                                                                                                          |
-| `fileName`         | string  | no       |         | The file name associated with the code rendered by the code block. Useful if the code block is used as part of tutorial.                                                                                                                                                   |
-| `formatOptions`    | object  | no       |         | Configuration options given to the [`formatCode`](#formatcode) utility function to auto-format the code block.                                                                                                                                                             |
-| `highlightedLines` | string  | no       |         | Specifies which lines in the code block should be highlighted. See the examples below on for information on how to format this string.                                                                                                                                     |
-| `language`         | string  | no       |         | Configures the language used for syntax highlighting. Must match one of the languages or its aliases from [`prismjs`](https://prismjs.com/#supported-languages). To learn more about configuring supported languages, visit the [`prism` configuration section](#prism).   |
-| `lineNumbers`      | boolean | no       | `false` | Determines whether to show line numbers inside the code block.                                                                                                                                                                                                             |
-| `live`             | boolean | no       | `false` | Determines whether the code block is live-editable or not. Useful when used in conjunction with the `preview` option, though not required.                                                                                                                                 |
-| `preview`          | boolean | no       | `false` | Determines whether a live preview is displayed using the value in the code block. Useful in conjunction with the `live` option to allow the user to edit the code snippet.                                                                                                 |
-| `scope`            | object  | no       |         | Configures the variables available as globals for the live preview. By default, only `React` is injected. To find out more about how the `scope` prop works, visit the [`react-live` documentation](https://github.com/FormidableLabs/react-live#how-does-the-scope-work). |
+| Prop               | Type    | Required | Default  | Description                                                                                                                                                                                                                                                                |
+| ------------------ | ------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoFormat`       | boolean | no       | `true`\* | Determines whether to auto format the code using prettier. `true` will force code formatting to occur. `false` will force disable code formatting. If left empty, code formatting will only run on a subset of supported languages (see below)                             |
+| `children`         | string  | yes      |          | The code to be rendered in the code block                                                                                                                                                                                                                                  |
+| `className`        | string  | no       |          | Adds a `className` to the outer container of the code block. Useful if you need to position the code block within its parent element.                                                                                                                                      |
+| `components`       | object  | no       |          | Swap out the elements used when rendering various elements of the code block. See the "Configurable components" guide below to learn more about this prop.                                                                                                                 |
+| `copyable`         | boolean | no       | `true`   | Determines whether to render a copy button for the content inside the code block.                                                                                                                                                                                          |
+| `fileName`         | string  | no       |          | The file name associated with the code rendered by the code block. Useful if the code block is used as part of tutorial.                                                                                                                                                   |
+| `formatOptions`    | object  | no       |          | Configuration options given to the [`formatCode`](#formatcode) utility function to auto-format the code block.                                                                                                                                                             |
+| `highlightedLines` | string  | no       |          | Specifies which lines in the code block should be highlighted. See the examples below on for information on how to format this string.                                                                                                                                     |
+| `language`         | string  | no       |          | Configures the language used for syntax highlighting. Must match one of the languages or its aliases from [`prismjs`](https://prismjs.com/#supported-languages). To learn more about configuring supported languages, visit the [`prism` configuration section](#prism).   |
+| `lineNumbers`      | boolean | no       | `false`  | Determines whether to show line numbers inside the code block.                                                                                                                                                                                                             |
+| `live`             | boolean | no       | `false`  | Determines whether the code block is live-editable or not. Useful when used in conjunction with the `preview` option, though not required.                                                                                                                                 |
+| `preview`          | boolean | no       | `false`  | Determines whether a live preview is displayed using the value in the code block. Useful in conjunction with the `live` option to allow the user to edit the code snippet.                                                                                                 |
+| `scope`            | object  | no       |          | Configures the variables available as globals for the live preview. By default, only `React` is injected. To find out more about how the `scope` prop works, visit the [`react-live` documentation](https://github.com/FormidableLabs/react-live#how-does-the-scope-work). |
+
+**Auto code formatting**
+
+Out of the box, the `CodeBlock` component will use prettier to format code for a
+subset of languages. These include:
+
+- `jsx`/`javascript`
+- `html`
+- `graphql`
+- `json`
+- `css`/`sass`/`scss`
+
+To force formatting for another language, set the `autoFormat` prop value to
+`true`. To force disable code formatting, set the `autoFormat` prop value to
+`false`.
+
+**NOTE:** If you choose to force enable code formatting for a language not
+listed above, you may need to use the `formatOptions` prop to set the proper
+[`plugins`](https://prettier.io/docs/en/browser.html#plugins).
 
 **Configurable components**
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -2007,6 +2007,16 @@ Utility function that formats a string of code using
   when formatting the string of code. For a list of all available options, visit
   the [prettier documentation](https://prettier.io/docs/en/options.html).
 
+  - `options.language` _(string)_: Tells the function the language of the code
+    that will be formatted through prettier. This is used to detect a suitable
+    `parser` for the code. This is recommended if you are not setting the
+    `parser` option yourself. If no suitable parser is found for the current
+    language, or if the `language` option is not specified, this will fall back
+    to the `babel` parser. For more info on available
+    [plugins](https://prettier.io/docs/en/browser.html#plugins) and
+    [parsers](https://prettier.io/docs/en/options.html#parser), see the
+    [Prettier](https://prettier.io/) documentation.
+
   **Default:**
 
   ```js

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -1182,8 +1182,9 @@ depending on whether it is a relative or absolute URL.
 ### `MDXCodeBlock`
 
 Used to render a fenced code block using the [`CodeBlock`](#codeblock) component
-inside of an MDX document. This component works best in conjunction with the
-`MDXProvider` component exported from the `@mdx-js/react` package.
+or a [`Terminal`](#terminal) component inside of an MDX document. This component
+works best in conjunction with the `MDXProvider` component exported from the
+`@mdx-js/react` package.
 
 ```js
 import { MDXCodeBlock } from '@newrelic/gatsby-theme-newrelic';
@@ -1191,10 +1192,17 @@ import { MDXCodeBlock } from '@newrelic/gatsby-theme-newrelic';
 
 **Props**
 
-All props are forwarded to the `CodeBlock` component. This component also
-maintains the same defaults. See the "Using with fenced code blocks" section
-below to learn how options in fenced code blocks are forwarded to the
-`CodeBlock` component.
+All props are forwarded to the either the `CodeBlock` component, or the
+`Terminal` component (whichever is rendered based on the language. See below for
+more information). This component also maintains the same defaults. See the
+"Using with fenced code blocks" section below to learn how options in fenced
+code blocks are forwarded to the `CodeBlock` or `Terminal` component.
+
+**Terminals**
+
+This component will automatically render a [`Terminal`](#terminal) component
+whenver the language is specified as a shell language (`sh`, `shell`, or
+`bash`.) This is to provide a richer experience when rendering shell commands.
 
 **Usage with MDXProvider**
 
@@ -1229,10 +1237,22 @@ component. The following options are available for fenced code blocks when using
 this component.
 
 - `language`: Use a language identifier to enable syntax highlighting for the
-  fenced code block.
+  fenced code block. If this is a shell language (`sh`, `shell`, or `bash`), a
+  `Terminal` component is rendered instead.
 
 ````md
 ```js
+```
+````
+
+- `animate` (`Terminal` only): Determines whether to animate the shell
+  command and terminal output to make it appear as if the command is being
+  typed. _NOTE_: This is ignored if the `language` is not set to a shell
+  language.
+
+````md
+```sh animate
+
 ```
 ````
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -240,6 +240,8 @@ Default supported languages:
 - `ruby`
 - `shell`
 - `sql`
+- `sass`
+- `scss`
 
 **Example:** Add `swift` as a supported language
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -57,6 +57,7 @@ websites](https://opensource.newrelic.com).
   - [`Table`](#table)
   - [`Tag`](#tag)
   - [`TagList`](#taglist)
+  - [`Terminal`](#terminal)
   - [`Video`](#video)
 - [Hooks](#hooks)
   - [`useClipboard`](#useclipboard)
@@ -1608,6 +1609,114 @@ import { TagList } from '@newrelic/gatsby-theme-newrelic';
   <Tag>JavaScript</Tag>
   <Tag>Gatsby</Tag>
 </TagList>
+```
+
+### `Terminal`
+
+A nice alternative to the `CodeBlock` when rendering shell commands and terminal
+output.
+
+```js
+import { Terminal } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Props**
+
+| Prop       | Type    | Required | Default | Description                                                                                                                                                                                                        |
+| ---------- | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `animate`  | boolean | no       | `false` | Determines whether to animate the shell command to make it appear as if it is being typed. This will also animate any terminal output specified. Triggers when the user has scrolled 50% of the way down the page. |
+| `children` | string  | yes      |         | The code to be rendered in the code block. See below for examples on how to render terminal output.                                                                                                                |
+| `copyable` | boolean | no       | `true`  | Determines whether to render a copy button for the content inside the code block. NOTE: only shell commands will be copied. Terminal output will not be copied to the clipboard.                                   |
+
+**Terminal output**
+
+To render terminal output, prefix the line of code with the `[output]` marker
+(include a space after the closing bracket). This tells the `Terminal` to 1)
+avoid displaying the prompt for the current line and 2) avoid animating it with
+the typing animation. When animation is enabled, the terminal output will be
+rendered at various intervals of time to make it appear as if the command is
+doing some work.
+
+Terminal output can also be colored. By default it will render as plain text
+unless otherwise specified. To color a section of text, prefix the area of text
+with a color using curly brackets. For example, if you wanted to render some
+text as `blue`, prefix it with `{blue}`. The color of the text will extend unil
+the next color marker. You can "reset" the color back to plain text using the
+`{plain}` marker.
+
+For example, lets say you have this bit of terminal output that you'd like to
+display as colored:
+
+```
+✔  Component created successfully!
+```
+
+For this example, lets say only the checkmark should be green, while the rest of
+the text remain plain. To accomplish this, first specify this line as output
+(`[output]`), and add the color markers:
+
+```
+[output] {green}✔  {plain}Component created successfully!
+```
+
+Here is a more complex example:
+
+```
+[output]    {purple}nerdpack {blue}pageviews-app {plain}is available at {green}"./pageviews-app"
+```
+
+Here the output will render the text "nerdpack" as `purple`, then the app
+identifier as `blue` ("pageviews-app"), reset the text back to plain, and
+finally the string as `green`. Also notice how the text is indented after the
+`[output]` marker. This will render in the terminal as indented text.
+
+Here is a full list of the colors available:
+
+- `plain`
+- `green`
+- `red`
+- `muted`
+- `purple`
+- `blue`
+- `yellow`
+
+For your convenience, color aliases have been provided to give you some more
+semantically meaningful names, and provide better color consistency between
+meaningful blocks of text. The following color aliases are available:
+
+- `error` (`red`)
+- `identifier` (`blue`)
+- `string` (`green`)
+- `success` (`green`)
+- `timestamp` (`muted`)
+- `variable` (`variable`)
+- `warning` (`yellow`)
+
+```
+[output] {timestamp}2020-01-01 12:00:00 {success}✔ {purple}nerdpack {identifier}pageviews-app {plain} is available at {string}"./pageviews-app"
+```
+
+**Example**
+
+```js
+const shellCommand = `
+cd my-nerdlet
+nr1 nerdpack:serve
+`;
+
+const Example = () => <Terminal animate>{shellCommand}</Terminal>;
+```
+
+With terminal output
+
+```js
+const shellCommand = `
+nr1 create --type nerdpack --name pageviews-app
+[output] {success}✔  {plain}Component created successfully!
+[output]    {purple}nerdpack {blue}pageviews-app {plain}is available at {green}"./pageviews-app"
+`;
+
+const Example = () => <Terminal>{shellCommand}</Terminal>;
 ```
 
 ### `Video`

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -100,6 +100,7 @@ exports.onCreateBabelConfig = ({ actions }, themeOptions) => {
         'shell',
         'sql',
         'graphql',
+        'sass',
         ...(prism.languages || []),
       ]),
     },

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -101,6 +101,7 @@ exports.onCreateBabelConfig = ({ actions }, themeOptions) => {
         'sql',
         'graphql',
         'sass',
+        'scss',
         ...(prism.languages || []),
       ]),
     },

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -27,6 +27,7 @@ export { default as Spinner } from './src/components/Spinner';
 export { default as Table } from './src/components/Table';
 export { default as Tag } from './src/components/Tag';
 export { default as TagList } from './src/components/TagList';
+export { default as Terminal } from './src/components/Terminal';
 export { default as Video } from './src/components/Video';
 
 export { default as formatCode } from './src/utils/formatCode';

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -50,6 +50,7 @@
     "@elastic/react-search-ui-views": "^1.4.1",
     "@elastic/search-ui-site-search-connector": "^1.4.1",
     "@wry/equality": "^0.3.0",
+    "@xstate/react": "^1.1.0",
     "babel-plugin-prismjs": "^2.0.1",
     "date-fns": "^2.16.1",
     "gatsby-plugin-emotion": "^4.3.10",
@@ -71,9 +72,12 @@
     "react-middle-ellipsis": "^1.1.0",
     "react-simple-code-editor": "^0.11.0",
     "react-spring": "^8.0.27",
+    "react-typist": "^2.0.5",
+    "react-use": "^15.3.4",
     "use-dark-mode": "^2.3.1",
     "use-media": "^1.4.0",
     "use-persisted-state": "^0.3.0",
-    "warning": "^4.0.3"
+    "warning": "^4.0.3",
+    "xstate": "^4.15.1"
   }
 }

--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -15,6 +15,7 @@ const defaultComponents = {
 };
 
 const CodeBlock = ({
+  autoFormat,
   children,
   className,
   components: componentOverrides = {},
@@ -29,7 +30,10 @@ const CodeBlock = ({
   scope,
 }) => {
   const components = { ...defaultComponents, ...componentOverrides };
-  const formattedCode = useFormattedCode(children, formatOptions);
+  const formattedCode = useFormattedCode(children, {
+    ...formatOptions,
+    disable: !autoFormat,
+  });
   const [copied, copy] = useClipboard();
   const [code, setCode] = useState(formattedCode);
 
@@ -163,6 +167,7 @@ const CodeBlock = ({
 };
 
 CodeBlock.propTypes = {
+  autoFormat: PropTypes.bool,
   fileName: PropTypes.string,
   children: PropTypes.string.isRequired,
   className: PropTypes.string,
@@ -180,6 +185,7 @@ CodeBlock.propTypes = {
 };
 
 CodeBlock.defaultProps = {
+  autoFormat: true,
   copyable: true,
   lineNumbers: false,
   live: false,

--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -10,6 +10,16 @@ import MiddleEllipsis from 'react-middle-ellipsis';
 import useClipboard from '../hooks/useClipboard';
 import useFormattedCode from '../hooks/useFormattedCode';
 
+const AUTO_FORMATTED_LANGUAGES = [
+  'jsx',
+  'html',
+  'graphql',
+  'json',
+  'css',
+  'sass',
+  'scss',
+];
+
 const defaultComponents = {
   Preview: LivePreview,
 };
@@ -36,7 +46,10 @@ const CodeBlock = ({
   const components = { ...defaultComponents, ...componentOverrides };
   const formattedCode = useFormattedCode(children, {
     ...formatOptions,
-    disable: !autoFormat,
+    disable:
+      autoFormat == null
+        ? !AUTO_FORMATTED_LANGUAGES.includes(language)
+        : !autoFormat,
   });
   const [copied, copy] = useClipboard();
   const [code, setCode] = useState(formattedCode);
@@ -189,7 +202,6 @@ CodeBlock.propTypes = {
 };
 
 CodeBlock.defaultProps = {
-  autoFormat: true,
   copyable: true,
   lineNumbers: false,
   live: false,

--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -46,6 +46,7 @@ const CodeBlock = ({
   const components = { ...defaultComponents, ...componentOverrides };
   const formattedCode = useFormattedCode(children, {
     ...formatOptions,
+    language,
     disable:
       autoFormat == null
         ? !AUTO_FORMATTED_LANGUAGES.includes(language)

--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -29,6 +29,10 @@ const CodeBlock = ({
   preview,
   scope,
 }) => {
+  if (isJSLang()) {
+    language = 'jsx';
+  }
+
   const components = { ...defaultComponents, ...componentOverrides };
   const formattedCode = useFormattedCode(children, {
     ...formatOptions,
@@ -191,5 +195,7 @@ CodeBlock.defaultProps = {
   live: false,
   preview: false,
 };
+
+const isJSLang = (language) => ['js', 'javascript'].includes(language);
 
 export default CodeBlock;

--- a/packages/gatsby-theme-newrelic/src/components/MDXCodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/MDXCodeBlock.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CodeBlock from './CodeBlock';
+import Terminal from './Terminal';
+import { isShellLanguage } from '../utils/codeBlock';
 
 const MDXCodeBlock = ({
+  animate,
   children,
   className,
   copyable,
@@ -11,21 +14,30 @@ const MDXCodeBlock = ({
   lineHighlight,
   preview,
   ...props
-}) => (
-  <CodeBlock
-    {...props}
-    copyable={copyable !== 'false'}
-    highlightedLines={lineHighlight}
-    language={className?.replace('language-', '')}
-    lineNumbers={lineNumbers === 'true'}
-    live={live === 'true'}
-    preview={preview === 'true'}
-  >
-    {children}
-  </CodeBlock>
-);
+}) => {
+  const language = className?.replace('language-', '');
+
+  return isShellLanguage ? (
+    <Terminal animate={animate} copyable={copyable}>
+      {children}
+    </Terminal>
+  ) : (
+    <CodeBlock
+      {...props}
+      copyable={copyable !== 'false'}
+      highlightedLines={lineHighlight}
+      language={language}
+      lineNumbers={lineNumbers === 'true'}
+      live={live === 'true'}
+      preview={preview === 'true'}
+    >
+      {children}
+    </CodeBlock>
+  );
+};
 
 MDXCodeBlock.propTypes = {
+  animate: PropTypes.bool,
   children: PropTypes.string,
   className: PropTypes.string,
   copyable: PropTypes.oneOf(['true', 'false']),

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/CommandLine.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/CommandLine.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css, keyframes } from '@emotion/core';
+import Prompt from './Prompt';
+import Typist from 'react-typist';
+
+const blink = keyframes`
+  0%, 49% {
+    background: #c0c5ce;
+  }
+
+  50%, 100% {
+    background: none;
+  }
+`;
+
+const CommandLine = ({
+  animate,
+  avgTypingDelay,
+  cursor,
+  children,
+  prompt,
+  typingDelay,
+  onFinishedTyping,
+}) => {
+  const element = animate ? (
+    <Typist
+      startDelay={typingDelay}
+      avgTypingDelay={avgTypingDelay}
+      cursor={{ show: false }}
+      onTypingDone={onFinishedTyping}
+      css={css`
+        &:empty {
+          display: inline-block;
+        }
+      `}
+    >
+      {children}
+    </Typist>
+  ) : (
+    children
+  );
+
+  return (
+    <div
+      css={css`
+        display: grid;
+        grid-template-columns: 1ch auto;
+        grid-gap: 1ch;
+        justify-content: start;
+        align-items: baseline;
+      `}
+    >
+      <Prompt character={prompt} />
+      <div
+        css={css`
+          position: relative;
+          color: #fafafa;
+          white-space: pre;
+
+          &:empty {
+            height: 100%;
+          }
+
+          ${cursor &&
+          css`
+            &:after {
+              content: '';
+              display: block;
+              width: 1ch;
+              height: 1.25em;
+              animation: ${blink} 1.25s infinite;
+              position: absolute;
+              top: 1px;
+              right: -1ch;
+            }
+          `};
+        `}
+      >
+        {element}
+      </div>
+    </div>
+  );
+};
+
+CommandLine.propTypes = {
+  animate: PropTypes.bool,
+  avgTypingDelay: PropTypes.number,
+  children: PropTypes.node,
+  cursor: PropTypes.bool,
+  prompt: PropTypes.oneOf(['$', '>']),
+  typingDelay: PropTypes.number,
+  onFinishedTyping: PropTypes.func,
+};
+
+CommandLine.defaultProps = {
+  animate: false,
+  avgTypingDelay: 40,
+  typingDelay: 0,
+};
+
+export default CommandLine;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/MenuBar.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/MenuBar.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { Button, Icon } from '@newrelic/gatsby-theme-newrelic';
+
+const MenuBar = ({ copyable, copied, onCopy }) => (
+  <div
+    css={css`
+      background: var(--chrome-color);
+      display: grid;
+      grid-template-columns: repeat(3, auto) 1fr 90px;
+      grid-gap: 0.5rem;
+      align-items: center;
+      padding: 0 1rem;
+      border-top-left-radius: var(--border-radius);
+      border-top-right-radius: var(--border-radius);
+      height: 38px;
+    `}
+  >
+    <FrameButton color="#ed6b60" />
+    <FrameButton color="#f5be4f" />
+    <FrameButton color="#62c554" />
+    <div
+      css={css`
+        color: #ccc;
+        text-align: center;
+        font-family: var(--code-font);
+        font-size: 0.75rem;
+      `}
+    >
+      bash
+    </div>
+    {copyable && (
+      <Button
+        variant={Button.VARIANT.LINK}
+        size={Button.SIZE.SMALL}
+        onClick={onCopy}
+        className="dark-mode"
+        css={css`
+          justify-self: end;
+          white-space: nowrap;
+        `}
+      >
+        <Icon
+          name={Icon.TYPE.COPY}
+          css={css`
+            margin-right: 0.5rem;
+          `}
+        />
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    )}
+  </div>
+);
+
+MenuBar.propTypes = {
+  copied: PropTypes.bool,
+  copyable: PropTypes.bool,
+  onCopy: PropTypes.func,
+};
+
+const FrameButton = ({ color }) => (
+  <div
+    css={css`
+      background: ${color};
+      border-radius: 50%;
+      width: 10px;
+      height: 10px;
+    `}
+  />
+);
+
+FrameButton.propTypes = {
+  color: PropTypes.string,
+};
+
+export default MenuBar;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/Prompt.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/Prompt.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const Prompt = ({ character }) => (
+  <span
+    css={css`
+      color: var(--color-nord-10);
+      user-select: none;
+    `}
+  >
+    {character || ' '}
+  </span>
+);
+
+Prompt.propTypes = {
+  character: PropTypes.string,
+};
+
+export default Prompt;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/Shell.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/Shell.js
@@ -1,0 +1,186 @@
+import React, { useEffect, useState, useRef, useLayoutEffect } from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import CommandLine from './CommandLine';
+import ShellOutput from './ShellOutput';
+import theme from './theme';
+import translateLines from './utils/translateLines';
+import { useMachine } from '@xstate/react';
+import machine from './machine';
+import gaussianRound from './gaussianRound';
+import MenuBar from './MenuBar';
+import { useIntersection } from 'react-use';
+import { useClipboard } from '@newrelic/gatsby-theme-newrelic';
+
+const Shell = ({ animate, copyable, highlight, code }) => {
+  const { tokens, getTokenProps } = highlight;
+  const lines = translateLines(tokens, code);
+
+  const [height, setHeight] = useState(null);
+  const ref = useRef();
+  const shellRef = useRef();
+  const [state, send] = useMachine(machine, {
+    context: { lines },
+  });
+
+  const [copied, copy] = useClipboard();
+
+  const intersection = useIntersection(ref, {
+    root: null,
+    rootMargin: '0px 0px -50% 0px',
+  });
+
+  useEffect(() => {
+    if (animate && intersection?.isIntersecting) {
+      send('BEGIN_TYPING');
+    }
+  }, [animate, intersection, send]);
+
+  useLayoutEffect(() => {
+    const { height } = shellRef.current.getBoundingClientRect();
+    setHeight(height);
+
+    if (animate) {
+      send('INIT');
+    }
+  }, [animate, send]);
+
+  const { lineNumber, renderedLines } = state.context;
+
+  return (
+    <div
+      ref={ref}
+      css={css`
+        --chrome-color: #252526;
+        --border-radius: 0.25rem;
+
+        background: #1e1e1e;
+        border-radius: var(--border-radius);
+      `}
+    >
+      <MenuBar
+        copyable={copyable}
+        copied={copied}
+        onCopy={() => copy(getCopyOutput(lines))}
+      />
+      <pre
+        ref={shellRef}
+        css={css`
+          ${theme};
+
+          padding: 1rem;
+          height: ${height}px;
+          font-family: var(--code-font);
+          font-size: 0.75rem;
+          border-bottom-left-radius: var(--border-radius);
+          border-bottom-right-radius: var(--border-radius);
+          color: var(--color-nord-6);
+          display: block;
+          overflow: auto;
+          white-space: pre;
+          word-spacing: normal;
+          word-break: normal;
+          tab-size: 2;
+          hyphens: none;
+          text-shadow: none;
+
+          > code {
+            background: none;
+            padding: 0;
+            width: 100%;
+          }
+
+          .token-line {
+            display: grid;
+            grid-template-columns: 1ch 1fr;
+            grid-gap: 1rem;
+          }
+        `}
+      >
+        <code>
+          {state.matches('idle') && <CommandLine cursor prompt="$" />}
+          {renderedLines.map(({ type, line }, idx) => {
+            const previousLine = renderedLines[idx - 1];
+
+            return type === 'OUTPUT' ? (
+              <ShellOutput key={idx} line={line} />
+            ) : (
+              <CommandLine
+                key={idx}
+                cursor={state.matches('typing') && idx === lineNumber}
+                animate={!state.matches('boot')}
+                prompt={
+                  type === 'MULTILINE_COMMAND' &&
+                  previousLine?.type === 'MULTILINE_COMMAND'
+                    ? '>'
+                    : '$'
+                }
+                typingDelay={getTypingDelay(line, previousLine)}
+                onFinishedTyping={() => send('PRESS_ENTER')}
+              >
+                {line.map((token, key) => (
+                  // eslint-disable-next-line react/jsx-key
+                  <span
+                    css={css`
+                      display: inline-block;
+                      vertical-align: baseline;
+                    `}
+                    {...getTokenProps({ token, key })}
+                  />
+                ))}
+              </CommandLine>
+            );
+          })}
+        </code>
+      </pre>
+    </div>
+  );
+};
+
+const getCopyOutput = (lines) => {
+  return lines
+    .filter(({ type }) => ['COMMAND', 'MULTILINE_COMMAND'].includes(type))
+    .map(({ line }) =>
+      line
+        .filter((token) => !token.types.includes('comment'))
+        .map((token) => token.content)
+        .join('')
+        .trimEnd()
+    )
+    .filter(Boolean)
+    .join('\n');
+};
+
+const getTypingDelay = (line, previousLine) => {
+  // Delay the first line more than every other line to allow time for the user
+  // to adjust to the animation after scrolling the terminal into view
+  if (!previousLine) {
+    return 1500;
+  }
+
+  // Allow commands immediately following output space to breathe so that the
+  // user has time to ingest the output before the typing animation begins again
+  if (previousLine.type === 'OUTPUT') {
+    return Math.max(800, gaussianRound(1000, 50));
+  }
+
+  // If we are starting a new command after typing a previous command, delay
+  // the typing just a bit, unless we are continuing a multiline command
+  if (line.type === 'COMMAND' || previousLine.type !== 'MULTILINE_COMMAND') {
+    return Math.max(250, gaussianRound(250, 25));
+  }
+
+  return 0;
+};
+
+Shell.propTypes = {
+  animate: PropTypes.bool,
+  code: PropTypes.string.isRequired,
+  copyable: PropTypes.bool,
+  highlight: PropTypes.shape({
+    tokens: PropTypes.array.isRequired,
+    getTokenProps: PropTypes.func.isRequired,
+  }),
+};
+
+export default Shell;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/ShellOutput.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/ShellOutput.js
@@ -55,10 +55,13 @@ const OUTPUT_COLORS = {
   yellow: 'var(--color-nord-13)',
 };
 
+OUTPUT_COLORS.error = OUTPUT_COLORS.red;
+OUTPUT_COLORS.identifier = OUTPUT_COLORS.blue;
+OUTPUT_COLORS.string = OUTPUT_COLORS.green;
+OUTPUT_COLORS.success = OUTPUT_COLORS.green;
 OUTPUT_COLORS.timestamp = OUTPUT_COLORS.muted;
 OUTPUT_COLORS.variable = OUTPUT_COLORS.purple;
-OUTPUT_COLORS.success = OUTPUT_COLORS.green;
-OUTPUT_COLORS.error = OUTPUT_COLORS.red;
+OUTPUT_COLORS.warning = OUTPUT_COLORS.yellow;
 
 ShellOutput.propTypes = {
   line: PropTypes.string.isRequired,

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/ShellOutput.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/ShellOutput.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+
+const TOKENS = /{([a-z]+)}(.*?(?={|$))/g;
+
+const ShellOutput = ({ line }) => (
+  <div
+    css={css`
+      color: #fafafa;
+      white-space: pre;
+    `}
+  >
+    {tokenize(line).map((token, key) => (
+      <span
+        key={key}
+        css={css`
+          color: ${OUTPUT_COLORS[token.color] || OUTPUT_COLORS.plain};
+
+          &:empty {
+            display: inline-block;
+          }
+        `}
+      >
+        {token.text}
+      </span>
+    ))}
+  </div>
+);
+
+const tokenize = (text) => {
+  const tokens = Array.from(text.matchAll(TOKENS));
+
+  if (tokens.length === 0) {
+    return [{ color: 'plain', text }];
+  }
+
+  const startOfColorIdx = text.indexOf('{');
+  const coloredTokens = tokens.map(([, color, text]) => ({ color, text }));
+
+  return startOfColorIdx === 0
+    ? coloredTokens
+    : [{ color: 'plain', text: text.slice(0, startOfColorIdx) }].concat(
+        coloredTokens
+      );
+};
+
+const OUTPUT_COLORS = {
+  plain: 'currentColor',
+  green: 'var(--color-nord-14)',
+  red: 'var(--color-nord-11)',
+  muted: 'var(--color-nord-3)',
+  purple: 'var(--color-nord-15)',
+  blue: 'var(--color-nord-9)',
+  yellow: 'var(--color-nord-13)',
+};
+
+OUTPUT_COLORS.timestamp = OUTPUT_COLORS.muted;
+OUTPUT_COLORS.variable = OUTPUT_COLORS.purple;
+OUTPUT_COLORS.success = OUTPUT_COLORS.green;
+OUTPUT_COLORS.error = OUTPUT_COLORS.red;
+
+ShellOutput.propTypes = {
+  line: PropTypes.string.isRequired,
+};
+
+export default ShellOutput;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/Terminal.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/Terminal.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Highlight from 'prism-react-renderer';
+import Prism from 'prismjs';
+import Shell from './Shell';
+
+const Terminal = ({ children, ...props }) => {
+  const code = children.trim();
+
+  return (
+    <Highlight Prism={Prism} code={code} language="shell">
+      {(highlight) => <Shell {...props} code={code} highlight={highlight} />}
+    </Highlight>
+  );
+};
+
+Terminal.propTypes = {
+  animate: PropTypes.bool,
+  copyable: PropTypes.bool,
+  children: PropTypes.string,
+};
+
+Terminal.defaultProps = {
+  animate: false,
+  copyable: true,
+};
+
+export default Terminal;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/gaussianRound.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/gaussianRound.js
@@ -1,0 +1,14 @@
+// https://github.com/jstejada/react-typist/blob/d067d1a0a357ac221ddb83efe4e0d9719a39c672/src/utils.js#L9-L17
+const gaussianRound = (mean, std) => {
+  const times = 12;
+  let sum = 0;
+
+  for (let idx = 0; idx < times; idx++) {
+    sum += Math.random();
+  }
+
+  sum -= times / 2;
+  return Math.round(sum * std) + mean;
+};
+
+export default gaussianRound;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/index.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/index.js
@@ -1,0 +1,1 @@
+export { default } from './Terminal';

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/machine.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/machine.js
@@ -1,0 +1,101 @@
+import { assign, spawn, Machine } from 'xstate';
+import gaussianRound from './gaussianRound';
+
+const ONLY_WHITESPACE = /^\s*$/;
+
+const machine = Machine(
+  {
+    id: 'terminal',
+    initial: 'boot',
+    context: {
+      renderedLines: [],
+      lineNumber: 0,
+    },
+    states: {
+      boot: {
+        entry: assign({ renderedLines: ({ lines }) => lines }),
+        on: {
+          INIT: 'idle',
+        },
+      },
+      idle: {
+        entry: assign({ renderedLines: [] }),
+        on: {
+          BEGIN_TYPING: {
+            target: 'typing',
+            actions: assign({
+              renderedLines: ({ lines }) => lines.slice(0, 1),
+            }),
+          },
+        },
+      },
+      typing: {
+        on: {
+          PRESS_ENTER: [
+            { target: 'waiting', cond: 'awaitsOutput' },
+            { actions: 'nextLine', cond: 'isMultilineCommand' },
+            { actions: 'nextLine', cond: 'hasNextCommand' },
+            { target: 'done' },
+          ],
+        },
+      },
+      waiting: {
+        entry: assign({
+          ref: ({ lines, lineNumber }, event) => {
+            return spawn((send) => {
+              if (ONLY_WHITESPACE.test(lines[lineNumber].line)) {
+                return send('ECHO');
+              }
+
+              const id = setTimeout(
+                () => {
+                  send('ECHO');
+                },
+                event.type === 'PRESS_ENTER'
+                  ? 1000
+                  : Math.max(30, gaussianRound(90, 40))
+              );
+
+              return () => clearTimeout(id);
+            });
+          },
+        }),
+        on: {
+          ECHO: [
+            { target: 'waiting', actions: 'nextLine', cond: 'awaitsOutput' },
+            { target: 'typing', actions: 'nextLine', cond: 'hasNextCommand' },
+            { target: 'done' },
+          ],
+        },
+      },
+      done: {
+        type: 'final',
+      },
+    },
+  },
+  {
+    actions: {
+      nextLine: assign({
+        lineNumber: (context) => context.lineNumber + 1,
+        renderedLines: ({ renderedLines, lines, lineNumber }) => [
+          ...renderedLines,
+          lines[lineNumber + 1],
+        ],
+      }),
+    },
+    guards: {
+      awaitsOutput: ({ lines, lineNumber }) =>
+        lines[lineNumber + 1]?.type === 'OUTPUT',
+
+      isMultilineCommand: ({ lines, lineNumber }) =>
+        lines[lineNumber].type === 'MULTILINE_COMMAND',
+
+      isDone: ({ lines, lineNumber }) => lineNumber === lines.length - 1,
+
+      hasNextCommand: ({ lines, lineNumber }) =>
+        lines[lineNumber + 1]?.type === 'COMMAND',
+    },
+  }
+);
+
+export default machine;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/theme.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/theme.js
@@ -1,0 +1,29 @@
+import { css } from '@emotion/core';
+
+export default css`
+  .namespace {
+    opacity: 0.7;
+  }
+  .token {
+    &.plain:empty {
+      display: inline-block;
+    }
+
+    &.comment {
+      color: var(--color-nord-3);
+    }
+
+    &.punctuation,
+    &.operator {
+      color: var(--color-nord-9);
+    }
+
+    &.constant {
+      color: var(--color-nord-15);
+    }
+
+    &.string {
+      color: var(--color-nord-14);
+    }
+  }
+`;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/utils/collapseLine.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/utils/collapseLine.js
@@ -1,0 +1,8 @@
+const collapseLine = (line) => {
+  return line
+    .filter((token) => !token.types.includes('comment'))
+    .map((token) => token.content)
+    .join('');
+};
+
+export default collapseLine;

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/utils/translateLines.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/utils/translateLines.js
@@ -1,0 +1,28 @@
+import collapseLine from './collapseLine';
+
+const MULTILINE_COMMAND = /\\\s*$/;
+const OUTPUT_TAG = /^\[output\](\s|$)/;
+
+const translateLines = (lines, code) => {
+  const rawLines = code.split('\n');
+
+  return lines.map((line, idx) => {
+    const command = collapseLine(line);
+
+    return OUTPUT_TAG.test(command)
+      ? {
+          type: 'OUTPUT',
+          line: rawLines[idx].replace(OUTPUT_TAG, ''),
+        }
+      : {
+          type:
+            MULTILINE_COMMAND.test(command) ||
+            MULTILINE_COMMAND.test(collapseLine(lines[idx - 1] || []))
+              ? 'MULTILINE_COMMAND'
+              : 'COMMAND',
+          line,
+        };
+  });
+};
+
+export default translateLines;

--- a/packages/gatsby-theme-newrelic/src/hooks/useFormattedCode.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useFormattedCode.js
@@ -4,7 +4,7 @@ import formatCode from '../utils/formatCode';
 const useFormattedCode = (code, options) => {
   return useDeepMemo(() => {
     try {
-      return formatCode(code, options).trim();
+      return options.disable ? code.trim() : formatCode(code, options).trim();
     } catch (e) {
       return code.trim();
     }

--- a/packages/gatsby-theme-newrelic/src/utils/codeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/utils/codeBlock.js
@@ -1,0 +1,3 @@
+const SHELL_LANGUAGES = ['sh', 'bash', 'shell'];
+
+export const isShellLanguage = (language) => SHELL_LANGUAGES.includes(language);

--- a/packages/gatsby-theme-newrelic/src/utils/formatCode.js
+++ b/packages/gatsby-theme-newrelic/src/utils/formatCode.js
@@ -4,7 +4,16 @@ import parserGraphQL from 'prettier/parser-graphql';
 import parserPostCSS from 'prettier/parser-postcss';
 import parserHTML from 'prettier/parser-html';
 
-const formatCode = (code, formatOptions = {}) =>
+const PARSERS = {
+  graphql: 'graphql',
+  css: 'css',
+  scss: 'scss',
+  sass: 'scss',
+  json: 'json',
+  html: 'html',
+};
+
+const formatCode = (code, { language, ...formatOptions } = {}) =>
   prettier.format(code, {
     trailingComma: 'es5',
     printWidth: 80,
@@ -12,7 +21,7 @@ const formatCode = (code, formatOptions = {}) =>
     semi: true,
     singleQuote: true,
     plugins: [parserBabel, parserGraphQL, parserPostCSS, parserHTML],
-    parser: 'babel',
+    parser: PARSERS[language] || 'babel',
     ...formatOptions,
   });
 

--- a/packages/gatsby-theme-newrelic/src/utils/formatCode.js
+++ b/packages/gatsby-theme-newrelic/src/utils/formatCode.js
@@ -1,5 +1,8 @@
 import prettier from 'prettier/standalone';
 import parserBabel from 'prettier/parser-babel';
+import parserGraphQL from 'prettier/parser-graphql';
+import parserPostCSS from 'prettier/parser-postcss';
+import parserHTML from 'prettier/parser-html';
 
 const formatCode = (code, formatOptions = {}) =>
   prettier.format(code, {
@@ -8,7 +11,7 @@ const formatCode = (code, formatOptions = {}) =>
     tabWidth: 2,
     semi: true,
     singleQuote: true,
-    plugins: [parserBabel],
+    plugins: [parserBabel, parserGraphQL, parserPostCSS, parserHTML],
     parser: 'babel',
     ...formatOptions,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,6 +3503,11 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.14.tgz#37daaf78069e7948520474c87b80092ea912520a"
   integrity sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==
 
+"@types/js-cookie@2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -3916,6 +3921,19 @@
   integrity sha512-DRDAu/e3oWBj826OWNV/GCmSdHD248mASXImgNoLE/3SDvpgb+k6G/+TAmdpIB35ju264+kB22Rx92eXg52DnA==
   dependencies:
     tslib "^1.9.3"
+
+"@xobotyi/scrollbar-width@1.9.5":
+  version "1.9.5"
+  resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
+  integrity sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==
+
+"@xstate/react@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.1.0.tgz#f8e869d77c682cdd4fdeb30bd7269ba414334856"
+  integrity sha512-ac5xAOFZ1AGsem0Y6uXG+zXWKXFDnZeJLBaXnJ84ReFHCWCCwF19JdtJgfu1t4I1r3jTnJR9W6eZKELVfvriqw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.0.0"
+    use-subscription "^1.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -4972,6 +4990,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+bowser@^1.7.3:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
+  integrity sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ==
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -6244,6 +6267,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 copyfiles@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.3.0.tgz#1c26ebbe3d46bba2d309a3fd8e3aaccf53af8c76"
@@ -6449,6 +6479,14 @@ css-declaration-sorter@^4.0.1:
     postcss "^7.0.1"
     timsort "^0.3.0"
 
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  integrity sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
+
 css-loader@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-1.0.1.tgz#6885bb5233b35ec47b006057da01cc640b6b79fe"
@@ -6514,6 +6552,14 @@ css-tree@1.0.0-alpha.39:
   integrity sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==
   dependencies:
     mdn-data "2.0.6"
+    source-map "^0.6.1"
+
+css-tree@^1.0.0-alpha.28:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
+  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
+  dependencies:
+    mdn-data "2.0.14"
     source-map "^0.6.1"
 
 css-what@2.1:
@@ -6656,6 +6702,11 @@ csstype@^2.2.0, csstype@^2.5.2, csstype@^2.5.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+
+csstype@^2.5.5:
+  version "2.6.14"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.14.tgz#004822a4050345b55ad4dcc00be1d9cf2f4296de"
+  integrity sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -8376,7 +8427,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -8420,10 +8471,20 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-shallow-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
+  integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
+
+fastest-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz#9122d406d4c9d98bea644a6b6853d5874b87b028"
+  integrity sha1-kSLUBtTJ2YvqZEpraFPVh0uHsCg=
 
 fastparse@^1.1.2:
   version "1.1.2"
@@ -10416,6 +10477,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -10651,6 +10717,14 @@ inline-style-parser@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
+
+inline-style-prefixer@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz#d390957d26f281255fe101da863158ac6eb60911"
+  integrity sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==
+  dependencies:
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@3.3.0:
   version "3.3.0"
@@ -12760,6 +12834,11 @@ mdast-util-toc@^3.1.0:
     unist-util-is "^2.1.2"
     unist-util-visit "^1.1.0"
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 mdn-data@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
@@ -13237,6 +13316,20 @@ nan@^2.12.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
+nano-css@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.3.0.tgz#9d3cd29788d48b6a07f52aa4aec7cf4da427b6b5"
+  integrity sha512-uM/9NGK9/E9/sTpbIZ/bQ9xOLOIHZwrrb/CRlbDHBU/GFS7Gshl24v/WJhwsVViWkpOXUmiZ66XO7fSB4Wd92Q==
+  dependencies:
+    css-tree "^1.0.0-alpha.28"
+    csstype "^2.5.5"
+    fastest-stable-stringify "^1.0.1"
+    inline-style-prefixer "^4.0.0"
+    rtl-css-js "^1.9.0"
+    sourcemap-codec "^1.4.1"
+    stacktrace-js "^2.0.0"
+    stylis "3.5.0"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -15096,7 +15189,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -15532,6 +15625,38 @@ react-transition-group@^2.2.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-typist@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-typist/-/react-typist-2.0.5.tgz#9830395a73a03e6368e1392ecb98edaa3a648e44"
+  integrity sha512-iZCkeqeegO0TlkTMiH2JD1tvMtY9RrXkRylnAI6m8aCVAUUwNzoWTVF7CKLij6THeOMcUDCznLDDvNp55s+YZA==
+  dependencies:
+    prop-types "^15.5.10"
+
+react-universal-interface@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
+  integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
+
+react-use@^15.3.4:
+  version "15.3.4"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-15.3.4.tgz#f853d310bd71f75b38900a8caa3db93f6dc6e872"
+  integrity sha512-cHq1dELW6122oi1+xX7lwNyE/ugZs5L902BuO8eFJCfn2api1KeuPVG1M/GJouVARoUf54S2dYFMKo5nQXdTag==
+  dependencies:
+    "@types/js-cookie" "2.2.6"
+    "@xobotyi/scrollbar-width" "1.9.5"
+    copy-to-clipboard "^3.2.0"
+    fast-deep-equal "^3.1.3"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.2.1"
+    react-universal-interface "^0.6.2"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.0.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^2.1.0"
+    ts-easing "^0.2.0"
+    tslib "^2.0.0"
 
 react@^16.13.1:
   version "16.13.1"
@@ -16143,6 +16268,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -16300,6 +16430,13 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
+rtl-css-js@^1.9.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.0.tgz#daa4f192a92509e292a0519f4b255e6e3c076b7d"
+  integrity sha512-Dl5xDTeN3e7scU1cWX8c9b6/Nqz3u/HgR4gePc1kWXYiQWVQbKCEyK6+Hxve9LbcJ5EieHy1J9nJCN3grTtGwg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -16427,6 +16564,11 @@ schema-utils@^2.6.6:
     "@types/json-schema" "^7.0.5"
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
+
+screenfull@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.0.2.tgz#b9acdcf1ec676a948674df5cd0ff66b902b0bed7"
+  integrity sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ==
 
 section-matter@^1.0.0:
   version "1.0.0"
@@ -16572,6 +16714,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-harmonic-interval@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz#e1773705539cdfb80ce1c3d99e7f298bb3995249"
+  integrity sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -16988,6 +17135,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@0.7.3, source-map@^0.7.2, source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
@@ -17003,7 +17155,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.1, sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -17155,6 +17307,13 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stack-generator@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.5.tgz#fb00e5b4ee97de603e0773ea78ce944d81596c36"
+  integrity sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==
+  dependencies:
+    stackframe "^1.1.1"
+
 stack-trace@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
@@ -17171,6 +17330,23 @@ stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
   integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
+
+stacktrace-gps@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz#7688dc2fc09ffb3a13165ebe0dbcaf41bcf0c69a"
+  integrity sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.1.1"
+
+stacktrace-js@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.2.tgz#4ca93ea9f494752d55709a081d400fdaebee897b"
+  integrity sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==
+  dependencies:
+    error-stack-parser "^2.0.6"
+    stack-generator "^2.0.5"
+    stacktrace-gps "^3.0.4"
 
 standard-as-callback@^2.0.1:
   version "2.0.1"
@@ -17537,6 +17713,11 @@ stylis-rule-sheet@^0.0.10:
   resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
   integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
 
+stylis@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.0.tgz#016fa239663d77f868fef5b67cf201c4b7c701e1"
+  integrity sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw==
+
 stylis@^3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
@@ -17818,6 +17999,11 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
+throttle-debounce@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
+  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
+
 through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -17970,6 +18156,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -18064,6 +18255,11 @@ trough@^1.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
+
+ts-easing@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
+  integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
 ts-pnp@^1.1.6:
   version "1.2.0"
@@ -18637,6 +18833,11 @@ use-dark-mode@^2.3.1:
     "@use-it/event-listener" "^0.1.2"
     use-persisted-state "^0.3.0"
 
+use-isomorphic-layout-effect@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.0.tgz#4db2111e0d53ca694187ea5fd5cb2ba610286fe0"
+  integrity sha512-kady5Z1O1qx5RitodCCKbpJSVEtECXYcnBnb5Q48Bz5V6gBmTu85ZcGdVwVFs8+DaOurNb/L5VdGHoQRMknghw==
+
 use-media@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.4.0.tgz#e777bf1f382a7aacabbd1f9ce3da2b62e58b2a98"
@@ -18648,6 +18849,13 @@ use-persisted-state@^0.3.0:
   integrity sha512-UlWEq0JYg7NbvcRBZ1g6Bwe4SEbYfr1wr/D5mrmfCzSxXSwsPRYygGLlsxHcW58Rf7gGwRPBT23sNVvyVn4WYg==
   dependencies:
     "@use-it/event-listener" "^0.1.2"
+
+use-subscription@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
+  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
+  dependencies:
+    object-assign "^4.1.1"
 
 use@^3.1.0:
   version "3.1.1"
@@ -19371,6 +19579,11 @@ xstate@^4.11.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.11.0.tgz#dc0bd31079fe22918c2c27c118d6310bef3dcd9e"
   integrity sha512-v+S3jF2YrM2tFOit8o7+4N3FuFd9IIGcIKHyfHeeNjMlmNmwuiv/IbY9uw7ECifx7H/A9aGLcxPSr0jdjTGDww==
+
+xstate@^4.15.1:
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.15.1.tgz#0553453c1cd201fedaf35a3cc518fe56090dbc3a"
+  integrity sha512-8dD/GnTwxUuDr/cY42vi+Enu4mpbuUXWISYJ0a9BC+cIFvqufJsepyDLS6lLsznfUP0GS5Yx9m3IQWFhAoGt/A==
 
 xstate@^4.9.1:
   version "4.13.0"


### PR DESCRIPTION
## Description

Brings over the `Terminal` component from the docs site into the theme! This will allow us to use it on all sites when rendering shell content. On top of the `Terminal` component, this PR does the following:

* Adds sass/scss syntax highlighting support out of the box
* Adds the ability to turn off auto code formatting on code blocks
* Default enables auto code formatting on a subset of languages, rather than trying to format text in every code block (addresses https://github.com/newrelic/developer-website/issues/222)
* Adds code formatting support for more languages
* Auto detects the prettier parser that should be used based on the language