### PR TITLE
chore: remove utmsource from gatsby-config

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -10,7 +10,6 @@ module.exports = {
     repository: 'https://github.com/newrelic/gatsby-theme-newrelic',
     siteUrl: 'https://developer.newrelic.com',
     titleTemplate: '%s | Gatsby Theme Demo Site',
-    utmSource: 'demo-site',
     branch: 'develop',
   },
   plugins: [

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -174,12 +174,6 @@ exports.sourceNodes = (
 exports.createResolvers = ({ createResolvers }, themeOptions) => {
   const { layout = {} } = themeOptions;
 
-  const defaultUtmSource = {
-    'https://developer.newrelic.com': 'developer-site',
-    'https://opensource.newrelic.com': 'opensource-site',
-    'https://docs.newrelic.com': 'docs-site',
-  };
-
   createResolvers({
     Site: {
       layout: {
@@ -188,10 +182,6 @@ exports.createResolvers = ({ createResolvers }, themeOptions) => {
       },
     },
     SiteSiteMetadata: {
-      utmSource: {
-        resolve: ({ siteUrl, utmSource }) =>
-          utmSource || defaultUtmSource[siteUrl],
-      },
       branch: {
         resolve: ({ branch }) => branch || DEFAULT_BRANCH,
       },


### PR DESCRIPTION
This resolves the bug found when trying to bump the theme on the dev and oss sites 

```
SiteSiteMetadata.utmSource provided incorrect OutputType: 'Object({
resolve: [function wrappedTracingResolver], extensions: Object({
createdFrom: "createResolvers" }) })'



  Error: SiteSiteMetadata.utmSource provided incorrect OutputType: 'Ob
  ject({ resolve: [function wrappedTracingResolve

```

Related PRS: 

https://github.com/newrelic/opensource-website/pull/749
https://github.com/newrelic/developer-website/pull/1254