### PR TITLE
Minor image + link style changes

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -59,6 +59,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 1200,
+              linkImagesToOriginal: false,
             },
           },
         ],

--- a/demo/src/pages/build-apps/build-hello-world-app.mdx
+++ b/demo/src/pages/build-apps/build-hello-world-app.mdx
@@ -124,6 +124,12 @@ When your new application opens, notice that it doesn't display any helpful desc
 
 ![An empty application description in the catalog](./images/catalog-description-empty.png)
 
+<figcaption>
+
+This is a custom caption that goes under the image
+
+</figcaption>
+
 ## Add details to describe your project
 
 Now that your new application is in the New Relic One catalog, you can add details that help users understand what your application does and how to use it.

--- a/demo/src/templates/basic.js
+++ b/demo/src/templates/basic.js
@@ -17,30 +17,40 @@ const BasicTemplate = ({ data, location }) => {
   } = data;
 
   return (
-    <Layout.Main
-      css={css`
-        display: grid;
-        grid-template-areas: 'content page-tools';
-        grid-template-columns: minmax(0, 1fr) 320px;
-        grid-column-gap: var(--site-content-padding);
-      `}
-    >
+    <>
       <SEO location={location} title={frontmatter.title} />
-      <h1>{frontmatter.title}</h1>
-      <Layout.Content>
-        <MarkdownContainer>
-          <MDX body={body} />
-        </MarkdownContainer>
-      </Layout.Content>
+      <Layout.Main
+        css={css`
+          display: grid;
+          grid-template-areas:
+            'page-title page-tools'
+            'content page-tools';
+          grid-template-columns: minmax(0, 1fr) 320px;
+          grid-column-gap: var(--site-content-padding);
+        `}
+      >
+        <h1
+          css={css`
+            grid-area: page-title;
+          `}
+        >
+          {frontmatter.title}
+        </h1>
+        <Layout.Content>
+          <MarkdownContainer>
+            <MDX body={body} />
+          </MarkdownContainer>
+        </Layout.Content>
 
-      <Layout.PageTools>
-        <ContributingGuidelines
-          fileRelativePath={fields.fileRelativePath}
-          pageTitle={frontmatter.title}
-        />
-        <RelatedResources resources={relatedResources} />
-      </Layout.PageTools>
-    </Layout.Main>
+        <Layout.PageTools>
+          <ContributingGuidelines
+            fileRelativePath={fields.fileRelativePath}
+            pageTitle={frontmatter.title}
+          />
+          <RelatedResources resources={relatedResources} />
+        </Layout.PageTools>
+      </Layout.Main>
+    </>
   );
 };
 

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -122,6 +122,7 @@ const Button = styled.button`
   border: 1px solid transparent;
   transition: all 0.15s ease-out;
   white-space: nowrap;
+  text-decoration: none;
 
   ${({ variant }) => styles.variant[variant]}
   ${({ size }) => styles.size[size]}

--- a/packages/gatsby-theme-newrelic/src/components/Dropdown/MenuItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Dropdown/MenuItem.js
@@ -16,6 +16,7 @@ const MenuItem = ({ as, children, href, onClick }) => {
         font-size: 0.75rem;
         transition: all 0.2s ease-out;
         color: var(--text-color);
+        text-decoration: none;
 
         &:hover {
           color: var(--text-color);

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -184,6 +184,7 @@ const GlobalHeader = ({ className }) => {
                 -ms-overflow-style: -ms-autohiding-scrollbar;
 
                 > li {
+                  margin: 0;
                   flex: 0 0 auto;
                 }
               `}

