### PR TITLE
Add className to outer wrapper

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Table.js
+++ b/packages/gatsby-theme-newrelic/src/components/Table.js
@@ -4,13 +4,13 @@ import { css } from '@emotion/core';
 
 const Table = ({ className, children }) => (
   <div
+    className={className}
     css={css`
       width: 100%;
       overflow-x: auto;
     `}
   >
     <table
-      className={className}
       css={css`
         border-collapse: collapse;
         border-spacing: 0;


### PR DESCRIPTION
# Description

With the recent update to the `<Table>` component to make it scrollable, the `className` was not moved to the outer container. This creates a problem with the `MDXTable` component when trying to add spacing since it does not apply the proper element.
