### PR TITLE
Care about casing on key press events

### DIFF
--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useKeyPress.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useKeyPress.js
@@ -86,6 +86,16 @@ test('ignores whitespace', () => {
   expect(handler).toHaveBeenCalledTimes(1);
 });
 
+test('handles case sensitive keys', () => {
+  const handler = jest.fn();
+
+  renderHook(() => useKeyPress('ArrowDown', handler));
+
+  fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+  expect(handler).toHaveBeenCalledTimes(1);
+});
+
 test('allows multiple keys to be specified', () => {
   const handler = jest.fn();
 

--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useKeyPress.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useKeyPress.js
@@ -76,20 +76,10 @@ test('handles alt key', () => {
   expect(handler).toHaveBeenCalledTimes(1);
 });
 
-test('does not care about casing', () => {
-  const handler = jest.fn();
-
-  renderHook(() => useKeyPress('sHiFt+B', handler));
-
-  fireEvent.keyDown(document.body, { key: 'b', shiftKey: true });
-
-  expect(handler).toHaveBeenCalledTimes(1);
-});
-
 test('ignores whitespace', () => {
   const handler = jest.fn();
 
-  renderHook(() => useKeyPress('ctrl  + C', handler));
+  renderHook(() => useKeyPress('ctrl  + c', handler));
 
   fireEvent.keyDown(document.body, { key: 'c', ctrlKey: true });
 

--- a/packages/gatsby-theme-newrelic/src/hooks/useKeyPress.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useKeyPress.js
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import useDeepMemo from './useDeepMemo';
 
 const normalizeKeyCombination = (keys) => {
-  const [modifier, k] = keys.toLowerCase().split(/\s*\+\s*/);
+  const [modifier, k] = keys.split(/\s*\+\s*/);
 
   return k == null ? [null, modifier] : [modifier, k];
 };


### PR DESCRIPTION
## Description

`useKeyPress` currently lowercases the keys passed to the handler before it checks if a match occurs. For most key presses, this is fine, but for some, casing matter. This PR ensures casing is maintained so that matches against keys like `ArrowUp` or `ArrowDown` function as expected.
