### PR TITLE
Support search for locale pages with translated content

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -82,6 +82,8 @@ const GlobalHeader = ({ className }) => {
 
   const locale = useLocale();
 
+  console.log(locale.locale);
+
   return (
     <>
       <AnnouncementBanner />
@@ -125,6 +127,7 @@ const GlobalHeader = ({ className }) => {
                 margin: 3rem auto;
                 height: calc(100vh - 6rem);
               `}
+              locale={locale}
             />
           </Overlay>
           <nav

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -82,8 +82,6 @@ const GlobalHeader = ({ className }) => {
 
   const locale = useLocale();
 
-  console.log(locale.locale);
-
   return (
     <>
       <AnnouncementBanner />
@@ -127,7 +125,6 @@ const GlobalHeader = ({ className }) => {
                 margin: 3rem auto;
                 height: calc(100vh - 6rem);
               `}
-              locale={locale}
             />
           </Overlay>
           <nav

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -19,13 +19,14 @@ import useQueryParams from '../hooks/useQueryParams';
 import useThemeTranslation from '../hooks/useThemeTranslation';
 import useInstrumentedData from '../hooks/useInstrumentedData';
 import usePrevious from '../hooks/usePrevious';
+import useLocale from '../hooks/useLocale';
 
 const connector = new SiteSearchAPIConnector({
   documentType: 'page',
   engineKey: 'Ad9HfGjDw4GRkcmJjUut',
 });
 
-const configOptions = {
+const swiftypeConfig = {
   apiConnector: connector,
   searchQuery: {
     result_fields: {
@@ -48,7 +49,7 @@ const configOptions = {
     filters: [
       {
         field: 'type',
-        values: ['docs', 'developer', 'opensource'],
+        values: defaultSwiftypeFilters,
         type: 'any',
       },
       {
@@ -63,60 +64,48 @@ const configOptions = {
   },
 };
 
-const getSwiftypeConfig = (locale) => {
-  const typeValues = locale.isDefault
-    ? ['docs', 'developer', 'opensource']
-    : [
+const defaultSwiftypeFilters = [
+  {
+    field: 'type',
+    values: ['docs', 'developer', 'opensource'],
+    type: 'any',
+  },
+  {
+    field: 'document_type',
+    values: ['!views_page_menu', '!views_page_content'],
+    type: 'any',
+  },
+];
+
+const SwiftypeSearch = ({ className }) => {
+  const { setQueryParam } = useQueryParams();
+  const { t } = useThemeTranslation();
+  const locale = useLocale();
+  const localizedSwiftypeFilters = [
+    {
+      field: 'type',
+      values: [
         `docs-${locale.locale}`,
         `developer-${locale.locale}`,
         `opensource-${locale.locale}`,
-      ];
-  return {
-    apiConnector: connector,
-    searchQuery: {
-      result_fields: {
-        title: {
-          snippet: {
-            size: 100,
-            fallback: true,
-          },
-        },
-        body: {
-          snippet: {
-            size: 400,
-            fallback: true,
-          },
-        },
-        url: {
-          raw: {},
-        },
-      },
-      filters: [
-        {
-          field: 'type',
-          values: typeValues,
-          type: 'any',
-        },
-        {
-          field: 'document_type',
-          values: ['!views_page_menu', '!views_page_content'],
-          type: 'any',
-        },
       ],
+      type: 'any',
     },
-    initialState: {
-      resultsPerPage: 10,
+    {
+      field: 'document_type',
+      values: ['!views_page_menu', '!views_page_content'],
+      type: 'any',
     },
-  };
-};
-
-const SwiftypeSearch = ({ className, locale }) => {
-  const { setQueryParam } = useQueryParams();
-  const { t } = useThemeTranslation();
+  ];
+  useEffect(() => {
+    swiftypeConfig.searchQuery.filters = locale.isDefault
+      ? defaultSwiftypeFilters
+      : localizedSwiftypeFilters;
+  });
 
   return (
     <div css={styles} className={className}>
-      <SearchProvider config={getSwiftypeConfig(locale)}>
+      <SearchProvider config={swiftypeConfig}>
         <WithSearch
           mapContextToProps={({
             isLoading,
@@ -223,7 +212,6 @@ const InputView = ({ getAutocomplete, getInputProps }) => {
 
 SwiftypeSearch.propTypes = {
   className: PropTypes.string,
-  locale: PropTypes.object,
 };
 
 InputView.propTypes = {

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -46,10 +46,28 @@ const swiftypeConfig = {
         raw: {},
       },
     },
-    filters: [
+  },
+  initialState: {
+    resultsPerPage: 10,
+  },
+};
+
+const SwiftypeSearch = ({ className, locales }) => {
+  const { setQueryParam } = useQueryParams();
+  const { t } = useThemeTranslation();
+  const locale = useLocale();
+  const setFilters = (state, locale) => {
+    const typeValues = locale.isDefault
+      ? ['docs', 'developer', 'opensource']
+      : [
+          `docs-${locale.locale}`,
+          `developer-${locale.locale}`,
+          `opensource-${locale.locale}`,
+        ];
+    state.filters = [
       {
         field: 'type',
-        values: defaultSwiftypeFilters,
+        values: typeValues,
         type: 'any',
       },
       {
@@ -57,51 +75,13 @@ const swiftypeConfig = {
         values: ['!views_page_menu', '!views_page_content'],
         type: 'any',
       },
-    ],
-  },
-  initialState: {
-    resultsPerPage: 10,
-  },
-};
-
-const defaultSwiftypeFilters = [
-  {
-    field: 'type',
-    values: ['docs', 'developer', 'opensource'],
-    type: 'any',
-  },
-  {
-    field: 'document_type',
-    values: ['!views_page_menu', '!views_page_content'],
-    type: 'any',
-  },
-];
-
-const SwiftypeSearch = ({ className }) => {
-  const { setQueryParam } = useQueryParams();
-  const { t } = useThemeTranslation();
-  const locale = useLocale();
-  const localizedSwiftypeFilters = [
-    {
-      field: 'type',
-      values: [
-        `docs-${locale.locale}`,
-        `developer-${locale.locale}`,
-        `opensource-${locale.locale}`,
-      ],
-      type: 'any',
-    },
-    {
-      field: 'document_type',
-      values: ['!views_page_menu', '!views_page_content'],
-      type: 'any',
-    },
-  ];
-  useEffect(() => {
-    swiftypeConfig.searchQuery.filters = locale.isDefault
-      ? defaultSwiftypeFilters
-      : localizedSwiftypeFilters;
-  });
+    ];
+    return state;
+  };
+  swiftypeConfig.onSearch = (state, queryConfig, next) => {
+    const updatedState = setFilters(state, locale);
+    return next(updatedState, queryConfig);
+  };
 
   return (
     <div css={styles} className={className}>

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';
 import {
   SearchProvider,
@@ -52,10 +52,11 @@ const swiftypeConfig = {
   },
 };
 
-const SwiftypeSearch = ({ className, locales }) => {
+const SwiftypeSearch = ({ className }) => {
   const { setQueryParam } = useQueryParams();
   const { t } = useThemeTranslation();
   const locale = useLocale();
+
   const setFilters = (state, locale) => {
     const typeValues = locale.isDefault
       ? ['docs', 'developer', 'opensource']

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import SiteSearchAPIConnector from '@elastic/search-ui-site-search-connector';
 import {
   SearchProvider,
@@ -48,7 +48,7 @@ const configOptions = {
     filters: [
       {
         field: 'type',
-        values: ['docs', 'docs-jp', 'developer', 'opensource'],
+        values: ['docs', 'developer', 'opensource'],
         type: 'any',
       },
       {
@@ -63,13 +63,60 @@ const configOptions = {
   },
 };
 
-const SwiftypeSearch = ({ className }) => {
+const getSwiftypeConfig = (locale) => {
+  const typeValues = locale.isDefault
+    ? ['docs', 'developer', 'opensource']
+    : [
+        `docs-${locale.locale}`,
+        `developer-${locale.locale}`,
+        `opensource-${locale.locale}`,
+      ];
+  return {
+    apiConnector: connector,
+    searchQuery: {
+      result_fields: {
+        title: {
+          snippet: {
+            size: 100,
+            fallback: true,
+          },
+        },
+        body: {
+          snippet: {
+            size: 400,
+            fallback: true,
+          },
+        },
+        url: {
+          raw: {},
+        },
+      },
+      filters: [
+        {
+          field: 'type',
+          values: typeValues,
+          type: 'any',
+        },
+        {
+          field: 'document_type',
+          values: ['!views_page_menu', '!views_page_content'],
+          type: 'any',
+        },
+      ],
+    },
+    initialState: {
+      resultsPerPage: 10,
+    },
+  };
+};
+
+const SwiftypeSearch = ({ className, locale }) => {
   const { setQueryParam } = useQueryParams();
   const { t } = useThemeTranslation();
 
   return (
     <div css={styles} className={className}>
-      <SearchProvider config={configOptions}>
+      <SearchProvider config={getSwiftypeConfig(locale)}>
         <WithSearch
           mapContextToProps={({
             isLoading,
@@ -176,6 +223,7 @@ const InputView = ({ getAutocomplete, getInputProps }) => {
 
 SwiftypeSearch.propTypes = {
   className: PropTypes.string,
+  locale: PropTypes.object,
 };
 
 InputView.propTypes = {

--- a/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SwiftypeSearch.js
@@ -48,12 +48,12 @@ const configOptions = {
     filters: [
       {
         field: 'type',
-        values: ['docs', 'developer', 'opensource'],
+        values: ['docs', 'docs-jp', 'developer', 'opensource'],
         type: 'any',
       },
       {
         field: 'document_type',
-        values: ['!views_page_menu'],
+        values: ['!views_page_menu', '!views_page_content'],
         type: 'any',
       },
     ],


### PR DESCRIPTION
## Description

This work updates swiftype search to switch the filters on `type` (distinguishes what site the page belongs to) based on the locale context. If a user is on the default locale of the site (English), it filters for the standard types (docs, developer, opensource). If a user is on a locale namespaced page (ex: https:docs.newrelic.com/jp/docs/agents) and uses search, it will filter for those locale pages in the index. 

This also adds a filter to exclude `views_page_content` for now (attribute dictionary and whats new page) because those pages tend to add noise like menu pages (because they are lists / links of content that lives and is indexed separately).

**Note**: All locale namespaced pages automatically get the localized meta tag `type` via the theme. If a namespaced page only has English and not translated content, we tell swiftype to exclude it from the index.

**Note**: Since we don't expose any controls for user to switch which languages to search for, we probably want to only support searching sites on a per locale basis, otherwise if English search terms are used users will often see duplicate records (there's still English terms in translated pages that can be matched on).

**Note**: There may be some `jp` pages that are indexed by swiftype with only English content. In those cases, I've found it's because an .mdx file for the page exists in `src/i18n` but it's in English so it may not have been migrated correctly (copying content from `manual-edits` folder is one factor i think).

## Related issues / PRs
Closes https://github.com/newrelic/docs-website/issues/1191

## Screenshot(s)

### Search w/English on English namespace
<img width="1280" alt="2021-03-19_11-13-18" src="https://user-images.githubusercontent.com/2952843/111825169-5f4fa000-88a4-11eb-86fe-958e1797accd.png">

### Search w/Japanese on JP namespace
<img width="1280" alt="2021-03-19_11-14-03" src="https://user-images.githubusercontent.com/2952843/111825272-83ab7c80-88a4-11eb-8c2e-de484a5aa6e9.png">

### Search w/English on JP namespace
<img width="1280" alt="2021-03-19_11-20-06" src="https://user-images.githubusercontent.com/2952843/111825825-2cf27280-88a5-11eb-9fd4-0b1c56902b76.png">
