### PR TITLE
Add language toggle in the global header + i18n config options

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -13,6 +13,9 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
+        i18n: {
+          additionalLocales: [{ name: 'Japanese', path: 'jp', locale: 'jp' }],
+        },
         layout: {
           contentPadding: '2rem',
           maxWidth: '1480px',

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -14,7 +14,7 @@ module.exports = {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
         i18n: {
-          additionalLocales: [{ name: 'Japanese', path: 'jp', locale: 'jp' }],
+          additionalLocales: [{ name: 'Japanese', locale: 'jp' }],
         },
         layout: {
           contentPadding: '2rem',

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -41,11 +41,18 @@ exports.createSchemaCustomization = ({ actions }) => {
       branch: String!
       contributingUrl: String
     }
+
+    type SiteLocale @dontInfer {
+      name: String!
+      path: String!
+      locale: String!
+      isDefault: Boolean!
+    }
   `);
 };
 
 exports.createResolvers = ({ createResolvers }, themeOptions) => {
-  const { layout = {} } = themeOptions;
+  const { layout = {}, i18n = {} } = themeOptions;
 
   const defaultUtmSource = {
     'https://developer.newrelic.com': 'developer-site',
@@ -58,6 +65,16 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
       layout: {
         type: 'SiteLayout',
         resolve: () => layout,
+      },
+      locales: {
+        type: '[SiteLocale!]!',
+        resolve: () => [
+          { name: 'English', path: 'en', locale: 'en', isDefault: true },
+          ...(i18n.additionalLocales || []).map((locale) => ({
+            ...locale,
+            isDefault: false,
+          })),
+        ],
       },
     },
     SiteSiteMetadata: {

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -44,7 +44,6 @@ exports.createSchemaCustomization = ({ actions }) => {
 
     type SiteLocale @dontInfer {
       name: String!
-      path: String!
       locale: String!
       isDefault: Boolean!
     }
@@ -69,7 +68,7 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
       locales: {
         type: '[SiteLocale!]!',
         resolve: () => [
-          { name: 'English', path: '', locale: 'en', isDefault: true },
+          { name: 'English', locale: 'en', isDefault: true },
           ...(i18n.additionalLocales || []).map((locale) => ({
             ...locale,
             isDefault: false,

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -69,7 +69,7 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
       locales: {
         type: '[SiteLocale!]!',
         resolve: () => [
-          { name: 'English', path: 'en', locale: 'en', isDefault: true },
+          { name: 'English', path: '', locale: 'en', isDefault: true },
           ...(i18n.additionalLocales || []).map((locale) => ({
             ...locale,
             isDefault: false,

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -123,10 +123,6 @@ const Button = styled.button`
   transition: all 0.15s ease-out;
   white-space: nowrap;
 
-  &:hover {
-    transform: translate3d(0, -1px, 0);
-  }
-
   ${({ variant }) => styles.variant[variant]}
   ${({ size }) => styles.size[size]}
   ${({ disabled }) => disabled && styles.disabled}

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Context.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext();

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Dropdown.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Dropdown.js
@@ -1,0 +1,59 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import DropdownContext from './Context';
+import Toggle from './Toggle';
+import Menu from './Menu';
+import MenuItem from './MenuItem';
+
+const ALIGNMENTS = {
+  left: 'flex-start',
+  center: 'center',
+  right: 'flex-end',
+};
+
+const Dropdown = ({ align, children }) => {
+  const [open, setOpen] = useState(false);
+  const value = useMemo(
+    () => ({ align, open, toggle: () => setOpen((open) => !open) }),
+    [align, open]
+  );
+  const hide = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('click', hide);
+    }
+
+    return () => document.removeEventListener('click', hide);
+  }, [hide, open]);
+
+  return (
+    <DropdownContext.Provider value={value}>
+      <div
+        css={css`
+          display: flex;
+          justify-content: ${ALIGNMENTS[align]};
+          position: relative;
+        `}
+      >
+        {children}
+      </div>
+    </DropdownContext.Provider>
+  );
+};
+
+Dropdown.propTypes = {
+  align: PropTypes.oneOf(Object.keys(ALIGNMENTS)),
+  children: PropTypes.node,
+};
+
+Dropdown.defaultProps = {
+  align: 'left',
+};
+
+Dropdown.Toggle = Toggle;
+Dropdown.Menu = Menu;
+Dropdown.MenuItem = MenuItem;
+
+export default Dropdown;

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Menu.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Menu.js
@@ -24,11 +24,18 @@ const Menu = ({ children }) => {
       css={css`
         --arrow-size: 5px;
         --arrow-offset: 0.5rem;
+        --background-color: white;
+        --text-color: var(--color-neutrals-900);
+
+        .dark-mode & {
+          --text-color: var(--color-dark-900);
+          --background-color: var(--color-dark-050);
+        }
 
         position: absolute;
         top: calc(100% + var(--arrow-size));
         display: ${open ? 'block' : 'none'};
-        background: white;
+        background: var(--background-color);
         border-radius: 0.25rem;
         z-index: 1000;
         padding: 0.5rem;
@@ -41,7 +48,7 @@ const Menu = ({ children }) => {
           top: calc(-1 * var(--arrow-size));
           border-left: var(--arrow-size) solid transparent;
           border-right: var(--arrow-size) solid transparent;
-          border-bottom: var(--arrow-size) solid white;
+          border-bottom: var(--arrow-size) solid var(--background-color);
           width: 0;
           height: 0;
           z-index: 1000;

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Menu.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Menu.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import useDropdown from './useDropdown';
+
+const ARROW_ALIGNMENTS = {
+  left: css`
+    left: var(--arrow-offset);
+  `,
+  center: css`
+    left: 50%;
+    transform: translateX(-50%);
+  `,
+  right: css`
+    right: var(--arrow-offset);
+  `,
+};
+
+const Menu = ({ children }) => {
+  const { align, open } = useDropdown();
+
+  return (
+    <div
+      css={css`
+        --arrow-size: 5px;
+        --arrow-offset: 0.5rem;
+
+        position: absolute;
+        top: calc(100% + var(--arrow-size));
+        display: ${open ? 'block' : 'none'};
+        background: white;
+        border-radius: 0.25rem;
+        z-index: 1000;
+        padding: 0.5rem;
+        box-shadow: 0 3px 8px 0 rgba(22, 38, 59, 0.2);
+
+        &::before {
+          content: '';
+          position: absolute;
+          display: block;
+          top: calc(-1 * var(--arrow-size));
+          border-left: var(--arrow-size) solid transparent;
+          border-right: var(--arrow-size) solid transparent;
+          border-bottom: var(--arrow-size) solid white;
+          width: 0;
+          height: 0;
+          z-index: 1000;
+
+          ${ARROW_ALIGNMENTS[align]};
+        }
+      `}
+    >
+      <div
+        css={css`
+          max-height: 20rem;
+          min-width: 100px;
+          overflow-y: auto;
+        `}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+Menu.propTypes = {
+  children: PropTypes.node,
+};
+
+export default Menu;

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/MenuItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/MenuItem.js
@@ -9,16 +9,23 @@ const MenuItem = ({ children, href, onClick }) => {
   return (
     <Component
       onClick={onClick}
+      to={href}
       css={css`
+        display: block;
         padding: 0.25rem 0.5rem;
         font-size: 0.75rem;
         transition: all 0.2s ease-out;
-        color: black;
+        color: var(--text-color);
 
         &:hover {
+          color: var(--text-color);
           cursor: pointer;
-          background: var(--color-neutrals-300);
+          background: var(--color-neutrals-200);
           border-radius: 0.25rem;
+
+          .dark-mode & {
+            background: var(--color-dark-200);
+          }
         }
       `}
     >

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/MenuItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/MenuItem.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Link from '../Link';
+import { css } from '@emotion/core';
+
+const MenuItem = ({ children, href, onClick }) => {
+  const Component = href ? Link : 'div';
+
+  return (
+    <Component
+      onClick={onClick}
+      css={css`
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+        transition: all 0.2s ease-out;
+        color: black;
+
+        &:hover {
+          cursor: pointer;
+          background: var(--color-neutrals-300);
+          border-radius: 0.25rem;
+        }
+      `}
+    >
+      {children}
+    </Component>
+  );
+};
+
+MenuItem.propTypes = {
+  children: PropTypes.node.isRequired,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export default MenuItem;

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Toggle.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Toggle.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import Button from '../Button';
+import Icon from '../Icon';
+import useDropdown from './useDropdown';
+
+const Toggle = ({ children, variant, size }) => {
+  const { open, toggle } = useDropdown();
+
+  return (
+    <Button variant={variant} onClick={toggle} size={size}>
+      {children}
+      <Icon
+        name="fe-chevron-down"
+        css={css`
+          margin-left: 0.25rem;
+          transform: rotate(${open ? '180deg' : '0'});
+        `}
+      />
+    </Button>
+  );
+};
+
+Toggle.propTypes = {
+  children: PropTypes.node,
+  variant: Button.propTypes.variant,
+  size: Button.propTypes.size,
+};
+
+export default Toggle;

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/index.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/index.js
@@ -1,0 +1,1 @@
+export { default } from './Dropdown';

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/useDropdown.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/useDropdown.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import DropdownContext from './Context';
+
+const useDropdown = () => useContext(DropdownContext);
+
+export default useDropdown;

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -6,6 +6,7 @@ import AnnouncementBanner from './AnnouncementBanner';
 import DarkModeToggle from './DarkModeToggle';
 import ExternalLink from './ExternalLink';
 import Button from './Button';
+import Dropdown from './Dropdown';
 import NewRelicLogo from './NewRelicLogo';
 import Icon from './Icon';
 import SwiftypeSearch from './SwiftypeSearch';
@@ -16,6 +17,7 @@ import useMedia from 'use-media';
 import { useLocation } from '@reach/router';
 import useQueryParams from '../hooks/useQueryParams';
 import useKeyPress from '../hooks/useKeyPress';
+import path from 'path';
 import { rgba } from 'polished';
 
 const action = css`
@@ -56,11 +58,17 @@ const GlobalHeader = ({ className }) => {
           contentPadding
           maxWidth
         }
+        locales {
+          name
+          locale
+          isDefault
+        }
       }
     }
   `);
 
   const {
+    locales,
     siteMetadata: { utmSource, siteUrl },
     layout,
   } = site;
@@ -77,11 +85,20 @@ const GlobalHeader = ({ className }) => {
   });
 
   const hideLogoText = useMedia({ maxWidth: '655px' });
-  const useSearchIcon = useMedia({ maxWidth: '585px' });
+  const useCondensedHeader = useMedia({ maxWidth: '585px' });
   const inDocsSite = [
     'https://docs.newrelic.com',
     'https://docs-preview.newrelic.com',
   ].includes(siteUrl);
+
+  const matchLocalePath = new RegExp(
+    `^\\/(${locales.map(({ locale }) => locale).join('|')})`
+  );
+
+  const selectedLocale =
+    locales.find((locale) =>
+      new RegExp(`^\\/${locale.locale}(?=/)`).test(location.pathname)
+    ) || locales.find((locale) => locale.isDefault);
 
   return (
     <>
@@ -91,7 +108,6 @@ const GlobalHeader = ({ className }) => {
         className={className}
         css={css`
           background-color: var(--color-neutrals-100);
