### PR TITLE
Fix auto terminals in MDX code blocks

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/MDXCodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/MDXCodeBlock.js
@@ -17,7 +17,7 @@ const MDXCodeBlock = ({
 }) => {
   const language = className?.replace('language-', '');
 
-  return isShellLanguage ? (
+  return isShellLanguage(language) ? (
     <Terminal animate={animate} copyable={copyable}>
       {children}
     </Terminal>


### PR DESCRIPTION
## Description

With the recent change to the `MDXCodeBlock` component to automatically render terminals for shell languages, it appears I forgot to call the function :facepalm:, which means that all code blocks inside of an MDX document are rendering as a terminal. This PR ensures the terminal is rendered conditionally. 
