### PR TITLE
Add swiftype type field for all NR subdomains

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -41,7 +41,7 @@ const SEO = ({ title, location, children }) => {
   const getSwiftypeSiteType = () => {
     const nrSubDomain = /.*\.newrelic\.com/.test(location.hostname)
       ? location.hostname.split('.')[0]
-      : 'demo';
+      : null;
     const localeString = locale.isDefault ? '' : `-${locale.locale}`;
     return nrSubDomain ? nrSubDomain.concat(localeString) : null;
   };

--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -67,7 +67,11 @@ const SEO = ({ title, location, children }) => {
         );
       })}
       {getSwiftypeSiteType() && (
-        <meta class="swiftype" name="type" content={getSwiftypeSiteType()} />
+        <meta
+          className="swiftype"
+          name="type"
+          content={getSwiftypeSiteType()}
+        />
       )}
       {children}
     </Helmet>
@@ -78,6 +82,7 @@ SEO.propTypes = {
   title: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string,
+    hostname: PropTypes.string,
   }).isRequired,
   children: PropTypes.node,
 };

--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -38,6 +38,14 @@ const SEO = ({ title, location, children }) => {
       ? location.pathname
       : location.pathname.replace(new RegExp(`^\\/${locale.locale}`), '/');
 
+  const getSwiftypeSiteType = () => {
+    const nrSubDomain = /.*\.newrelic\.com/.test(location.hostname)
+      ? location.hostname.split('.')[0]
+      : null;
+    const localeString = !locale.isDefault ? `-${locale.locale}` : '';
+    return nrSubDomain ? nrSubDomain.concat(localeString) : null;
+  };
+
   return (
     <Helmet titleTemplate={template}>
       <html lang={locale.hrefLang} />
@@ -58,6 +66,9 @@ const SEO = ({ title, location, children }) => {
           />
         );
       })}
+      {getSwiftypeSiteType() && (
+        <meta class="swiftype" name="type" content={getSwiftypeSiteType()} />
+      )}
       {children}
     </Helmet>
   );

--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -39,8 +39,9 @@ const SEO = ({ title, location, children }) => {
       : location.pathname.replace(new RegExp(`^\\/${locale.locale}`), '/');
 
   const getSwiftypeSiteType = () => {
-    const nrSubDomain = /.*\.newrelic\.com/.test(location.hostname)
-      ? location.hostname.split('.')[0]
+    const hostname = new URL(siteUrl).hostname;
+    const nrSubDomain = /.*\.newrelic\.com/.test(hostname)
+      ? hostname.split('.')[0]
       : null;
     const localeString = locale.isDefault ? '' : `-${locale.locale}`;
     return nrSubDomain ? nrSubDomain.concat(localeString) : null;
@@ -83,7 +84,6 @@ SEO.propTypes = {
   title: PropTypes.string,
   location: PropTypes.shape({
     pathname: PropTypes.string,
-    hostname: PropTypes.string,
   }).isRequired,
   children: PropTypes.node,
 };

--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -41,7 +41,7 @@ const SEO = ({ title, location, children }) => {
   const getSwiftypeSiteType = () => {
     const nrSubDomain = /.*\.newrelic\.com/.test(location.hostname)
       ? location.hostname.split('.')[0]
-      : null;
+      : 'demo';
     const localeString = !locale.isDefault ? `-${locale.locale}` : '';
     return nrSubDomain ? nrSubDomain.concat(localeString) : null;
   };
@@ -70,6 +70,7 @@ const SEO = ({ title, location, children }) => {
         <meta
           className="swiftype"
           name="type"
+          data-type="enum"
           content={getSwiftypeSiteType()}
         />
       )}

--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -42,7 +42,7 @@ const SEO = ({ title, location, children }) => {
     const nrSubDomain = /.*\.newrelic\.com/.test(location.hostname)
       ? location.hostname.split('.')[0]
       : 'demo';
-    const localeString = !locale.isDefault ? `-${locale.locale}` : '';
+    const localeString = locale.isDefault ? '' : `-${locale.locale}`;
     return nrSubDomain ? nrSubDomain.concat(localeString) : null;
   };
 


### PR DESCRIPTION
Adds some logic to `<SEO />` component to get New Relic subdomain value from `siteMetaData.siteUrl` and the locale of the page if it's not the default (so any language other than English) and set the swiftype `type` field. Those values are currently set to the subdomain value in the Swiftype index.

Does not generate the meta tag if not on a New Relic subdomain (ex: localhost)

This requires opensource, docs, and developer sites to remove the code they use to generate the `type` field.

### Example meta tags
Docs site (English)

     <meta class="swiftype" name="type" data-type="enum" content="docs">

Docs site (Japanese)

    <meta class="swiftype" name="type" data-type="enum" content="docs-jp">

## Related issues
- https://github.com/newrelic/docs-website/issues/1204