### PR TITLE
Documentation for `i18n` settings and the `<Dropdown />` component

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -143,7 +143,7 @@ module.exports = {
           },
         },
         i18n: {
-          additionalLocales: [{ name: 'Japanese', locale: 'jp' }],
+          additionalLocales: [{ name: '日本語', locale: 'jp' }],
         }
         robots: {
           policy: [{ userAgent: '*', allow: '/' }],
@@ -210,7 +210,7 @@ These values are used to generate locale-specific pages and to populate a dropdo
 {
   i18n: {
     additionalLocales: [
-      { name: 'Japanese', locale: 'jp' },
+      { name: '日本語', locale: 'jp' },
       { name: 'Korean', locale: 'ko' },
     ];
   }
@@ -696,7 +696,7 @@ const MyLayout = () => (
 
 ### `Dropdown`
 
-Used in combination with [`Dropdown.Toggle`](#dropdowntoggle), [`Dropdown.Menu`](#dropdownmenu), and [`Dropdown.MenuItem`](#dropdownmenuitem) to create dropdown menus.
+Used in combination with [`Dropdown.Toggle`](#dropdowntoggle), [`Dropdown.Menu`](#dropdownmenu), and [`Dropdown.MenuItem`](#dropdownmenuitem) to create a dropdown.
 
 ```js
 import { Dropdown } from '@newrelic/gatsby-theme-newrelic';
@@ -706,7 +706,7 @@ import { Dropdown } from '@newrelic/gatsby-theme-newrelic';
 
 | Prop       | Type | Required | Default | Description                                                                    |
 | ---------- | ---- | -------- | ------- | ------------------------------------------------------------------------------ |
-| `align`    | enum | no       | "left"  | The position of the menu arrow. \*Must be either `left`, `right`, or `center`. |
+| `align`    | enum | no       | "left"  | The position of the menu arrow. Must be either `left`, `right`, or `center`. |
 | `children` | node | yes      |         | Components used for the dropdown.                                              |
 
 ```jsx
@@ -734,7 +734,7 @@ Used within a [`Dropdown`](#dropdown) component to render a button that can togg
 | ---------- | ---- | -------- | ------- | -------------------------------------------------------------------- |
 | `size`     | enum | no       |         | The `size` prop for the underlying [`Button`](#button) component.    |
 | `variant`  | enum | yes      |         | The `variant` prop for the underlying [`Button`](#button) component. |
-| `children` | node | no       |         | Text or component used to render the toggle, in addition to an icon. |
+| `children` | node | no       |         | Content used to render the toggle |
 
 #### `Dropdown.Menu`
 
@@ -744,7 +744,7 @@ Used within a [`Dropdown`](#dropdown) component to render the _menu_ that is sho
 
 | Props      | Type | Required | Default | Description                                      |
 | ---------- | ---- | -------- | ------- | ------------------------------------------------ |
-| `children` | node | yes      |         | Sub-components used to create the dropdown menu. |
+| `children` | node | yes      |         | Content rendered inside the dropdown menu. Should consist of `Dropdown.MenuItem` components. |
 
 #### `Dropdown.MenuItem`
 
@@ -756,7 +756,7 @@ Used within a [`Dropdown.Menu`](#dropdownmenu) component (within a [`Dropdown`](
 | ---------- | -------- | -------- | ------- | ------------------------------------------------------------------------------- |
 | `href`     | string   | no       |         | A path that, if supplied, will be used as a [`Link`](#link).                    |
 | `onClick`  | function | no       |         | An optional click event handler that is triggerd when the component is clicked. |
-| `children` | node     | yes      |         | Text or component used to render the toggle, in addition to an icon.            |
+| `children` | node     | yes      |         | Content for the `MenuItem`.            |
 
 ### `ExternalLink`
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -28,6 +28,10 @@ websites](https://opensource.newrelic.com).
   - [`CodeBlock`](#codeblock)
   - [`ContributingGuidelines`](#contributingguidelines)
   - [`CookieConsentDialog`](#cookieconsentdialog)
+  - [`Dropdown`](#dropdown)
+    - [`Dropdown.Toggle`](#dropdowntoggle)
+    - [`Dropdown.Menu`](#dropdownmenu)
+    - [`Dropdown.MenuItem`](#dropdownmenuitem)
   - [`ExternalLink`](#externallink)
   - [`FeatherSVG`](#feathersvg)
   - [`Feedback`](#feedback)
@@ -689,6 +693,70 @@ const MyLayout = () => (
   </>
 );
 ```
+
+### `Dropdown`
+
+Used in combination with [`Dropdown.Toggle`](#dropdowntoggle), [`Dropdown.Menu`](#dropdownmenu), and [`Dropdown.MenuItem`](#dropdownmenuitem) to create dropdown menus.
+
+```js
+import { Dropdown } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Props**
+
+| Prop       | Type | Required | Default | Description                                                                    |
+| ---------- | ---- | -------- | ------- | ------------------------------------------------------------------------------ |
+| `align`    | enum | no       | "left"  | The position of the menu arrow. \*Must be either `left`, `right`, or `center`. |
+| `children` | node | yes      |         | Components used for the dropdown.                                              |
+
+```jsx
+import { DropDown, Button } from '@newrelic/gatsby-theme-newrelic';
+
+const Example = (
+  <Dropdown align="right">
+    <Dropdown.Toggle variant={Button.VARIANT.NORMAL}>Menu</Dropdown.Toggle>
+    <Dropdown.Menu>
+      <Dropdown.MenuItem>Item 1</Dropdown.MenuItem>
+      <Dropdown.MenuItem>Item 2</Dropdown.MenuItem>
+      <Dropdown.MenuItem>Item 3</Dropdown.MenuItem>
+    </Dropdown.Menu>
+  </Dropdown>
+);
+```
+
+#### `Dropdown.Toggle`
+
+Used within a [`Dropdown`](#dropdown) component to render a button that can toggle whether or not the dropdown menu is visible.
+
+**Props**
+
+| Prop       | Type | Required | Default | Description                                                          |
+| ---------- | ---- | -------- | ------- | -------------------------------------------------------------------- |
+| `size`     | enum | no       |         | The `size` prop for the underlying [`Button`](#button) component.    |
+| `variant`  | enum | yes      |         | The `variant` prop for the underlying [`Button`](#button) component. |
+| `children` | node | no       |         | Text or component used to render the toggle, in addition to an icon. |
+
+#### `Dropdown.Menu`
+
+Used within a [`Dropdown`](#dropdown) component to render the _menu_ that is shown when the dropdown is open.
+
+**Props**
+
+| Props      | Type | Required | Default | Description                                      |
+| ---------- | ---- | -------- | ------- | ------------------------------------------------ |
+| `children` | node | yes      |         | Sub-components used to create the dropdown menu. |
+
+#### `Dropdown.MenuItem`
+
+Used within a [`Dropdown.Menu`](#dropdownmenu) component (within a [`Dropdown`](#dropdown) component) to render an individual dropdown menu item.
+
+**Props**
+
+| Props      | Type     | Required | Default | Description                                                                     |
+| ---------- | -------- | -------- | ------- | ------------------------------------------------------------------------------- |
+| `href`     | string   | no       |         | A path that, if supplied, will be used as a [`Link`](#link).                    |
+| `onClick`  | function | no       |         | An optional click event handler that is triggerd when the component is clicked. |
+| `children` | node     | yes      |         | Text or component used to render the toggle, in addition to an icon.            |
 
 ### `ExternalLink`
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -15,6 +15,7 @@ websites](https://opensource.newrelic.com).
   - [Options](#options)
     - [`newrelic`](#newrelic)
     - [`robots`](#robots)
+    - [`i18n`](#i18n)
     - [`layout`](#layout)
     - [`prism`](#prism)
     - [`gaTrackingId`](#gatrackingid)
@@ -137,6 +138,9 @@ module.exports = {
             },
           },
         },
+        i18n: {
+          additionalLocales: [{ name: 'Japanese', locale: 'jp' }],
+        }
         robots: {
           policy: [{ userAgent: '*', allow: '/' }],
         },
@@ -189,6 +193,25 @@ the available configuration options, visit [the
 documentation.](https://www.gatsbyjs.org/packages/gatsby-plugin-robots-txt/)
 
 **Default**: `{ policy: [{ userAgent: '*', allow: '/' }] }`
+
+#### `i18n`
+
+Optional configuration for internationalization (i18n). `additionalLocales` can be supplied to add support for languages other than English (the default language). Each locale needs a `name` (used for display in the UI) and a `locale` (used by Gatsby and display in the UI on smaller screens).
+
+These values are used to generate locale-specific pages and to populate a dropdown in the `<GlobalHeader />` component.
+
+**Example**
+
+```js
+{
+  i18n: {
+    additionalLocales: [
+      { name: 'Japanese', locale: 'jp' },
+      { name: 'Korean', locale: 'ko' },
+    ];
+  }
+}
+```
 
 #### `layout`
 

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Dropdown.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Dropdown.js
@@ -45,7 +45,7 @@ const Dropdown = ({ align, children }) => {
 
 Dropdown.propTypes = {
   align: PropTypes.oneOf(Object.keys(ALIGNMENTS)),
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
 };
 
 Dropdown.defaultProps = {

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/Toggle.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/Toggle.js
@@ -24,7 +24,7 @@ const Toggle = ({ children, variant, size }) => {
 
 Toggle.propTypes = {
   children: PropTypes.node,
-  variant: Button.propTypes.variant,
+  variant: Button.propTypes.variant.isRequired,
   size: Button.propTypes.size,
 };
 


### PR DESCRIPTION
## Description
Adds the internationalization documentation for the theme settings and documents how to use the dropdown components (including the sub-components).

## Reviewer Notes
This documentation covers the work done in #187

I marked two props a `isRequired`:
* `children` for the `<Dropdown />` component - doesn't make sense to render a dropdown without a toggle or menu
* `variant` for the `<Dropdown.Toggle />` component - it's required by the underlying `<Button />` component

We might want to consider a default `variant` on the button so that we can remove the requirement on this component. Either way, it's outside fo the scope of this PR.