### PR TITLE
Related resource component + tweaks

### DIFF
--- a/demo/src/pages/build-apps/build-hello-world-app.mdx
+++ b/demo/src/pages/build-apps/build-hello-world-app.mdx
@@ -1,5 +1,10 @@
 ---
 title: 'Create a "Hello, World!" application'
+resources:
+  - title: New Relic One VSCode extension
+    url: https://marketplace.visualstudio.com/items?itemName=new-relic.nr1
+  - title: Build on New Relic One
+    url: https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application
 ---
 
 Here's how you can quickly build a "Hello, World!" application in New Relic One. In these steps, you create a local version of the New Relic One site where you can prototype your application. Then, when you're ready to share the application with others, you can publish it to New Relic One.

--- a/demo/src/pages/build-apps/build-hello-world-app.mdx
+++ b/demo/src/pages/build-apps/build-hello-world-app.mdx
@@ -5,6 +5,8 @@ resources:
     url: https://marketplace.visualstudio.com/items?itemName=new-relic.nr1
   - title: Build on New Relic One
     url: https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/build-new-relic-one/new-relic-one-build-your-own-custom-new-relic-one-application
+  - title: Build apps
+    url: /build-apps
 ---
 
 Here's how you can quickly build a "Hello, World!" application in New Relic One. In these steps, you create a local version of the New Relic One site where you can prototype your application. Then, when you're ready to share the application with others, you can publish it to New Relic One.