--- a/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
@@ -35,6 +35,7 @@ const GlobalNavLink = ({ children, href }) => {
         color: var(--secondary-text-color);
         font-size: 0.6875rem;
         transition: 0.2s;
+        text-decoration: none;
 
         ${isCurrentSite && '&,'}
         &:hover {

--- a/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
@@ -38,11 +38,11 @@ const GlobalNavLink = ({ children, href }) => {
 
         ${isCurrentSite && '&,'}
         &:hover {
-          background-color: var(--color-neutrals-200);
+          background-color: var(--color-neutrals-300);
           color: var(--color-neutrals-700);
 
           .dark-mode & {
-            background-color: var(--color-dark-200);
+            background-color: var(--color-dark-300);
             color: var(--color-dark-700);
           }
         }

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -39,7 +39,6 @@ const GlobalStyles = ({ layout }) => (
 
       a {
         cursor: pointer;
-        text-decoration: none;
         color: var(--link-color);
         transition: 0.2s ease-out;
 

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -201,6 +201,11 @@ const GlobalStyles = ({ layout }) => (
         }
       }
 
+      figcaption {
+        font-size: 0.75rem;
+        color: var(--accent-text-color);
+      }
+
       .gatsby-resp-image-wrapper,
       .gatsby-resp-image-image,
       .gatsby-resp-image-background-image {

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -201,6 +201,12 @@ const GlobalStyles = ({ layout }) => (
           background: var(--color-brand-500);
         }
       }
+
+      .gatsby-resp-image-wrapper,
+      .gatsby-resp-image-image,
+      .gatsby-resp-image-background-image {
+        border-radius: 0.25rem;
+      }
     `}
   />
 );

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/themes.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/themes.js
@@ -13,8 +13,8 @@ export default css`
     --tertiary-background-color: var(--color-neutrals-200);
 
     --accent-text-color: var(--color-neutrals-500);
-    --link-color: var(--color-brand-600);
-    --link-hover-color: var(--color-brand-500);
+    --link-color: var(--color-brand-500);
+    --link-hover-color: var(--color-brand-300);
     --border-color: var(--color-neutrals-400);
     --border-hover-color: var(--color-neutrals-500);
     --divider-color: var(--color-neutrals-100);

--- a/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
@@ -29,6 +29,10 @@ const MarkdownContainer = ({
         blockquote:not(:last-child) {
           margin-bottom: var(--block-element-spacing);
         }
+
+        figcaption {
+          margin-bottom: var(--text-spacing);
+        }
       `}
     >
       {children}

--- a/packages/gatsby-theme-newrelic/src/components/NavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/NavLink.js
@@ -35,6 +35,7 @@ const NavLink = ({
         padding: 0.5rem var(--nav-link-padding);
         margin: 0 calc(var(--nav-link-padding) * -1);
         font-size: 0.875rem;
+        text-decoration: none;
 
         &:hover {
           color: var(--primary-text-hover-color);

--- a/packages/gatsby-theme-newrelic/src/components/Surface.js
+++ b/packages/gatsby-theme-newrelic/src/components/Surface.js
@@ -34,6 +34,7 @@ const styles = {
 const Surface = styled.div`
   border-radius: 0.25rem;
   box-shadow: var(--shadow-3);
+  text-decoration: none;
 
   ${({ base }) => styles.base[base]};
 

--- a/packages/gatsby-theme-newrelic/src/components/Tag.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tag.js
@@ -15,6 +15,7 @@ const Tag = styled.span`
   font-size: 0.75rem;
   transition: all 0.07s cubic-bezier(0.25, 0.46, 0.45, 0.94);
   backface-visibility: hidden;
+  text-decoration: none;
 
   .dark-mode & {
     color: var(--color-dark-700);


### PR DESCRIPTION
# Description

* Add a small border radius around images to make them feel more like they are
  part of the page
* Links now use text decoration. We had some feedback that links were difficult
  to decipher for colorblind folks. Talking with @djsauble, we decided that
  adding text decoration to links was a good move.

![localhost_8001_build-apps_build-hello-world-app](https://user-images.githubusercontent.com/565661/107103902-4a2b2000-67d4-11eb-808b-1d5e825f3dcf.png)

