### PR TITLE
fix(nav): on search the item collapse should work

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/NavItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/NavItem.js
@@ -52,10 +52,10 @@ const NavItem = ({ page, __parent: parent, __depth: depth = 0 }) => {
   }, [hasChangedPage, shouldExpand]);
 
   useEffect(() => {
-    if (matchesSearch && !isExpanded) {
+    if (matchesSearch && !shouldExpand) {
       setIsExpanded(true);
     }
-  }, [matchesSearch, isExpanded, searchTerm]);
+  }, [matchesSearch, shouldExpand, searchTerm]);
 
   useLayoutEffect(() => {
     if (!searchTerm) {


### PR DESCRIPTION
fixes https://github.com/newrelic/docs-website/issues/938

cases (demo app):

 * Nav search for "relic" displays all items containing "relic" and the collapse works
   * Then search "data" displays all items containing "data" (previous collapsed are no longer collapsed) and the collapse works 