### PR TITLE
Add an issueLabels prop to forward to CreateIssueButton

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
+++ b/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
@@ -9,7 +9,12 @@ import CreateIssueButton from './CreateIssueButton';
 import EditPageButton from './EditPageButton';
 import Trans from './Trans';
 
-const ContributingGuidelines = ({ className, fileRelativePath, pageTitle }) => {
+const ContributingGuidelines = ({
+  className,
+  fileRelativePath,
+  issueLabels,
+  pageTitle,
+}) => {
   const {
     site: {
       siteMetadata: { contributingUrl },
@@ -51,6 +56,7 @@ const ContributingGuidelines = ({ className, fileRelativePath, pageTitle }) => {
           variant={Button.VARIANT.OUTLINE}
           size={Button.SIZE.SMALL}
           instrumentation={{ component: 'ContributingGuidelines' }}
+          labels={issueLabels}
         />
 
         {fileRelativePath && (
@@ -82,6 +88,7 @@ const ContributingGuidelines = ({ className, fileRelativePath, pageTitle }) => {
 ContributingGuidelines.propTypes = {
   className: PropTypes.string,
   fileRelativePath: PropTypes.string,
+  issueLabels: CreateIssueButton.propTypes.labels,
   pageTitle: PropTypes.string,
 };
 


### PR DESCRIPTION
Relates to https://github.com/newrelic/docs-website/issues/1206

## Description

We added the ability to make `issues` a prop to our `CreateIssueButton` component (#311), but we forgot that the component is used inside of `ContributingGuidelines`. This PR adds a prop to forward to `CreateIssueButton` so that we can override the labels for the create issue button.

