### PR TITLE
Tessen: Enable all Segment integrations by default

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -39,13 +39,23 @@ const tessenAction = (action, config) => (name, category, properties = {}) => {
   }
 
   if (canTrack()) {
-    window.Tessen[action](name, {
-      ...properties,
-      category,
-      nr_product: config.product,
-      nr_subproduct: config.subproduct,
-      location: 'Public',
-    });
+    window.Tessen[action](
+      name,
+      {
+        ...properties,
+        category,
+        nr_product: config.product,
+        nr_subproduct: config.subproduct,
+        location: 'Public',
+      },
+      {
+        Segment: {
+          integrations: {
+            All: true,
+          },
+        },
+      }
+    );
   }
 };
 


### PR DESCRIPTION
## Description
Adds 3rd arg to any `tessen.page()` and `tessen.track()` calls to enable all Segment integrations by default.

We can also control what integrations/destinations are enabled/disabled in the Segment UI.