### PR TITLE
fix(search): invalid css

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchInput.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchInput.js
@@ -162,7 +162,7 @@ const SearchInput = forwardRef(
               transform: translateY(-50%);
               border: 1px solid var(--border-color);
               line-height: 1;
-              text-align: middle;
+              text-align: center;
               background: var(--color-neutrals-100);
 
               ${styles.size[size].hotkey}


### PR DESCRIPTION
While solving a few other search-component issues I noticed that the search component had invalid css;

#### How did I notice this?

 * Well the IDE said it is invalid css.. and I know that it is.

#### How was this never noticed before?

 * Bad CI linting
 * Someone editing in notepad?

#### How could this ever have happened?

 * Someone editing in notepad?
