### PR TITLE
Simplify yes/no GH issue template copy

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GitHubIssueButton.js
+++ b/packages/gatsby-theme-newrelic/src/components/GitHubIssueButton.js
@@ -9,15 +9,9 @@ import UAParser from 'ua-parser-js';
 const generatePageContextMarkdown = ({ pageUrl }) => {
   const { os, browser, device } = new UAParser().getResult();
 
-  return `
-## Additional context
+  return `### Doc information (don't delete this section)
 
-[NOTE]: # (PLEASE DO NOT DELETE THIS SECTION. This contains useful information for the team.)
-
-### Page
-${pageUrl}
-
-### Environment
+* ${pageUrl}
 * ${getEnvironmentString('OS', os.name, os.version)}
 * ${getEnvironmentString('Browser', browser.name, browser.version)}
 * ${getEnvironmentString(

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -10,22 +10,27 @@ import useThemeTranslation from '../hooks/useThemeTranslation';
 import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
 
 const POSITIVE_ISSUE_BODY = `
-## Feedback
+### Tell us more about your feedback
 
-[NOTE]: # (Please put any feedback you have here)
-[TIP]: # (We'd love to hear what you like!)
+We're glad to hear this doc was helpful! We've recorded your feedback. Help us 
+improve other content by telling us what worked and what didn't:
+
+* What worked well in this doc?
+* How could we make this doc even better?
 `;
 
 const NEGATIVE_ISSUE_BODY = `
-## Feedback
+### Tell us more about your feedback
 
-[NOTE]: # (Please put any feedback you have here)
-[TIP]: # (Help us figure out what we could be doing better)
+Sorry to hear this doc wasn't helpful, but we'd love to make it better! We've 
+recorded your feedback. Help us improve this content by providing more info:
+
+* How can we improve this doc?
 `;
 
 const SimpleFeedback = ({ pageTitle, labels = [] }) => {
   const { t } = useThemeTranslation();
-  const issueTitle = pageTitle ? `Feedback: ${pageTitle}` : 'Website feedback';
+  const issueTitle = pageTitle ? `Feedback: ${pageTitle}` : 'Docs feedback';
 
   const handleClick = useInstrumentedHandler(null, (feedback) => ({
     actionName: 'feedback_click',


### PR DESCRIPTION
Related to https://github.com/newrelic/docs-website/pull/900 .

This PR simplifies the copy for GH issues resulting from yes/no button clicks.

**Reviewer notes**

This line in SimpleFeedback.js

```  const issueTitle = pageTitle ? `Feedback: ${pageTitle}` : 'Docs feedback';```

Seems to imply that the issue title will include the page title (which would be helpful in scanning issues). But the code doesn't seem to actually be working, at least on docs-preview.newrelic.com