### PR TITLE
Tracks tessen for sign up links and allows to specify additional props to the event

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
@@ -60,7 +60,7 @@ ExternalLink.propTypes = {
   children: PropTypes.node,
   href: PropTypes.string,
   onClick: PropTypes.func,
-  trackingProps: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  instrumentation: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 };
 
 export default ExternalLink;

--- a/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
@@ -9,14 +9,25 @@ import { useLocation } from '@reach/router';
 const isNewRelic = (to) => to.startsWith('https://newrelic.com');
 const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 
-const ExternalLink = ({ children, onClick, href, component, ...props }) => {
+const ExternalLink = ({
+  children,
+  onClick,
+  href,
+  trackingProps = {},
+  ...props
+}) => {
   const locale = useLocale();
   const tessen = useTessen();
   const location = useLocation();
+  const properties =
+    typeof trackingProps === 'string'
+      ? { customProp: trackingProps }
+      : trackingProps;
 
   const handleClick = useInstrumentedHandler(onClick, {
     actionName: 'externalLink_click',
     href: href,
+    ...properties,
   });
 
   const link = isNewRelic(href)
@@ -28,7 +39,7 @@ const ExternalLink = ({ children, onClick, href, component, ...props }) => {
     tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
       href: link,
       path: location.pathname,
-      component,
+      ...properties,
     });
   };
 
@@ -49,6 +60,7 @@ ExternalLink.propTypes = {
   children: PropTypes.node,
   href: PropTypes.string,
   onClick: PropTypes.func,
+  trackingProps: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 };
 
 export default ExternalLink;

--- a/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
@@ -3,26 +3,40 @@ import PropTypes from 'prop-types';
 import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
 import { localizeExternalLink } from '../utils/localization';
 import useLocale from '../hooks/useLocale';
+import useTessen from '../hooks/useTessen';
+import { useLocation } from '@reach/router';
 
 const isNewRelic = (to) => to.startsWith('https://newrelic.com');
