### PR TITLE
fix(Table): Vertically align the text in cells to the top of the cell instead of the center

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Table.js
+++ b/packages/gatsby-theme-newrelic/src/components/Table.js
@@ -21,6 +21,7 @@ const Table = ({ className, children }) => (
         th {
           min-width: 5rem;
           padding: 0.5rem 1rem;
+          vertical-align: top;
         }
 
         tr {


### PR DESCRIPTION
Closes https://github.com/newrelic/docs-website/issues/879

## Description

We've had a good amount of feedback about the table cell alignment and wanting that vertically aligned to the top. This PR updates the table component to vertically align cells to the top.

## Screenshots

**Before**
<img width="794" alt="Screen Shot 2021-02-25 at 11 58 32 PM" src="https://user-images.githubusercontent.com/565661/109272403-ad9de180-77c5-11eb-962f-6afbc5fe8e7d.png">

**After**
<img width="782" alt="Screen Shot 2021-02-25 at 11 58 20 PM" src="https://user-images.githubusercontent.com/565661/109272422-b4c4ef80-77c5-11eb-955f-d03ad5258467.png">


