### PR TITLE
fix emotion warning about stringified function

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchInput.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchInput.js
@@ -51,7 +51,7 @@ const SearchInput = forwardRef(
         style={style}
         css={css`
           position: relative;
-          width: ${(props) => props.width || '100%'};
+          width: ${width || '100%'};
           box-shadow: var(--shadow-1);
           ${size && styles.size[size].container}
         `}


### PR DESCRIPTION
# Description

Fixes the following warning:

```
Functions that are interpolated in css calls will be stringified.
If you want to have a css call based on props, create a function that returns a css call like this
let dynamicStyle = (props) => css`color: ${props.color}`
It can be called directly with props or interpolated in a styled call like this
let SomeComponent = styled('div')`${dynamicStyle}`
```