-          overflow: hidden;
           position: sticky;
           top: 0;
           z-index: 80;
@@ -229,7 +245,7 @@ const GlobalHeader = ({ className }) => {
                 color: var(--secondary-text-color);
 
                 &:not(:first-of-type) {
-                  margin-left: 1rem;
+                  margin-left: 0.5rem;
                 }
               }
             `}
@@ -239,7 +255,7 @@ const GlobalHeader = ({ className }) => {
                 flex: 1;
               `}
             >
-              {useSearchIcon ? (
+              {useCondensedHeader ? (
                 <Link to="?q=" css={actionLink}>
                   <Icon css={actionIcon} name="fe-search" size="0.875rem" />
                 </Link>
@@ -261,6 +277,34 @@ const GlobalHeader = ({ className }) => {
                 />
               )}
             </li>
+            {locales.length > 1 && (
+              <li>
+                <Dropdown align="right">
+                  <Dropdown.Toggle
+                    size={Button.SIZE.EXTRA_SMALL}
+                    variant={Button.VARIANT.LINK}
+                  >
+                    {useCondensedHeader
+                      ? selectedLocale.locale.toUpperCase()
+                      : selectedLocale.name}
+                  </Dropdown.Toggle>
+                  <Dropdown.Menu>
+                    {locales.map(({ locale, name, isDefault }) => (
+                      <Dropdown.MenuItem
+                        key={locale}
+                        href={path.join(
+                          '/',
+                          isDefault ? '' : locale,
+                          location.pathname.replace(matchLocalePath, '')
+                        )}
+                      >
+                        {name}
+                      </Dropdown.MenuItem>
+                    ))}
+                  </Dropdown.Menu>
+                </Dropdown>
+              </li>
+            )}
             <li>
               <DarkModeToggle css={[actionIcon, action]} size="0.875rem" />
             </li>
@@ -270,16 +314,18 @@ const GlobalHeader = ({ className }) => {
                 align-items: center;
               `}
             >
-              <ExternalLink
+              <Button
+                as={ExternalLink}
+                size={Button.SIZE.EXTRA_SMALL}
+                variant={Button.VARIANT.LINK}
                 href="https://one.newrelic.com"
                 css={css`
-                  font-size: 0.675rem;
                   font-weight: 600;
                   white-space: nowrap;
                 `}
               >
                 Log in
-              </ExternalLink>
+              </Button>
             </li>
             <li
               css={css`


### PR DESCRIPTION
Closes #181

## Description

Adds a language toggle to the global header. This PR also adds the ability to configure additional locales supported for the sites. This will automatically create a route for each page in src/routes with a link to the localized route.

## Screenshots

<img width="1609" alt="Screen Shot 2021-01-05 at 4 19 34 PM" src="https://user-images.githubusercontent.com/565661/103713693-db0ea180-4f71-11eb-99b8-3b483197f401.png">
<img width="1485" alt="Screen Shot 2021-01-05 at 4 20 39 PM" src="https://user-images.githubusercontent.com/565661/103713775-fc6f8d80-4f71-11eb-85a9-436eef73f719.png">


