### PR TITLE
Initializes tessen only once

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -82,8 +82,6 @@ const initializeTessenTracking = ({ config, env, location }) => (
       },
     });
 
-    window.Tessen.debugLevel(2);
-
     window.Tessen.identify({});
 
     options.trackPageView && trackPageView({ config, env, location });


### PR DESCRIPTION
We were not recording updates on our pages because we were initialize tessen a bunch of times. As a result, we were initializing Segment and NR a bunch of times as well, which let to downstream errors that prevented us from recording our data. This should ensure that we only call initialize once!