### PR TITLE
Fix copyright date

### DIFF
--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -40,7 +40,7 @@
     "title": "Feedback"
   },
   "footer": {
-    "copyright": "Copyright {{copyrightSymbol}} 2020 New Relic Inc.",
+    "copyright": "Copyright {{copyrightSymbol}} 2021 New Relic Inc.",
     "careers": "Careers",
     "terms": "Terms of Service",
     "dcmaPolicy": "DCMA Policy",


### PR DESCRIPTION
# Description

The copyright date was updated in #222, but because the footer is translated, the translation also needed to be updated. This PR ensures the translation is up-to-date.
