### PR TITLE
Don't show cookie consent until the client has rendered

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -3,6 +3,9 @@ require('dotenv').config({
 });
 
 module.exports = {
+  flags: {
+    DEV_SSR: true,
+  },
   siteMetadata: {
     repository: 'https://github.com/newrelic/gatsby-theme-newrelic',
     siteUrl: 'https://developer.newrelic.com',

--- a/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
+++ b/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
@@ -25,7 +25,8 @@ const CookieConsentDialog = () => {
 
     Cookies.set(TRACKING_COOKIE_NAME, String(answer), options);
     setIsCookieSet(true);
-    if (answer) {
+
+    if (answer && window.initializeTessenTracking) {
       window.initializeTessenTracking({ trackPageView: true });
     }
   };

--- a/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
+++ b/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
@@ -5,10 +5,12 @@ import ExternalLink from './ExternalLink';
 import Button from './Button';
 import Trans from './Trans';
 import useThemeTranslation from '../hooks/useThemeTranslation';
+import useHasMounted from '../hooks/useHasMounted';
 import { TRACKING_COOKIE_NAME } from '../utils/constants';
 
 const CookieConsentDialog = () => {
   const { t } = useThemeTranslation();
+  const hasMounted = useHasMounted();
   const [isCookieSet, setIsCookieSet] = useState(
     Cookies.get(TRACKING_COOKIE_NAME)
   );
@@ -28,9 +30,10 @@ const CookieConsentDialog = () => {
     }
   };
 
-  if (isCookieSet) {
+  if (isCookieSet || !hasMounted) {
     return null;
   }
+
   return (
     <div
       css={css`


### PR DESCRIPTION
## Description

When loading our sites, the cookie consent dialog will show briefly before disappearing when a user has accepted cookies. The flash of content is less than ideal. This PR ensures the cookie consent is only shown once the component has rendered on the client to prevent that flash.
