### PR TITLE
Configurable sitemaps + GH buttons

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -186,7 +186,7 @@ are optional, they are highly recommended.
 
 #### `sitemap`
 
-Toggles the automatic creation of a sitemap on and off. Set this value to
+Toggles the automatic creation of a sitemap. Set this value to
 `false` to disable sitemaps.
 
 **Default:** `true`

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -13,6 +13,7 @@ websites](https://opensource.newrelic.com).
 - [Configuration](#configuration)
   - [Site metadata](#site-metadata)
   - [Options](#options)
+    - [`sitemap`](#sitemap)
     - [`newrelic`](#newrelic)
     - [`robots`](#robots)
     - [`i18n`](#i18n)
@@ -120,6 +121,7 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
+        sitemap: true,
         layout: {
           contentPadding: '2rem',
           maxWidth: '1600px',
@@ -181,6 +183,13 @@ are optional, they are highly recommended.
   the default behavior.
 
 ### Options
+
+#### `sitemap`
+
+Toggles the automatic creation of a sitemap on and off. Set this value to
+`false` to disable sitemaps.
+
+**Default:** `true`
 
 #### `newrelic`
 

--- a/packages/gatsby-theme-newrelic/gatsby-config.js
+++ b/packages/gatsby-theme-newrelic/gatsby-config.js
@@ -1,15 +1,15 @@
 module.exports = ({
   layout,
   newrelic,
-  swiftype,
   robots = {},
+  sitemap = true,
   gaTrackingId,
 }) => {
   return {
     plugins: [
       'gatsby-plugin-emotion',
       'gatsby-plugin-react-helmet',
-      'gatsby-plugin-sitemap',
+      sitemap && 'gatsby-plugin-sitemap',
       'gatsby-plugin-use-dark-mode',
       'gatsby-transformer-sharp',
       'gatsby-plugin-sharp',

--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -37,12 +37,6 @@ const GlobalFooter = ({ fileRelativePath, className, pageTitle }) => {
   const { branch, repository, siteUrl } = siteMetadata;
   const { pathname } = useLocation();
 
-  const page = { title: pageTitle, slug: pathname, siteUrl };
-  const title = pageTitle && `Issue: ${pageTitle}`;
-  const labels = ['bug'];
-
-  const issueUrl = createIssueURL({ repository, title, page, labels });
-
   return (
     <footer
       data-swiftype-index={false}
@@ -90,7 +84,7 @@ const GlobalFooter = ({ fileRelativePath, className, pageTitle }) => {
           />
         </Link>
         <div>
-          {fileRelativePath && (
+          {repository && fileRelativePath && (
             <Button
               as={ExternalLink}
               href={`${repository}/blob/${branch}/${fileRelativePath}`}
@@ -110,20 +104,27 @@ const GlobalFooter = ({ fileRelativePath, className, pageTitle }) => {
             </Button>
           )}
 
-          <Button
-            as={ExternalLink}
-            href={issueUrl}
-            variant={Button.VARIANT.OUTLINE}
-            size={Button.SIZE.SMALL}
-          >
-            <Icon
-              name="fe-github"
-              css={css`
-                margin-right: 0.5rem;
-              `}
-            />
-            {t('github.createIssue')}
-          </Button>
+          {repository && (
+            <Button
+              as={ExternalLink}
+              href={createIssueURL({
+                repository,
+                title: pageTitle && `Issue: ${pageTitle}`,
+                page: { title: pageTitle, slug: pathname, siteUrl },
+                labels: ['bug'],
+              })}
+              variant={Button.VARIANT.OUTLINE}
+              size={Button.SIZE.SMALL}
+            >
+              <Icon
+                name="fe-github"
+                css={css`
+                  margin-right: 0.5rem;
+                `}
+              />
+              {t('github.createIssue')}
+            </Button>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Closes #214
Closes #215

## Description

Adds the ability to disable sitemaps with the `sitemap: false` option in `gatsby-config.js`. Also removes the GitHub buttons in the footer if the `repository` is not configured 
