### PR TITLE
feat: added signup button logic

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -50,6 +50,7 @@ const GlobalHeader = ({ className }) => {
       site {
         siteMetadata {
           utmSource
+          siteUrl
         }
         layout {
           contentPadding
@@ -60,7 +61,7 @@ const GlobalHeader = ({ className }) => {
   `);
 
   const {
-    siteMetadata: { utmSource },
+    siteMetadata: { utmSource, siteUrl },
     layout,
   } = site;
 
@@ -77,7 +78,11 @@ const GlobalHeader = ({ className }) => {
 
   const hideLogoText = useMedia({ maxWidth: '655px' });
   const useSearchIcon = useMedia({ maxWidth: '585px' });
-  const domain = window.location.hostname;
+  // const domain = window.location.hostname;
+  const inDocsSite = [
+    'https://docs.newrelic.com',
+    'https://docs-preview.newrelic.com',
+  ].includes(siteUrl);
 
   return (
     <>
@@ -290,12 +295,7 @@ const GlobalHeader = ({ className }) => {
                 size={Button.SIZE.EXTRA_SMALL}
                 variant={Button.VARIANT.PRIMARY}
               >
-                <span>
-                  {domain === 'www.docs-preview.newrelic.com' ||
-                  domain === 'www.docs.newrelic.com'
-                    ? 'Sign Up'
-                    : 'Start Now'}
-                </span>
+                <span>{inDocsSite ? 'Sign Up' : 'Start Now'}</span>
               </Button>
             </li>
           </ul>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -78,7 +78,6 @@ const GlobalHeader = ({ className }) => {
 
   const hideLogoText = useMedia({ maxWidth: '655px' });
   const useSearchIcon = useMedia({ maxWidth: '585px' });
-  // const domain = window.location.hostname;
   const inDocsSite = [
     'https://docs.newrelic.com',
     'https://docs-preview.newrelic.com',

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -77,6 +77,7 @@ const GlobalHeader = ({ className }) => {
 
   const hideLogoText = useMedia({ maxWidth: '655px' });
   const useSearchIcon = useMedia({ maxWidth: '585px' });
+  const domain = window.location.hostname;
 
   return (
     <>
@@ -289,7 +290,12 @@ const GlobalHeader = ({ className }) => {
                 size={Button.SIZE.EXTRA_SMALL}
                 variant={Button.VARIANT.PRIMARY}
               >
-                <span>Sign up</span>
+                <span>
+                  {domain === 'www.docs-preview.newrelic.com' ||
+                  domain === 'www.docs.newrelic.com'
+                    ? 'Sign Up'
+                    : 'Start Now'}
+                </span>
               </Button>
             </li>
           </ul>


### PR DESCRIPTION
this PR adds logic to the sign up button to show sign up text when on the docs site domains, and start now text on all other domains.  To test you can use `window.location.href` as `window.location.hostname` doesn't work on localhost URLS.

```
//testing

const domain = window.location.href;

console.log(window.location.href);

{domain === 'http://localhost:8001/' ||
domain === 'http://localhost:8001/build-apps'
  ? 'Sign Up'
  : 'Start Now'}
```