### PR TITLE
Fix reference to undefined variable

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -30,11 +30,11 @@ const trackViaTessen = ({ location }, themeOptions) => {
   window.initializeTessenTracking = initializeTessenTracking({
     config: tessenConfig,
     env,
-    location
+    location,
   });
 
   window.initializeTessenTracking();
-  
+
   // wrap inside a timeout to make sure react-helmet is done with its changes (https://github.com/gatsbyjs/gatsby/issues/11592)
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
@@ -52,7 +52,7 @@ const trackPageView = ({ config, env, location }) => {
     ...properties
   } = pageView;
 
-  const tessen = createTessen(tessenConfig);
+  const tessen = createTessen(config);
 
   if (!canSendPageView(pageView)) {
     return warnAboutNoop(pageView);


### PR DESCRIPTION
## Description

The theme contains an error when booting up the site due to a reference to an undefined variable. This PR fixes the reference to that variable.
