### PR TITLE
fix: li>p element should not have a bottom margin

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
@@ -24,6 +24,11 @@ const MarkdownContainer = ({
           &:not(:last-child) {
             margin-bottom: var(--text-spacing);
           }
+          li {
+            p:last-of-type {
+              margin-bottom: 0;
+            }
+          }
         }
 
         blockquote:not(:last-child) {


### PR DESCRIPTION
~~@jerelmiller Though this could impact lists that expect a margin... ;-)~~

Edit: as requested now only changes the `MarkdownContainer` styles for this list style issue

fixes https://github.com/newrelic/docs-website/issues/945

https://github.com/newrelic/docs-website/pull/1110