### PR TITLE
chore: adds issuelabel prop to global footer

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -16,7 +16,12 @@ import Link from './Link';
 // the footer
 const copyrightSymbol = String.fromCharCode(169);
 
-const GlobalFooter = ({ fileRelativePath, className, pageTitle }) => {
+const GlobalFooter = ({
+  fileRelativePath,
+  className,
+  pageTitle,
+  issueLabels,
+}) => {
   const { t } = useThemeTranslation();
   const { site, sitePage } = useStaticQuery(graphql`
     query FooterQuery {
@@ -99,6 +104,7 @@ const GlobalFooter = ({ fileRelativePath, className, pageTitle }) => {
               fileRelativePath={fileRelativePath}
               variant={Button.VARIANT.OUTLINE}
               size={Button.SIZE.SMALL}
+              labels={issueLabels}
               instrumentation={{ component: 'GlobalFooter' }}
             />
           )}

--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -92,6 +92,7 @@ const GlobalFooter = ({
               pageTitle={pageTitle}
               variant={Button.VARIANT.OUTLINE}
               size={Button.SIZE.SMALL}
+              labels={issueLabels}
               instrumentation={{ component: 'GlobalFooter' }}
               css={css`
                 margin-right: 0.5rem;
@@ -104,7 +105,6 @@ const GlobalFooter = ({
               fileRelativePath={fileRelativePath}
               variant={Button.VARIANT.OUTLINE}
               size={Button.SIZE.SMALL}
-              labels={issueLabels}
               instrumentation={{ component: 'GlobalFooter' }}
             />
           )}
@@ -202,6 +202,7 @@ GlobalFooter.propTypes = {
   fileRelativePath: PropTypes.string,
   className: PropTypes.string,
   pageTitle: PropTypes.string,
+  issueLabels: CreateIssueButton.propTypes.labels,
 };
 
 export default GlobalFooter;


### PR DESCRIPTION
This PR adds an issueLabels prop to the global footer so we can define the type of label that is attached to an issue when a user clicks create issue on the Docs Site. Given the changes implemented here:

https://github.com/newrelic/docs-website/issues/1206

I think this will just `work` after this is merged and we bump the theme on the docs site. 🤞 