### PR TITLE
Add course callout variant

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -169,6 +169,9 @@ const IndexPage = () => {
           <Callout variant={Callout.VARIANT.TIP} title={null}>
             Here's a tip with no title
           </Callout>
+          <Callout variant={Callout.VARIANT.COURSE}>
+            This callout is for a guide that is part of a super cool course
+          </Callout>
         </section>
         <section>
           <h2>A code block</h2>

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -637,11 +637,11 @@ import { Callout } from '@newrelic/gatsby-theme-newrelic'`
 
 **Props**
 
-| Prop        | Type   | Required | Default | Description                                                                                                                         |
-| ----------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `className` | string | no       |         | Adds a `className` to the callout. Useful if you need to position the callout within its parent element.                            |
-| `variant`   | enum   | yes      |         | Configures the variant of the callout. Must be one of `Callout.VARIANT.CAUTION`, `Callout.VARIANT.IMPORTANT`, `Callout.VARIANT.TIP` |
-| `title`     | enum   | no       |         | Set the title text. Defaults to variant name. You may hide the title by passing `null` as the value.                                |
+| Prop        | Type   | Required | Default | Description                                                                                                                                                   |
+| ----------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `className` | string | no       |         | Adds a `className` to the callout. Useful if you need to position the callout within its parent element.                                                      |
+| `variant`   | enum   | yes      |         | Configures the variant of the callout. Must be one of `Callout.VARIANT.CAUTION`, `Callout.VARIANT.IMPORTANT`, `Callout.VARIANT.TIP`, `Callout.VARIANT.COURSE` |
+| `title`     | enum   | no       |         | Set the title text. Defaults to variant name. You may hide the title by passing `null` as the value.                                                          |
 
 **Examples**
 

--- a/packages/gatsby-theme-newrelic/src/components/Callout.js
+++ b/packages/gatsby-theme-newrelic/src/components/Callout.js
@@ -7,6 +7,7 @@ const VARIANTS = {
   CAUTION: 'caution',
   IMPORTANT: 'important',
   TIP: 'tip',
+  COURSE: 'course',
 };
 
 const styles = {
@@ -31,6 +32,13 @@ const styles = {
     [VARIANTS.TIP]: css`
       border-color: var(--color-green-400);
       background: var(--callout-tip-background-color);
+    `,
+    [`${VARIANTS.COURSE}-title`]: css`
+      color: var(--color-brand-400);
+    `,
+    [VARIANTS.COURSE]: css`
+      border-color: var(--color-brand-400);
+      background: var(--callout-course-background-color);
     `,
   },
 };

--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/themes.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/themes.js
@@ -23,6 +23,7 @@ export default css`
     --callout-caution-background-color: #fce9e935;
     --callout-important-background-color: #fff9cc30;
     --callout-tip-background-color: #d1f7d925;
+    --callout-course-background-color: #00b3c310;
 
     input::placeholder {
       color: var(--color-neutrals-500);

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -13,7 +13,8 @@
   "callout": {
     "tip": "Tip",
     "caution": "Caution",
-    "important": "Important"
+    "important": "Important",
+    "course": "Course"
   },
   "github": {
     "createIssue": "Create issue",


### PR DESCRIPTION
This adds a variant to the callout component for `course`

Addresses https://github.com/newrelic/developer-website/issues/1239 but can't be considered fully done until we have the Japanese translation for course. While the current use case for this callout is on the developer site, it's possible we'd want to use it to link to a guide from the docs site, etc. 

<img width="746" alt="Screen Shot 2021-04-12 at 3 04 36 PM" src="https://user-images.githubusercontent.com/39655074/114468533-7e3e0b00-9ba0-11eb-8f09-97b803f24afd.png">
