### PR TITLE
Add support for opening all collapsers via query param

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -1,10 +1,11 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import Icon from './Icon';
 import { animated, useSpring } from 'react-spring';
 import { usePrevious, useIsomorphicLayoutEffect } from 'react-use';
 import useKeyPress from '../hooks/useKeyPress';
+import useQueryParams from '../hooks/useQueryParams';
 
 const ResizeObserver = global.ResizeObserver || class ResizeObserver {};
 
@@ -16,6 +17,15 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
   const previousIsOpen = usePrevious(isOpen);
 
   useKeyPress(['s', 'f', 'h'], (e) => setIsOpen(e.key !== 'h'));
+
+  const { queryParams } = useQueryParams();
+
+  useEffect(() => {
+    setIsOpen(
+      queryParams.has('collapsers') &&
+        queryParams.get('collapsers') === 'showAll'
+    );
+  });
 
   const observer = useMemo(
     () =>

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -10,22 +10,19 @@ import useQueryParams from '../hooks/useQueryParams';
 const ResizeObserver = global.ResizeObserver || class ResizeObserver {};
 
 const Collapser = ({ title, id, defaultOpen, children }) => {
+  const { queryParams } = useQueryParams();
   const [element, ref] = useState();
-  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [isOpen, setIsOpen] = useState(() => {
+    return queryParams.has('collapsers') &&
+      queryParams.get('collapsers') === 'openAll'
+      ? true
+      : defaultOpen;
+  });
   const [height, setHeight] = useState(0);
   const { height: viewHeight } = useSpring({ height: isOpen ? height : 0 });
   const previousIsOpen = usePrevious(isOpen);
 
   useKeyPress(['s', 'f', 'h'], (e) => setIsOpen(e.key !== 'h'));
-
-  const { queryParams } = useQueryParams();
-
-  useEffect(() => {
-    setIsOpen(
-      queryParams.has('collapsers') &&
-        queryParams.get('collapsers') === 'openAll'
-    );
-  });
 
   const observer = useMemo(
     () =>

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -23,7 +23,7 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
   useEffect(() => {
     setIsOpen(
       queryParams.has('collapsers') &&
-        queryParams.get('collapsers') === 'showAll'
+        queryParams.get('collapsers') === 'openAll'
     );
   });
 

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/core';
 import Icon from './Icon';

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -14,7 +14,7 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
   const [element, ref] = useState();
   const [isOpen, setIsOpen] = useState(() => {
     return queryParams.has('collapsers') &&
-      queryParams.get('collapsers') === 'openAll'
+      queryParams.get('collapsers') === 'open'
       ? true
       : defaultOpen;
   });

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/Collapser.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/Collapser.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
+import { LocationProvider } from '@reach/router';
 import Collapser from '../Collapser';
 
 test('hides collapser content by default', () => {
   render(
-    <Collapser title="The title">The content inside the callout</Collapser>
+    <LocationProvider>
+      <Collapser title="The title">The content inside the callout</Collapser>
+    </LocationProvider>
   );
 
   expect(screen.getByText(/The content/)).toHaveAttribute(
@@ -15,9 +18,11 @@ test('hides collapser content by default', () => {
 
 test('allows collapser to be open by default', () => {
   render(
-    <Collapser defaultOpen title="The title">
-      The content inside the callout
-    </Collapser>
+    <LocationProvider>
+      <Collapser defaultOpen title="The title">
+        The content inside the callout
+      </Collapser>
+    </LocationProvider>
   );
 
   expect(screen.getByText(/The content/)).toHaveAttribute(
@@ -28,7 +33,9 @@ test('allows collapser to be open by default', () => {
 
 test('opens the collapser by pressing the "s" key', () => {
   render(
-    <Collapser title="The title">The content inside the callout</Collapser>
+    <LocationProvider>
+      <Collapser title="The title">The content inside the callout</Collapser>
+    </LocationProvider>
   );
 
   fireEvent.keyDown(document.body, { key: 's' });
@@ -41,7 +48,9 @@ test('opens the collapser by pressing the "s" key', () => {
 
 test('opens the collapser by pressing the "f" key', () => {
   render(
-    <Collapser title="The title">The content inside the callout</Collapser>
+    <LocationProvider>
+      <Collapser title="The title">The content inside the callout</Collapser>
+    </LocationProvider>
   );
 
   fireEvent.keyDown(document.body, { key: 'f' });

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/Collapser.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/Collapser.test.js
@@ -1,11 +1,21 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import { LocationProvider } from '@reach/router';
+import {
+  createMemorySource,
+  createHistory,
+  LocationProvider,
+} from '@reach/router';
 import Collapser from '../Collapser';
+
+let history = createHistory(window);
+
+// for some types of tests you want a memory source
+let source = createMemorySource('/index?collapsers=open');
+let historyWithQueryParam = createHistory(source);
 
 test('hides collapser content by default', () => {
   render(
-    <LocationProvider>
+    <LocationProvider history={history}>
       <Collapser title="The title">The content inside the callout</Collapser>
     </LocationProvider>
   );
@@ -18,7 +28,7 @@ test('hides collapser content by default', () => {
 
 test('allows collapser to be open by default', () => {
   render(
-    <LocationProvider>
+    <LocationProvider history={history}>
       <Collapser defaultOpen title="The title">
         The content inside the callout
       </Collapser>
@@ -31,9 +41,22 @@ test('allows collapser to be open by default', () => {
   );
 });
 
+test('opens collapser via query param', () => {
+  render(
+    <LocationProvider history={historyWithQueryParam}>
+      <Collapser title="The title">The content inside the callout</Collapser>
+    </LocationProvider>
+  );
+
+  expect(screen.getByText(/The content/)).toHaveAttribute(
+    'aria-hidden',
+    'false'
+  );
+});
+
 test('opens the collapser by pressing the "s" key', () => {
   render(
-    <LocationProvider>
+    <LocationProvider history={history}>
       <Collapser title="The title">The content inside the callout</Collapser>
     </LocationProvider>
   );
@@ -48,7 +71,7 @@ test('opens the collapser by pressing the "s" key', () => {
 
 test('opens the collapser by pressing the "f" key', () => {
   render(
-    <LocationProvider>
+    <LocationProvider history={history}>
       <Collapser title="The title">The content inside the callout</Collapser>
     </LocationProvider>
   );


### PR DESCRIPTION
Closes [docs-website/795](https://github.com/newrelic/docs-website/issues/795)

## Description
Adds support for opening all collapsers via query param: `collapsers=openAll`. This is particularly useful when uploading contexts to Smartling so all content is visible to translators.