+const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 
-const ExternalLink = ({ children, onClick, href, ...props }) => {
+const ExternalLink = ({ children, onClick, href, component, ...props }) => {
   const locale = useLocale();
+  const tessen = useTessen();
+  const location = useLocation();
+
+  const handleClick = useInstrumentedHandler(onClick, {
+    actionName: 'externalLink_click',
+    href: href,
+  });
 
   const link = isNewRelic(href)
     ? localizeExternalLink({ link: href, locale })
     : href;
 
-  const handleClick = useInstrumentedHandler(onClick, {
-    actionName: 'externalLink_click',
-    href: link,
-  });
+  const trackSignUp = () => {
+    handleClick();
+    tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
+      href: link,
+      path: location.pathname,
+      component,
+    });
+  };
 
   return (
     <a
       {...props}
       href={link}
-      onClick={handleClick}
+      onClick={isSignup(href) ? trackSignUp : handleClick}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
@@ -34,7 +34,7 @@ const ExternalLink = ({
     ? localizeExternalLink({ link: href, locale })
     : href;
 
-  const trackSignUp = () => {
+  const trackSignUp = (event) => {
     handleClick();
     tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
       href: link,

--- a/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
@@ -13,16 +13,16 @@ const ExternalLink = ({
   children,
   onClick,
   href,
-  trackingProps = {},
+  instrumentation = {},
   ...props
 }) => {
   const locale = useLocale();
   const tessen = useTessen();
   const location = useLocation();
   const properties =
-    typeof trackingProps === 'string'
-      ? { customProp: trackingProps }
-      : trackingProps;
+    typeof instrumentation === 'string'
+      ? { customProp: instrumentation }
+      : instrumentation;
 
   const handleClick = useInstrumentedHandler(onClick, {
     actionName: 'externalLink_click',

--- a/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/ExternalLink.js
@@ -1,66 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
-import { localizeExternalLink } from '../utils/localization';
-import useLocale from '../hooks/useLocale';
-import useTessen from '../hooks/useTessen';
-import { useLocation } from '@reach/router';
+import Link from './Link';
 
-const isNewRelic = (to) => to.startsWith('https://newrelic.com');
-const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
-
-const ExternalLink = ({
-  children,
-  onClick,
-  href,
-  instrumentation = {},
-  ...props
-}) => {
-  const locale = useLocale();
-  const tessen = useTessen();
-  const location = useLocation();
-  const properties =
-    typeof instrumentation === 'string'
-      ? { customProp: instrumentation }
-      : instrumentation;
-
-  const handleClick = useInstrumentedHandler(onClick, {
-    actionName: 'externalLink_click',
-    href: href,
-    ...properties,
-  });
-
-  const link = isNewRelic(href)
-    ? localizeExternalLink({ link: href, locale })
-    : href;
-
-  const trackSignUp = (event) => {
-    handleClick();
-    tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
-      href: link,
-      path: location.pathname,
-      ...properties,
-    });
-  };
-
-  return (
-    <a
-      {...props}
-      href={link}
-      onClick={isSignup(href) ? trackSignUp : handleClick}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {children}
-    </a>
-  );
+const ExternalLink = ({ href, ...props }) => {
+  return <Link to={href} {...props} />;
 };
 
 ExternalLink.propTypes = {
-  children: PropTypes.node,
   href: PropTypes.string,
-  onClick: PropTypes.func,
-  instrumentation: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 };
 
 export default ExternalLink;

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -426,7 +426,7 @@ const GlobalHeader = ({ className }) => {
                 }`}
                 size={Button.SIZE.EXTRA_SMALL}
                 variant={Button.VARIANT.PRIMARY}
-                trackingProperties={{ component: 'GlobalHeader' }}
+                instrumentation={{ component: 'GlobalHeader' }}
               >
                 <span>{t('button.signUp')}</span>
               </Button>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -51,11 +51,6 @@ const GlobalHeader = ({ className }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const { t } = useThemeTranslation();
 
-  const handleSignupClick = useInstrumentedHandler(null, {
-    actionName: 'signup_click',
-    component: 'GlobalHeader',
-  });
-
   const {
     allLocale: { nodes: locales },
     site,
@@ -426,12 +421,12 @@ const GlobalHeader = ({ className }) => {
             >
               <Button
                 as={ExternalLink}
-                onClick={handleSignupClick}
                 href={`https://newrelic.com/signup${
                   utmSource ? `?utm_source=${utmSource}` : ''
                 }`}
                 size={Button.SIZE.EXTRA_SMALL}
                 variant={Button.VARIANT.PRIMARY}
+                trackingProperties={{ component: 'GlobalHeader' }}
               >
                 <span>{t('button.signUp')}</span>
               </Button>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -15,7 +15,6 @@ import GlobalNavLink from './GlobalNavLink';
 import SearchInput from './SearchInput';
 import useMedia from 'use-media';
 import { useLocation } from '@reach/router';
-import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
 import useQueryParams from '../hooks/useQueryParams';
 import useLocale from '../hooks/useLocale';
 import useThemeTranslation from '../hooks/useThemeTranslation';

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -13,7 +13,7 @@ const isExternal = (to) => to.startsWith('http');
 const isNewRelic = (to) => to.startsWith('https://newrelic.com');
 const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 
-const Link = ({ to, onClick, instrumentation, ...props }) => {
+const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
   const locale = useLocale();
   const tessen = useTessen();
   const location = useLocation();

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -47,12 +47,11 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
 
   const trackSignUp = (event) => {
     handleExternalLinkClick();
-    tessen &&
-      tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
-        href: link,
-        path: location.pathname,
-        ...properties,
-      });
+    tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
+      href: link,
+      path: location.pathname,
+      ...properties,
+    });
   };
 
   if (to.startsWith(siteUrl)) {

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -32,15 +32,10 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
     }
   `);
 
-  const properties =
-    typeof instrumentation === 'string'
-      ? { customProp: instrumentation }
-      : instrumentation;
-
   const handleExternalLinkClick = useInstrumentedHandler(onClick, {
     actionName: 'externalLink_click',
     href: to,
-    ...properties,
+    ...instrumentation,
   });
 
   const link = isNewRelic(to) ? localizeExternalLink({ link: to, locale }) : to;
@@ -50,7 +45,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
     tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
       href: link,
       path: location.pathname,
-      ...properties,
+      ...instrumentation,
     });
   };
 
@@ -80,7 +75,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
 Link.propTypes = {
   onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
-  instrumentation: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  instrumentation: PropTypes.object),
 };
 
 export default Link;

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -37,7 +37,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
       ? { customProp: instrumentation }
       : instrumentation;
 
-  const handleClick = useInstrumentedHandler(onClick, {
+  const handleExternalLinkClick = useInstrumentedHandler(onClick, {
     actionName: 'externalLink_click',
     href: to,
     ...properties,
@@ -46,7 +46,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
   const link = isNewRelic(to) ? localizeExternalLink({ link: to, locale }) : to;
 
   const trackSignUp = (event) => {
-    handleClick();
+    handleExternalLinkClick();
     tessen &&
       tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
         href: link,
@@ -68,7 +68,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
       <a
         {...props}
         href={link}
-        onClick={isSignup(to) ? trackSignUp : handleClick}
+        onClick={isSignup(to) ? trackSignUp : handleExternalLinkClick}
         target="_blank"
         rel="noopener noreferrer"
       />

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -75,7 +75,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
 Link.propTypes = {
   onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
-  instrumentation: PropTypes.object),
+  instrumentation: PropTypes.object,
 };
 
 export default Link;

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -3,19 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, Link as GatsbyLink } from 'gatsby';
 import useLocale from '../hooks/useLocale';
-import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
-import { localizePath, localizeExternalLink } from '../utils/localization';
+import { localizePath } from '../utils/localization';
+import ExternalLink from './ExternalLink';
 
 const isHash = (to) => to.startsWith('#');
 const isExternal = (to) => to.startsWith('http');
-const isNewRelic = (to) => to.startsWith('https://newrelic.com');
 
 const Link = ({ to, onClick, ...props }) => {
   const locale = useLocale();
-  const handleExternalLinkClick = useInstrumentedHandler(onClick, {
-    actionName: 'externalLink_click',
-    href: to,
-  });
 
   const {
     site: {
@@ -40,18 +35,7 @@ const Link = ({ to, onClick, ...props }) => {
   }
 
   if (isExternal(to)) {
-    const link = isNewRelic(to)
-      ? localizeExternalLink({ link: to, locale })
-      : to;
-    return (
-      <a
-        href={link}
-        onClick={handleExternalLinkClick}
-        target="_blank"
-        rel="noopener noreferrer"
-        {...props}
-      />
-    );
+    return <ExternalLink href={to} onClick={onClick} {...props} />;
   }
 
   return <GatsbyLink to={localizePath({ path: to, locale })} {...props} />;

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -47,11 +47,12 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
 
   const trackSignUp = (event) => {
     handleClick();
-    tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
-      href: link,
-      path: location.pathname,
-      ...properties,
-    });
+    tessen &&
+      tessen.track('stitchedPathLinkClick', 'DocPageLinkClick', {
+        href: link,
+        path: location.pathname,
+        ...properties,
+      });
   };
 
   if (to.startsWith(siteUrl)) {

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/CodeBlock.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/CodeBlock.test.js
@@ -3,11 +3,6 @@ import CodeBlock from '../CodeBlock';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { renderWithTranslation } from '../../test-utils/renderHelpers';
 
-jest.mock('tessen', () => ({
-  page: () => {},
-  track: () => {},
-}));
-
 jest.mock('gatsby', () => ({
   __esModule: true,
   graphql: () => {},

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/CodeBlock.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/CodeBlock.test.js
@@ -3,6 +3,11 @@ import CodeBlock from '../CodeBlock';
 import { render, fireEvent, screen } from '@testing-library/react';
 import { renderWithTranslation } from '../../test-utils/renderHelpers';
 
+jest.mock('tessen', () => ({
+  page: () => {},
+  track: () => {},
+}));
+
 jest.mock('gatsby', () => ({
   __esModule: true,
   graphql: () => {},

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/CodeBlock.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/CodeBlock.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import CodeBlock from '../CodeBlock';
 import { render, fireEvent, screen } from '@testing-library/react';
-import { renderWithTranslation } from '../../test-utils/renderHelpers';
+import { renderWithProviders } from '../../test-utils/renderHelpers';
 
 jest.mock('gatsby', () => ({
   __esModule: true,
@@ -24,11 +24,17 @@ jest.mock('gatsby', () => ({
         repository: 'https://foobar.net',
       },
     },
+    newRelicThemeConfig: {
+      tessen: {
+        product: 'foo',
+        subproduct: 'foobar',
+      },
+    },
   }),
 }));
 
 test('renders embedded var tag', () => {
-  const { container } = renderWithTranslation(
+  const { container } = renderWithProviders(
     <CodeBlock language="graphql">{`
 query MyQuery(<var>$accountId</var>: ID!) {
   account(accountId: <var>$accountId</var>) {
@@ -46,7 +52,7 @@ query MyQuery(<var>$accountId</var>: ID!) {
 });
 
 test('renders embedded mark tags', () => {
-  const { container } = renderWithTranslation(
+  const { container } = renderWithProviders(
     <CodeBlock language="graphql">{`
 query <mark>MyQuery</mark>($accountId: ID!) {
   <mark>account(accountId: $accountId) {
@@ -66,7 +72,7 @@ query <mark>MyQuery</mark>($accountId: ID!) {
 });
 
 test('renders embedded anchor tags', () => {
-  const { container } = renderWithTranslation(
+  const { container } = renderWithProviders(
     <CodeBlock language="graphql">{`
 query MyQuery($accountId: ID!) {
   <a href="/docs/nerd-graph">account</a>(accountId: $accountId) {
@@ -84,7 +90,7 @@ query MyQuery($accountId: ID!) {
 });
 
 test('handles combinations of tags', () => {
-  const { container } = renderWithTranslation(
+  const { container } = renderWithProviders(
     <CodeBlock language="graphql">{`
 query MyQuery($accountId: ID!) {
   <a href="/docs/nerd-graph"><var>account</var></a>(accountId: $accountId) {
@@ -102,7 +108,7 @@ query MyQuery($accountId: ID!) {
 });
 
 test('leaves text as-is if other HTML tags are used', () => {
-  const { container, debug } = renderWithTranslation(
+  const { container, debug } = renderWithProviders(
     <CodeBlock language="graphql">{`
 query <span>MyQuery</span>($accountId: ID!) {
   account(<strong>accountId</strong>: $accountId) {
@@ -120,7 +126,7 @@ query <span>MyQuery</span>($accountId: ID!) {
 });
 
 test('leaves var/mark/a tags as raw text when language is html', () => {
-  const { container } = renderWithTranslation(
+  const { container } = renderWithProviders(
     <CodeBlock language="html">{`
     <!DOCTYPE html>
     <html>
@@ -143,7 +149,7 @@ test('leaves var/mark/a tags as raw text when language is html', () => {
 });
 
 test('handles xml tags if no language is specified', () => {
-  const { container } = renderWithTranslation(
+  const { container } = renderWithProviders(
     <CodeBlock>{`
 <dependency>
   <groupId>com.newrelic.agent.java</groupId>

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -26,6 +26,25 @@ i18n.init({
   },
 });
 
+jest.mock('gatsby', () => ({
+  __esModule: true,
+  graphql: () => {},
+  useStaticQuery: () => ({
+    site: {
+      siteMetadata: {
+        siteUrl: 'https://github.com/foo/bar',
+        repository: 'https://foobar.net',
+      },
+    },
+    newRelicThemeConfig: {
+      tessen: {
+        product: 'foo',
+        subproduct: 'foobar',
+      },
+    },
+  }),
+}));
+
 // Defining these here AND in the mock due to a limitation with jest
 // https://github.com/facebook/jest/issues/2567
 const REPO = 'https://foobar.net';

--- a/packages/gatsby-theme-newrelic/src/test-utils/renderHelpers.js
+++ b/packages/gatsby-theme-newrelic/src/test-utils/renderHelpers.js
@@ -2,6 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { themeNamespace } from '../utils/defaultOptions';
 import { I18nextProvider } from 'react-i18next';
+import {
+  LocationProvider,
+  createHistory,
+  createMemorySource,
+} from '@reach/router';
 import LocaleProvider from '../components/LocaleProvider';
 import translations from '../i18n/translations/en.json';
 import i18n from 'i18next';
@@ -30,6 +35,38 @@ export const renderWithTranslation = (component, options) => {
     <I18nextProvider i18n={i18n}>
       <LocaleProvider i18n={i18n}>{component}</LocaleProvider>
     </I18nextProvider>,
+    options
+  );
+};
+
+export const renderWithProviders = (component, options) => {
+  i18n.init({
+    defaultNS: 'translation',
+    initImmediate: false,
+    fallbackLng: 'en',
+    lng: 'en',
+    ns: [themeNamespace, 'translation'],
+    resources: {
+      en: {
+        [themeNamespace]: translations,
+      },
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+    react: {
+      useSuspense: false,
+    },
+  });
+
+  const history = createHistory(createMemorySource('/'));
+
+  return render(
+    <LocationProvider history={history}>
+      <I18nextProvider i18n={i18n}>
+        <LocaleProvider i18n={i18n}>{component}</LocaleProvider>
+      </I18nextProvider>
+    </LocationProvider>,
     options
   );
 };


### PR DESCRIPTION
tested it by console logging the event (because there was a no-op due to tessen not being configured for the demo site. Tracks when you click signup buttons, but not when you click a regular old external link. 

Also uses the external link component instead of `a` tag to separate actions for external links and links in general. 
Addresses https://github.com/newrelic/docs-website/issues/1113 once the theme is updated