### PR TITLE
fix(global-search): when cancelling a search the search input is cleared

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchInput.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchInput.js
@@ -141,6 +141,7 @@ const SearchInput = forwardRef(
               margin: 0;
               padding: 0;
               outline: none;
+              z-index: 123;
             `}
             type="button"
           >


### PR DESCRIPTION
fixes https://github.com/newrelic/docs-website/issues/937

Type "test" in the global search
Click the "x"... global search is cleared (previously was not)