--- a/demo/src/templates/basic.js
+++ b/demo/src/templates/basic.js
@@ -1,20 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
 import { graphql } from 'gatsby';
 import {
+  ContributingGuidelines,
   SEO,
   Layout,
   MarkdownContainer,
   MDX,
+  RelatedResources,
 } from '@newrelic/gatsby-theme-newrelic';
 
 const BasicTemplate = ({ data, location }) => {
   const {
-    mdx: { body, frontmatter },
+    mdx: { body, frontmatter, fields, relatedResources },
   } = data;
 
   return (
-    <Layout.Main>
+    <Layout.Main
+      css={css`
+        display: grid;
+        grid-template-areas: 'content page-tools';
+        grid-template-columns: minmax(0, 1fr) 320px;
+        grid-column-gap: var(--site-content-padding);
+      `}
+    >
       <SEO location={location} title={frontmatter.title} />
       <h1>{frontmatter.title}</h1>
       <Layout.Content>
@@ -22,6 +32,14 @@ const BasicTemplate = ({ data, location }) => {
           <MDX body={body} />
         </MarkdownContainer>
       </Layout.Content>
+
+      <Layout.PageTools>
+        <ContributingGuidelines
+          fileRelativePath={fields.fileRelativePath}
+          pageTitle={frontmatter.title}
+        />
+        <RelatedResources resources={relatedResources} />
+      </Layout.PageTools>
     </Layout.Main>
   );
 };
@@ -37,6 +55,13 @@ export const pageQuery = graphql`
       body
       frontmatter {
         title
+      }
+      fields {
+        fileRelativePath
+      }
+      relatedResources {
+        title
+        url
       }
     }
   }

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -63,6 +63,7 @@ websites](https://opensource.newrelic.com).
   - [`PageTools`](#pagetools)
     - [`PageTools.Section`](#pagetoolssection)
     - [`PageTools.Title`](#pagetoolstitle)
+  - [`RelatedResources`](#relatedresources-1)
   - [`SearchInput`](#searchinput)
   - [`SEO`](#seo)
   - [`SimpleFeedback`](#simplefeedback)
@@ -1818,6 +1819,37 @@ section of content inside of `PageTools`. Render this inside of a
 | ----------- | ------ | -------- | ------- | -------------------------------------------------------- |
 | `className` | string | no       |         | Additional `className` for the component.                |
 | `children`  | node   | no       |         | Title to be displayed in the `PageTools.Title` component |
+
+### `RelatedResources`
+
+Used to display related resources for the current page. This is meant to be used
+as a section inside of the [`PageTools`](#pagetools) component.
+
+```js
+import { RelatedResources } from '@newrelic/gatsby-theme-newrelic'`
+```
+
+**Props**
+
+| Prop        | Type       | Required | Default             | Description                                          |
+| ----------- | ---------- | -------- | ------------------- | ---------------------------------------------------- |
+| `resources` | Resource[] | yes      |                     | Array of resources to be displayed in the component. |
+| `title`     | string     | no       | 'Related resources' | Title to be displayed as the title for this section  |
+
+```ts
+type Resource = {
+  url: string
+  title: string
+}
+```
+
+**Examples**
+
+```js
+<PageTools>
+  <RelatedResources resources={relatedResources} />
+</PageTools>
+```
 
 ### `SearchInput`
 

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -16,6 +16,7 @@ websites](https://opensource.newrelic.com).
     - [`sitemap`](#sitemap)
     - [`newrelic`](#newrelic)
     - [`robots`](#robots)
+    - [`relatedResources`](#relatedresources)
     - [`i18n`](#i18n)
     - [`layout`](#layout)
     - [`prism`](#prism)
@@ -165,6 +166,11 @@ module.exports = {
             authorizationKey: 'my-auth-key',
           },
         },
+        relatedResources: {
+          labels: {
+            'https://my.website': 'my-website'
+          },
+        },
         gaTrackingId: 'UA-XXXXXX-XX',
       },
     },
@@ -217,6 +223,61 @@ documentation.](https://www.gatsbyjs.org/packages/gatsby-plugin-robots-txt/)
 
 **Default**: `{ policy: [{ userAgent: '*', allow: '/' }] }`
 
+#### `relatedResources`
+
+Optional configuration for related resources used in the right rail. Currently
+only `Mdx` nodes are supported.
+
+**Options:**
+
+- `labels` _(object)_: Map of URLs to their label. This is used to match
+  results displayed in the right rail with the label in the tag displayed
+  underneath the link. Use this to add additional labels not covered by the
+  default set of labels.
+
+- `swiftype` _(object | false)_: Configuration used for fetching results from
+  Swiftype for an `Mdx` node. Set this to `false` (the default) to disable
+  fetching related resources through Swiftype. If this is disabled, related
+  resources can only be sourced via frontmatter. If enabled, this takes the
+  following configuration:
+
+  - `resultsPath` _(string)_ **required**: Path to the file where Swiftype
+    results will be stored. If the `refetch` option is set to `false` (the
+    default), this file will be used to read related resource values for each
+    `Mdx` node. This file is only written to when `refetch` is set to `true`.
+
+  - `refetch` _(boolean)_: Determines whether to refetch results from Swiftype
+    for every `Mdx` node during a build. It's a good idea to only set this on a
+    special build (e.g. a build that happens on a cron job) so that Swiftype is
+    not searched on development or every build on the site.
+
+    - **Default**: `false`
+
+  - `engineKey` _(string)_ **required**: Swiftype's engine key used to fetch
+    results from a Swiftype search engine.
+
+  - `getSlug` _(function)_: Function to get the slug for an `Mdx` node.
+    Useful if the slug is set from something other than the filesystem. By
+    default, this will use the `createFilePath` helper to generate the slug for
+    the `Mdx` node. This function should accept an object as its only argument
+    with a key of `node` (i.e. `getSlug: ({ node }) => { /* do something */ }`)
+
+  - `filter` _(function)_: Function to determine whether Swfitype should be
+    queried for the `Mdx` node. Useful if you only need to get related resources
+    for a subset of nodes on the site. By default, all `Mdx` nodes are fetched.
+    This function should accept an object as its only argument with a key of
+    `node` and a key of `slug` (i.e. `filter: ({ node, slug }) => { /* do something */ }`).
+
+  - `getParams` _(function)_: Function that allows you to specify additional
+    params passed to Swiftype when running a search query. Useful if you want to
+    provide additional filters or field boosts. This function should accept an
+    object as its only argument with a key of `node` and a key of `slug`.
+
+  - `limit` _(integer)_: The limit of related resources that should be fetched
+    from Swiftype.
+
+    - **Default**: `5`
+
 #### `i18n`
 
 Optional configuration for internationalization (i18n).
@@ -267,6 +328,11 @@ query {
   }
 }
 ```
+
+These values are also available as global CSS variables. You can access them as:
+
+- `maxWidth`: `var(--site-max-width)`
+- `contentPadding`: `var(--site-content-padding)`
 
 #### `prism`
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -344,7 +344,15 @@ const createFile = (filepath, data, { reporter, message } = {}) => {
 };
 
 const createRelatedResources = async (
-  { node, actions, createContentDigest, getNodesByType, getNode, createNodeId },
+  {
+    node,
+    actions,
+    createContentDigest,
+    getNodesByType,
+    getNode,
+    createNodeId,
+    reporter,
+  },
   options
 ) => {
   const { swiftype } = options;
@@ -390,7 +398,7 @@ const createRelatedResources = async (
   ] = getNodesByType('Site');
 
   const swiftypeResources = await getRelatedResources(
-    { node, slug, siteUrl },
+    { node, slug, siteUrl, reporter },
     swiftype
   );
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -421,13 +421,13 @@ const validateSwiftypeOptions = (swiftypeOptions) => {
 
   if (!resultsPath) {
     throw new Error(
-      "[@newrelic/gatsby-theme-newrelic] You have enabled swiftype searches, but the 'resultsPath' is not defined. Please define a 'relatedResources.swiftype.resultsPath' option"
+      "You have enabled swiftype searches, but the 'resultsPath' is not defined. Please define a 'relatedResources.swiftype.resultsPath' option"
     );
   }
 
   if (!engineKey) {
     throw new Error(
-      "[@newrelic/gatsby-theme-newrelic] You have enabled swiftype searches, but the 'engineKey' is missing. Please define a 'relatedResources.swiftype.engineKey' option"
+      "You have enabled swiftype searches, but the 'engineKey' is missing. Please define a 'relatedResources.swiftype.engineKey' option"
     );
   }
 };

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -81,7 +81,9 @@ exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
       message: 'Creating an empty related resources file',
     });
 
-    writeableRelatedResourceData = fs.readFileSync(resultsPath);
+    writeableRelatedResourceData = JSON.parse(
+      fs.readFileSync(resultsPath, { encoding: 'utf-8' })
+    );
   }
 };
 
@@ -358,7 +360,6 @@ const createRelatedResources = async (
   const { frontmatter = {} } = node;
 
   const resources = frontmatter.resources || [];
-  const redirects = frontmatter.redirects || [];
 
   resources.forEach((resource) => {
     const child = createRelatedResourceNode({
@@ -372,8 +373,7 @@ const createRelatedResources = async (
     createParentChildLink({ parent: node, child: child });
   });
 
-  const { getSlug, filter = () => true, getParams = () => ({}) } =
-    swiftype || {};
+  const { getSlug, filter = () => true } = swiftype || {};
 
   const slug = getSlug
     ? getSlug({ node })
@@ -383,21 +383,14 @@ const createRelatedResources = async (
     return;
   }
 
-  const params = getParams({ node, slug });
-
   const [
     {
       siteMetadata: { siteUrl },
     },
   ] = getNodesByType('Site');
 
-  const excludedUrls = resources
-    .map((resource) => resource.url)
-    .concat(redirects)
-    .map((url) => (url.startsWith('/') ? siteUrl + url : url));
-
   const swiftypeResources = await getRelatedResources(
-    { slug, siteUrl, params, excludedUrls },
+    { node, slug, siteUrl },
     swiftype
   );
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -84,38 +84,11 @@ exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
 
-  createTypes(`
-    type SiteLayout @dontInfer {
-      contentPadding: String
-      maxWidth: String
-    }
-
-    type MdxFrontmatter @infer {
-      startDate: Date @dateformat(formatString: "YYYY-MM-DD")
-      endDate: Date @dateformat(formatString: "YYYY-MM-DD")
-    }
-
-    type SiteSiteMetadata {
-      repository: String
-      utmSource: String
-      branch: String!
-      contributingUrl: String
-      title: String
-      titleTemplate: String
-    }
-
-    type Locale implements Node {
-      name: String!
-      locale: String!
-      isDefault: Boolean!
-    }
-
-    type RelatedResource implements Node {
-      id: ID!
-      title: String!
-      url: String!
-    }
-  `);
+  createTypes(
+    fs.readFileSync(path.resolve(__dirname, './gatsby/type-defs.graphql'), {
+      encoding: 'utf-8',
+    })
+  );
 };
 
 exports.sourceNodes = (

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -95,10 +95,10 @@ exports.sourceNodes = (
   { actions, createNodeId, createContentDigest },
   themeOptions
 ) => {
-  const { i18n = {} } = themeOptions;
+  const { i18n, relatedResources } = withDefaults(themeOptions);
   const { createNode } = actions;
 
-  (i18n.additionalLocales || []).concat(defaultLocale).forEach((locale) => {
+  i18n.locales.forEach((locale) => {
     const isDefault = locale.locale === defaultLocale.locale;
 
     const data = {
@@ -117,6 +117,29 @@ exports.sourceNodes = (
         contentDigest: createContentDigest(data),
       },
     });
+  });
+
+  const config = {
+    relatedResources: {
+      labels: Object.entries(relatedResources.labels).map(
+        ([baseUrl, label]) => ({
+          baseUrl,
+          label,
+        })
+      ),
+    },
+  };
+
+  createNode({
+    ...config,
+    id: createNodeId('@newrelic/gatsby-theme-newrelic:config'),
+    parent: null,
+    children: [],
+    internal: {
+      type: 'NewRelicThemeConfig',
+      contentDigest: createContentDigest(config),
+      content: JSON.stringify(config),
+    },
   });
 };
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -65,8 +65,11 @@ exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
       });
   }
 
-  if (swiftype.file && !fs.existsSync(swiftype.file)) {
-    fs.writeFileSync(swiftype.file, '{}');
+  if (swiftype.file) {
+    createFile(swiftype.file, '{}', {
+      reporter,
+      message: 'Creating an empty related resources file',
+    });
   }
 };
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -348,10 +348,12 @@ const createRelatedResources = async (
     return;
   }
 
-  const frontmatterResources =
-    (node.frontmatter && node.frontmatter.resources) || [];
+  const { frontmatter = {} } = node;
 
-  frontmatterResources.forEach((resource) => {
+  const resources = frontmatter.resources || [];
+  const redirects = frontmatter.redirects || [];
+
+  resources.forEach((resource) => {
     const child = createRelatedResourceNode({
       parent: node.id,
       resource,
@@ -382,14 +384,19 @@ const createRelatedResources = async (
     },
   ] = getNodesByType('Site');
 
-  const resources = await getRelatedResources(
-    { slug, siteUrl, params },
+  const excludedUrls = resources
+    .map((resource) => resource.url)
+    .concat(redirects)
+    .map((url) => (url.startsWith('/') ? siteUrl + url : url));
+
+  const swiftypeResources = await getRelatedResources(
+    { slug, siteUrl, params, excludedUrls },
     swiftype
   );
 
-  writeableRelatedResourceData[slug] = resources;
+  writeableRelatedResourceData[slug] = swiftypeResources;
 
-  resources.forEach((resource) => {
+  swiftypeResources.forEach((resource) => {
     const child = createRelatedResourceNode({
       parent: node.id,
       resource,

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -13,6 +13,7 @@ let writeableRelatedResourceData = {};
 
 const uniq = (arr) => [...new Set(arr)];
 
+const ANNOUNCEMENTS_DIRECTORY = 'src/announcements';
 const DEFAULT_BRANCH = 'main';
 
 const matchesLocale = (path, locale) =>
@@ -35,7 +36,10 @@ exports.onPreInit = (_, themeOptions) => {
 exports.onPreBootstrap = ({ reporter, store }, themeOptions) => {
   const { program } = store.getState();
   const imagePath = path.join(program.directory, 'src/images');
-  const announcementsPath = path.join(program.directory, 'src/announcements');
+  const announcementsPath = path.join(
+    program.directory,
+    ANNOUNCEMENTS_DIRECTORY
+  );
   const { relatedResources = {} } = themeOptions;
 
   createDirectory(imagePath, {
@@ -344,7 +348,10 @@ const createRelatedResources = async (
   const { swiftype } = options;
   const { createNode, createParentChildLink } = actions;
 
-  if (node.internal.type !== 'Mdx') {
+  if (
+    node.internal.type !== 'Mdx' ||
+    node.fileAbsolutePath.includes(ANNOUNCEMENTS_DIRECTORY)
+  ) {
     return;
   }
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -367,21 +367,24 @@ const createRelatedResources = async (
     createParentChildLink({ parent: node, child: child });
   });
 
-  const { getSlug, filter = () => true, getParams = () => ({}) } = swiftype;
+  const { getSlug, filter = () => true, getParams = () => ({}) } =
+    swiftype || {};
 
-  if (!swiftype || !filter({ node })) {
+  const slug = getSlug
+    ? getSlug({ node })
+    : createFilePath({ node, getNode, trailingSlash: false });
+
+  if (!swiftype || !filter({ node, slug })) {
     return;
   }
+
+  const params = getParams({ node, slug });
 
   const [
     {
       siteMetadata: { siteUrl },
     },
   ] = getNodesByType('Site');
-
-  const defaultSlug = createFilePath({ node, getNode, trailingSlash: false });
-  const slug = getSlug ? getSlug({ node }) : defaultSlug;
-  const params = getParams({ node, slug });
 
   const resources = await getRelatedResources(
     { slug, siteUrl, params },

--- a/packages/gatsby-theme-newrelic/gatsby/type-defs.graphql
+++ b/packages/gatsby-theme-newrelic/gatsby/type-defs.graphql
@@ -28,3 +28,16 @@ type RelatedResource implements Node {
   title: String!
   url: String!
 }
+
+type NewRelicThemeConfig implements Node {
+  relatedResources: NewRelicThemeRelatedResourceConfig!
+}
+
+type NewRelicThemeRelatedResourceConfig {
+  labels: [RelatedResourceLabel!]!
+}
+
+type RelatedResourceLabel {
+  baseUrl: String!
+  label: String!
+}

--- a/packages/gatsby-theme-newrelic/gatsby/type-defs.graphql
+++ b/packages/gatsby-theme-newrelic/gatsby/type-defs.graphql
@@ -1,0 +1,30 @@
+type SiteLayout @dontInfer {
+  contentPadding: String
+  maxWidth: String
+}
+
+type MdxFrontmatter @infer {
+  startDate: Date @dateformat(formatString: "YYYY-MM-DD")
+  endDate: Date @dateformat(formatString: "YYYY-MM-DD")
+}
+
+type SiteSiteMetadata {
+  repository: String
+  utmSource: String
+  branch: String!
+  contributingUrl: String
+  title: String
+  titleTemplate: String
+}
+
+type Locale implements Node {
+  name: String!
+  locale: String!
+  isDefault: Boolean!
+}
+
+type RelatedResource implements Node {
+  id: ID!
+  title: String!
+  url: String!
+}

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -29,6 +29,7 @@ export { default as NewRelicLogo } from './src/components/NewRelicLogo';
 export { default as Overlay } from './src/components/Overlay';
 export { default as PageTools } from './src/components/PageTools';
 export { default as Portal } from './src/components/Portal';
+export { default as RelatedResources } from './src/components/RelatedResources';
 export { default as SearchInput } from './src/components/SearchInput';
 export { default as SEO } from './src/components/SEO';
 export { default as SimpleFeedback } from './src/components/SimpleFeedback';

--- a/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
@@ -104,15 +104,17 @@ const RelatedResources = ({ resources, title }) => {
                   )}
                 </Link>
 
-                <Tag
-                  css={css`
-                    text-transform: uppercase;
-                    font-size: 0.5625rem;
-                    letter-spacing: 0.5px;
-                  `}
-                >
-                  {label}
-                </Tag>
+                {label && (
+                  <Tag
+                    css={css`
+                      text-transform: uppercase;
+                      font-size: 0.5625rem;
+                      letter-spacing: 0.5px;
+                    `}
+                  >
+                    {label}
+                  </Tag>
+                )}
               </li>
             );
           })}

--- a/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
@@ -60,8 +60,11 @@ const RelatedResources = ({ resources, title }) => {
             padding: 0;
           `}
         >
-          {resources.map((resource) => {
-            const { url } = resource;
+          {resources.map(({ url, title }) => {
+            if (url.startsWith(siteUrl)) {
+              url = url.replace(siteUrl, '');
+            }
+
             const label = isRelative(url)
               ? currentSiteLabel
               : findLabel(url, labels);
@@ -90,7 +93,7 @@ const RelatedResources = ({ resources, title }) => {
                       vertical-align: middle;
                     `}
                   >
-                    {resource.title}
+                    {title}
                   </span>
 
                   {!isRelative(url) && (

--- a/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
@@ -16,7 +16,7 @@ const findLabel = (url, labels) => {
   return label;
 };
 
-const Resources = ({ resources, title }) => {
+const RelatedResources = ({ resources, title }) => {
   const { t } = useThemeTranslation();
   const {
     site: {
@@ -122,7 +122,7 @@ const Resources = ({ resources, title }) => {
   );
 };
 
-Resources.propTypes = {
+RelatedResources.propTypes = {
   resources: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string.isRequired,
@@ -132,4 +132,4 @@ Resources.propTypes = {
   title: PropTypes.string,
 };
 
-export default Resources;
+export default RelatedResources;

--- a/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import { graphql, useStaticQuery } from 'gatsby';
+import PageTools from './PageTools';
+import Tag from './Tag';
+import Icon from './Icon';
+import Link from './Link';
+import useThemeTranslation from '../hooks/useThemeTranslation';
+
+const isRelative = (url) => url.startsWith('/');
+
+const findLabel = (url, labels) => {
+  const { label } = labels.find(({ baseUrl }) => url.startsWith(baseUrl)) || {};
+
+  return label;
+};
+
+const Resources = ({ resources, title }) => {
+  const { t } = useThemeTranslation();
+  const {
+    site: {
+      siteMetadata: { siteUrl },
+    },
+    newRelicThemeConfig: {
+      relatedResources: { labels },
+    },
+  } = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          siteUrl
+        }
+      }
+      newRelicThemeConfig {
+        relatedResources {
+          labels {
+            baseUrl
+            label
+          }
+        }
+      }
+    }
+  `);
+
+  if (resources.length === 0) {
+    return null;
+  }
+
+  const currentSiteLabel = findLabel(siteUrl, labels);
+
+  return (
+    <PageTools.Section>
+      <PageTools.Title>{title || t('relatedResources.title')}</PageTools.Title>
+      <nav>
+        <ul
+          css={css`
+            list-style: none;
+            margin: 0;
+            padding: 0;
+          `}
+        >
+          {resources.map((resource) => {
+            const { url } = resource;
+            const label = isRelative(url)
+              ? currentSiteLabel
+              : findLabel(url, labels);
+
+            return (
+              <li
+                key={url}
+                css={css`
+                  font-size: 0.875rem;
+                  margin-top: 0;
+
+                  &:not(:last-child) {
+                    margin-bottom: 0.75rem;
+                  }
+                `}
+              >
+                <Link
+                  to={url}
+                  css={css`
+                    display: block;
+                    margin-bottom: 0.25rem;
+                  `}
+                >
+                  <span
+                    css={css`
+                      vertical-align: middle;
+                    `}
+                  >
+                    {resource.title}
+                  </span>
+
+                  {!isRelative(url) && (
+                    <Icon
+                      name="fe-external-link"
+                      css={css`
+                        margin-left: 0.25rem;
+                        vertical-align: middle;
+                      `}
+                    />
+                  )}
+                </Link>
+
+                <Tag
+                  css={css`
+                    text-transform: uppercase;
+                    font-size: 0.5625rem;
+                    letter-spacing: 0.5px;
+                  `}
+                >
+                  {label}
+                </Tag>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </PageTools.Section>
+  );
+};
+
+Resources.propTypes = {
+  resources: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  title: PropTypes.string,
+};
+
+export default Resources;

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -47,6 +47,9 @@
     "cookiePolicy": "Cookie Policy",
     "ukSlaveryAct": "UK Slavery Act"
   },
+  "relatedResources": {
+    "title": "Related resources"
+  },
   "searchInput": {
     "placeholder": "Search Docs, Developer, Open Source"
   },

--- a/packages/gatsby-theme-newrelic/src/utils/defaultOptions.js
+++ b/packages/gatsby-theme-newrelic/src/utils/defaultOptions.js
@@ -6,6 +6,21 @@ const themeSupportedLocales = ['en'];
 
 const uniq = (arr) => [...new Set(arr)];
 
+const DEFAULT_SITE_LABELS = {
+  'https://developer.newrelic.com': 'developer',
+  'https://opensource.newrelic.com': 'open source',
+  'https://docs.newrelic.com': 'docs',
+  'https://github.com': 'github',
+  'https://terraform.io': 'terraform',
+  'https://kubernetes.io': 'kubernetes',
+  'https://youtube.com': 'youtube',
+  'https://discuss.newrelic.com': 'discuss',
+  'https://blog.newrelic.com': 'blog',
+  'https://newrelic.com': 'newrelic.com',
+  'https://marketplace.visualstudio.com': 'visual studio',
+  'https://learn.newrelic.com': 'learn',
+};
+
 const withDefaults = (themeOptions) => {
   const { i18n = {}, relatedResources = {} } = themeOptions;
   const { i18nextOptions = {} } = i18n;
@@ -14,6 +29,10 @@ const withDefaults = (themeOptions) => {
     ...themeOptions,
     relatedResources: {
       ...relatedResources,
+      labels: {
+        ...DEFAULT_SITE_LABELS,
+        ...(relatedResources.labels || {}),
+      },
       swiftype: relatedResources.swiftype
         ? { limit: 5, refetch: false, ...relatedResources.swiftype }
         : false,

--- a/packages/gatsby-theme-newrelic/src/utils/defaultOptions.js
+++ b/packages/gatsby-theme-newrelic/src/utils/defaultOptions.js
@@ -7,11 +7,17 @@ const themeSupportedLocales = ['en'];
 const uniq = (arr) => [...new Set(arr)];
 
 const withDefaults = (themeOptions) => {
-  const { i18n = {} } = themeOptions;
+  const { i18n = {}, relatedResources = {} } = themeOptions;
   const { i18nextOptions = {} } = i18n;
 
   return {
     ...themeOptions,
+    relatedResources: {
+      ...relatedResources,
+      swiftype: relatedResources.swiftype
+        ? { limit: 5, refetch: false, ...relatedResources.swiftype }
+        : false,
+    },
     i18n: {
       extract: true,
       ...themeOptions.i18n,

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/createRelatedResourceNode.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/createRelatedResourceNode.js
@@ -2,20 +2,21 @@ module.exports = ({
   createNode,
   createNodeId,
   createContentDigest,
-  resource,
+  resource: { title, url },
   parent,
 }) => {
+  const data = { title, url };
+
   const node = {
-    id: createNodeId(`RelatedResource-${resource.url}`),
-    title: resource.title,
-    url: resource.url,
+    ...data,
+    id: createNodeId(`RelatedResource-${url}`),
     parent,
     children: [],
-    plugin: 'gatsby-source-swiftype',
+    plugin: '@newrelic/gatsby-theme-newrelic',
     internal: {
       type: 'RelatedResource',
-      content: JSON.stringify(resource),
-      contentDigest: createContentDigest(resource),
+      content: JSON.stringify(data),
+      contentDigest: createContentDigest(data),
     },
   };
 

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
@@ -1,23 +1,17 @@
 const fs = require('fs');
 const search = require('./search');
 
-module.exports = async ({ pathname, node, siteUrl }, swiftypeOptions) => {
-  const {
-    refetch,
-    engineKey,
-    limit,
-    file,
-    getParams = () => ({}),
-  } = swiftypeOptions;
+module.exports = async ({ slug, params, siteUrl }, swiftypeOptions) => {
+  const { refetch, engineKey, limit, resultsPath } = swiftypeOptions;
 
   if (refetch) {
-    return search(siteUrl + pathname, getParams({ node }), {
+    return search(siteUrl + slug, params, {
       engineKey,
       limit,
     });
   }
 
-  const data = JSON.parse(fs.readFileSync(file));
+  const data = JSON.parse(fs.readFileSync(resultsPath));
 
-  return data[pathname] || [];
+  return data[slug] || [];
 };

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const search = require('./search');
+const { once } = require('lodash');
 
 const getExcludedUrls = (node, siteUrl) => {
   const { frontmatter = {} } = node;
@@ -12,7 +13,17 @@ const getExcludedUrls = (node, siteUrl) => {
     .map((url) => (url.startsWith('/') ? siteUrl + url : url));
 };
 
-module.exports = async ({ node, slug, siteUrl }, swiftypeOptions) => {
+const warn = once((reporter) => {
+  reporter.warn(
+    '[@newrelic/gatsby-theme-newrelic] You are attempting to fetch Swiftype ' +
+      'results for related resources in development mode. As a precaution, ' +
+      'this has been disabled to prevent the accidental execution of queries ' +
+      'for large sites. Please disable the `relatedResources.swiftype.refetch` ' +
+      'flag in development to hide this warning.'
+  );
+});
+
+module.exports = async ({ node, slug, siteUrl, reporter }, swiftypeOptions) => {
   const {
     refetch,
     engineKey,
@@ -21,7 +32,15 @@ module.exports = async ({ node, slug, siteUrl }, swiftypeOptions) => {
     getParams = () => ({}),
   } = swiftypeOptions;
 
-  if (refetch) {
+  const isProdEnv = process.env.NODE_ENV === 'production';
+
+  if (refetch && !isProdEnv) {
+    warn(reporter);
+  }
+
+  // Force disable refetch if in development mode to prevent us from
+  // accidentally triggering potentially many queries
+  if (refetch && isProdEnv) {
     const { frontmatter = {} } = node;
     const defaultParams = { q: frontmatter.title };
     const params = getParams({ node, slug });

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const search = require('./search');
-const { once } = require('lodash');
+const { once, memoize } = require('lodash');
 
 const getExcludedUrls = (node, siteUrl) => {
   const { frontmatter = {} } = node;
@@ -40,10 +40,12 @@ const getResultsFromSwiftype = ({ node, siteUrl, slug }, swiftypeOptions) => {
   );
 };
 
-const getLocalResults = ({ slug }, swiftypeOptions) => {
-  const { resultsPath } = swiftypeOptions;
+const readResultsFromLocalFile = memoize((resultsPath) =>
+  JSON.parse(fs.readFileSync(resultsPath, { encoding: 'utf-8' }))
+);
 
-  const data = JSON.parse(fs.readFileSync(resultsPath));
+const getLocalResults = ({ slug }, swiftypeOptions) => {
+  const data = readResultsFromLocalFile(swiftypeOptions.resultsPath);
 
   return data[slug] || [];
 };

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
@@ -1,13 +1,17 @@
 const fs = require('fs');
 const search = require('./search');
 
-module.exports = async ({ slug, params, siteUrl }, swiftypeOptions) => {
+module.exports = async (
+  { slug, params, siteUrl, excludedUrls },
+  swiftypeOptions
+) => {
   const { refetch, engineKey, limit, resultsPath } = swiftypeOptions;
 
   if (refetch) {
     return search(siteUrl + slug, params, {
       engineKey,
       limit,
+      excludedUrls,
     });
   }
 

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
@@ -1,18 +1,40 @@
 const fs = require('fs');
 const search = require('./search');
 
-module.exports = async (
-  { slug, params, siteUrl, excludedUrls },
-  swiftypeOptions
-) => {
-  const { refetch, engineKey, limit, resultsPath } = swiftypeOptions;
+const getExcludedUrls = (node, siteUrl) => {
+  const { frontmatter = {} } = node;
+  const resources = frontmatter.resources || [];
+  const redirects = frontmatter.redirects || [];
+
+  return resources
+    .map((resource) => resource.url)
+    .concat(redirects)
+    .map((url) => (url.startsWith('/') ? siteUrl + url : url));
+};
+
+module.exports = async ({ node, slug, siteUrl }, swiftypeOptions) => {
+  const {
+    refetch,
+    engineKey,
+    limit,
+    resultsPath,
+    getParams = () => ({}),
+  } = swiftypeOptions;
 
   if (refetch) {
-    return search(siteUrl + slug, params, {
-      engineKey,
-      limit,
-      excludedUrls,
-    });
+    const { frontmatter = {} } = node;
+    const defaultParams = { q: frontmatter.title };
+    const params = getParams({ node, slug });
+
+    return search(
+      siteUrl + slug,
+      { ...defaultParams, ...params },
+      {
+        engineKey,
+        limit,
+        excludedUrls: getExcludedUrls(node, siteUrl),
+      }
+    );
   }
 
   const data = JSON.parse(fs.readFileSync(resultsPath));

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/search.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/search.js
@@ -13,7 +13,11 @@ const normalizeUrl = (url) => {
 
 const uniq = (arr) => [...new Set(arr)];
 
-module.exports = async (url, params = {}, { engineKey, limit }) => {
+module.exports = async (
+  url,
+  params = {},
+  { engineKey, limit, excludedUrls }
+) => {
   const { page: pageFilters = {} } = params.filters || {};
 
   const res = await fetch(
@@ -32,6 +36,7 @@ module.exports = async (url, params = {}, { engineKey, limit }) => {
           page: {
             ...pageFilters,
             url: uniq([
+              ...excludedUrls.flatMap((url) => normalizeUrl(`!${url}`)),
               ...normalizeUrl(`!${url}`),
               ...(pageFilters.url || []).flatMap(normalizeUrl),
             ]),


### PR DESCRIPTION
Relates to https://github.com/newrelic/docs-website/issues/427

[README updates](https://github.com/newrelic/gatsby-theme-newrelic/tree/jerel/related-resources/packages/gatsby-theme-newrelic)

# Description

Adds a `RelatedResources` component that can be used in the right rail of the site.

This PR also makes some tweaks to the related resource configuration. The theme now provides the related resources framework without the need to enable Swiftype. Out-of-the-box, related resources will now be sourced from frontmatter for all non-announcement `Mdx` nodes. The swiftype configuration has now been moved to the `relatedResources` config.

Some additional features worthy of mention:

* Force disable refetching in development mode. Will now show a warning if `refetch` is set to try and you run `gatsby develop`. This will help prevent accidental Swiftype queries for our sites, which can get costly fast.
* Filters out urls from resources and redirects specified in frontmatter for Swiftype search query
* Defaults the search query to the page title if a `q` param is not specified via `getParams`

## Screenshots

<img width="358" alt="Screen Shot 2021-02-04 at 12 36 10 AM" src="https://user-images.githubusercontent.com/565661/106866181-02e04a80-6681-11eb-9867-7adbfd95111f.png">



