### PR TITLE
Ensure anchor links are treated the same as relative links

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -21,7 +21,7 @@ const Link = ({ to, ...props }) => {
     to = to.replace(siteUrl, '');
   }
 
-  if (to.startsWith('/')) {
+  if (to.startsWith('/') || to.startsWith('#')) {
     return <GatsbyLink to={to} {...props} />;
   }
 


### PR DESCRIPTION
## Description

Ensures that anchor links (links that start with `#`, such as the links generated from `gatsby-remark-autolink-headers`) are treated the same as relative links. Currently they are treated the same as an external link, which opens the link in a new tab.
