### PR TITLE
Add a useInstrumentedHandler hook

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -86,6 +86,7 @@ websites](https://opensource.newrelic.com).
   - [`useActiveHash`](#useactivehash)
   - [`useClipboard`](#useclipboard)
   - [`useFormattedCode`](#useformattedcode)
+  - [`useInstrumentedHandler`](#useinstrumentedhandler)
   - [`useKeyPress`](#usekeypress)
   - [`useLayout`](#uselayout)
   - [`useQueryParams`](#usequeryparams)
@@ -2611,6 +2612,63 @@ With formatting options:
 
 ```js
 const formattedCode = useFormattedCode(code, { printWidth: 100 });
+```
+
+### `useInstrumentedHandler`
+
+A hook that wraps a function handler with New Relic Browser instrumentation.
+
+```js
+import { useInstrumentedHandler } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Arguments**
+
+- `handler` _(function)_: The function hander that should be augmented with New
+  Relic Browser instrumentation. This can be `null` or `undefined`.
+- `attributes` _(object | function)_: Data passed to the
+  [`newrelic.addPageAction`](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action)
+  API when called. The attributes **MUST** contain an `actionName` property,
+  otherwise the handler will not be instrumented. All other attributes will be
+  attached to the `attributes` property of the page action. You can pass a
+  function to instrument dynamic data. If this is a function, the function will
+  be called with the same arguments passed to the handler.
+
+**Returns**
+
+`function` - The wrapped function handler to be instrumented with New Relic
+Browser.
+
+**Examples**
+
+```js
+const MyComponent = () => {
+  const handleClick = useInstrumentedHandler(() => console.log('clicked'), {
+    actionName: 'click',
+  });
+
+  return (
+    <Button onClick={handleClick} variant="normal">
+      Click me
+    </Button>
+  );
+};
+```
+
+**Dynamic data**
+
+```js
+const MyComponent = () => {
+  const handler = useInstrumentedHandler(
+    (a, b) => add(a, b),
+    (a, b) => ({
+      actionName: 'add',
+      sum: a + b,
+    })
+  );
+
+  return <Counter adder={handler} />;
+};
 ```
 
 ### `useKeyPress`

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -49,6 +49,7 @@ export { default as formatCode } from './src/utils/formatCode';
 export { default as useActiveHash } from './src/hooks/useActiveHash';
 export { default as useClipboard } from './src/hooks/useClipboard';
 export { default as useFormattedCode } from './src/hooks/useFormattedCode';
+export { default as useInstrumentedHandler } from './src/hooks/useInstrumentedHandler';
 export { default as useKeyPress } from './src/hooks/useKeyPress';
 export { default as useLayout } from './src/hooks/useLayout';
 export { default as useLocale } from './src/hooks/useLocale';

--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
@@ -1,0 +1,121 @@
+import useInstrumentedHandler from '../useInstrumentedHandler';
+import { renderHook } from '@testing-library/react-hooks';
+
+const originalError = console.error;
+
+global.newrelic = {
+  addPageAction: jest.fn(),
+};
+
+afterEach(() => {
+  console.error = originalError;
+  global.newrelic.addPageAction.mockClear();
+});
+
+test('instruments page action and calls original handler with all arguments', () => {
+  const originalHandler = jest.fn();
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(originalHandler, { actionName: 'click' })
+  );
+
+  result.current(1, 2);
+
+  expect(originalHandler).toHaveBeenCalledTimes(1);
+  expect(originalHandler).toHaveBeenCalledWith(1, 2);
+  expect(global.newrelic.addPageAction).toHaveBeenCalledTimes(1);
+  expect(global.newrelic.addPageAction).toHaveBeenCalledWith('click', {});
+});
+
+test('attaches any additional fields in config as attributes', () => {
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(jest.fn(), { actionName: 'click', darkMode: true })
+  );
+
+  result.current();
+
+  expect(global.newrelic.addPageAction).toHaveBeenCalledWith('click', {
+    darkMode: true,
+  });
+});
+
+test('original return value is maintained', () => {
+  const originalHandler = () => 'tacos';
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(originalHandler, { actionName: 'click' })
+  );
+
+  const returnValue = result.current();
+
+  expect(returnValue).toEqual('tacos');
+});
+
+test('successfully instruments call if original handler is not set', () => {
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(null, { actionName: 'click' })
+  );
+
+  result.current('clicked!');
+
+  expect(global.newrelic.addPageAction).toHaveBeenCalledWith('click', {});
+});
+
+test('allows config argument to be a function called with the handler arguments', () => {
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(jest.fn(), (a, b) => ({
+      actionName: 'add',
+      sum: a + b,
+    }))
+  );
+
+  result.current(2, 2);
+
+  expect(global.newrelic.addPageAction).toHaveBeenCalledWith('add', { sum: 4 });
+});
+
+test('does not instrument the request if newrelic is not installed', () => {
+  const originalNewRelic = global.newrelic;
+  global.newrelic = null;
+
+  const originalHandler = jest.fn();
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(originalHandler, { actionName: 'not called' })
+  );
+
+  expect(() => result.current()).not.toThrow();
+  expect(originalHandler).toHaveBeenCalled();
+
+  global.newrelic = originalNewRelic;
+});
+
+test('warns if actionName is not set', () => {
+  console.error = jest.fn();
+
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(jest.fn(), { name: 'click' })
+  );
+
+  result.current();
+
+  expect(console.error).toHaveBeenCalledWith(
+    expect.stringContaining(
+      'You are attempting to instrument a handler, but the `actionName` property is not set. This will result in a no-op.'
+    )
+  );
+});
+
+test('does not warn if newrelic is not installed', () => {
+  const originalNewRelic = global.newrelic;
+
+  global.newrelic = null;
+  console.error = jest.fn();
+
+  const { result } = renderHook(() =>
+    useInstrumentedHandler(jest.fn(), { name: 'click' })
+  );
+
+  result.current();
+
+  expect(console.error).not.toHaveBeenCalled();
+
+  global.newrelic = originalNewRelic;
+});

--- a/packages/gatsby-theme-newrelic/src/hooks/useInstrumentedHandler.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useInstrumentedHandler.js
@@ -19,9 +19,7 @@ const useInstrumentedHandler = (handler, attributes) => {
           'You are attempting to instrument a handler, but the `actionName` property is not set. This will result in a no-op.'
         );
 
-        if (actionName) {
-          actionName && window.newrelic.addPageAction(actionName, attrs);
-        }
+        actionName && window.newrelic.addPageAction(actionName, attrs);
       }
 
       if (savedHandler.current) {

--- a/packages/gatsby-theme-newrelic/src/hooks/useInstrumentedHandler.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useInstrumentedHandler.js
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react';
+import warning from 'warning';
+
+const useInstrumentedHandler = (handler, attributes) => {
+  const savedHandler = useRef();
+
+  useEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
+  return useCallback(
+    (...args) => {
+      const { actionName, ...attrs } =
+        typeof attributes === 'function' ? attributes(...args) : attributes;
+
+      if (window.newrelic) {
+        warning(
+          actionName,
+          'You are attempting to instrument a handler, but the `actionName` property is not set. This will result in a no-op.'
+        );
+
+        if (actionName) {
+          actionName && window.newrelic.addPageAction(actionName, attrs);
+        }
+      }
+
+      if (savedHandler.current) {
+        return savedHandler.current(...args);
+      }
+    },
+    [attributes]
+  );
+};
+
+export default useInstrumentedHandler;


### PR DESCRIPTION
Adds a `useInstrumentedHandler` hook to easily augment handlers with `newrelic.addPageAction` calls.
