### PR TITLE
Do not add trailing slash to links with extension

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/__tests__/Link.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/Link.test.js
@@ -298,4 +298,21 @@ describe('when forceTrailingSlashes is enabled', () => {
     expect(link2).toHaveAttribute('href', '/test/path/#example');
     expect(link3).toHaveAttribute('href', '/test/path/?test=true');
   });
+
+  test('does not append trailing slash to links with extension', () => {
+    useStaticData({
+      newRelicThemeConfig: {
+        forceTrailingSlashes: true,
+      },
+    });
+
+    renderWithProviders(<Link to="/test/path.xml">XML</Link>);
+    renderWithProviders(<Link to="/test/path.json">JSON</Link>);
+
+    const xmlLink = screen.getByText('XML');
+    const jsonLink = screen.getByText('JSON');
+
+    expect(xmlLink).toHaveAttribute('href', '/test/path.xml');
+    expect(jsonLink).toHaveAttribute('href', '/test/path.json');
+  });
 });

--- a/packages/gatsby-theme-newrelic/src/utils/location.js
+++ b/packages/gatsby-theme-newrelic/src/utils/location.js
@@ -8,7 +8,7 @@ export const addTrailingSlash = (path) => {
   const dummyOrigin = 'https://example.com';
   const url = new URL(path, dummyOrigin);
 
-  if (!url.pathname.endsWith('/')) {
+  if (!url.pathname.endsWith('/') && !url.pathname.match(/\.[a-zA-Z]+$/)) {
     url.pathname = `${url.pathname}/`;
   }
 


### PR DESCRIPTION
## Description

Ensures links to locations with an extension (i.e. `.json`, `.xml`) do not add a trailing slash, even if `forceTrailingSlashes` is configured. This fixes the RSS feed links for release notes on the docs site.
