### PR TITLE
Fix referral field not being sent to analytics

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SignUpLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/SignUpLink.js
@@ -22,11 +22,12 @@ const SignUpLink = ({ href, onClick, instrumentation, ...props }) => {
   const locale = useLocale();
 
   return (
+    // eslint-disable-next-line react/jsx-no-target-blank
     <a
       {...props}
       href={formatHref(href, { locale })}
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       onClick={(e) => {
         if (onClick) {
           onClick(e);

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/Link.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/Link.test.js
@@ -112,7 +112,7 @@ test('renders correct signup link', () => {
 
   expect(link).toHaveAttribute('href', 'https://newrelic.com/signup');
   expect(link).toHaveAttribute('target', '_blank');
-  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  expect(link).toHaveAttribute('rel', 'noopener');
 });
 
 test('localizes the sign up link', () => {
@@ -133,7 +133,7 @@ test('localizes the sign up link', () => {
 
   expect(link).toHaveAttribute('href', 'https://newrelic.com/jp/signup');
   expect(link).toHaveAttribute('target', '_blank');
-  expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  expect(link).toHaveAttribute('rel', 'noopener');
 });
 
 describe('when forceTrailingSlashes is enabled', () => {


### PR DESCRIPTION
# Summary
The `referrer` field was not being sent when a user clicks the `free account` button on our sites. This was caused by the `rel="noreferrer"` property on our the SignUpLink component.
The `noreferrer` and `noopener` types control the information passed to the new tab. The former prevents referrer information from being passed to the new tab and the latter prevents a lot of other information from being passed.

We have 2 main options to fix this:
1. Remove the `noreferrer` type (possible security risk, but we do own the site we are linking to)
2. Do not open the link in a new tab

This PR currently fixes this issue through option 1.