### PR TITLE
Add SplitColorButton

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -49,10 +49,15 @@ module.exports = {
           // https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#localhost-mode
           features: {
             'developer-website_global-header-gh-buttons': 'on',
+            free_account_button_color: {
+              treatment: 'red',
+              config: '{ "color": "red" }',
+            },
           },
           core: {
             authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
           },
+          debug: false,
         },
       },
     },

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -75,6 +75,7 @@ websites](https://opensource.newrelic.com).
     - [`SEO`](#seo)
     - [`SimpleFeedback`](#simplefeedback)
     - [`Spinner`](#spinner)
+    - [`SplitColorButton`](#splitcolorbutton)
     - [`Surface`](#surface)
     - [`Table`](#table)
     - [`TableOfContents`](#tableofcontents)
@@ -2221,6 +2222,44 @@ import { Spinner } from '@newrelic/gatsby-theme-newrelic';
 const View = () => (
   return <Spinner />;
 );
+```
+
+### `SplitColorButton`
+
+A wrapper around the [`Button`](#button) for A/B testing. It takes in the name of a Split.io split and changes color based on the config.
+To connect this component to a split, pass the name of the split in as the value of the `treatmentName` prop. The name of the treatment does not matter, as the component only checks to see if it is `off`. The config value for each treatment, excluding `off`, must be JSON in the following form:
+```json
+{
+  "color": "<color>"
+}
+```
+
+Example treatment config:
+```json
+{
+  "color": "#000000"
+}
+```
+
+```js
+import { SplitColorButton } from '@newrelic/gatsby-theme-newrelic';
+```
+
+**Props**
+| Prop            | Type   | Required | Default | Description                                                                     |
+| ----------      | -----  | -------- | ------- | ------------------------------------------------------------------------------- |
+| `children`      | node   | no       |         | The content to display within the button. Usually a `<span>` with text content. |
+| `treatmentName` | string | yes      |         | The name of the treatment in Split.io.                                          |
+
+**Example**
+```js
+<SplitColorButton
+  treatmentName="TestFeature"
+  size={Button.SIZE.SMALL}
+  variant={Button.VARIANT.PRIMARY}
+>
+  <span>Click me!</span>
+</SplitColorButton>
 ```
 
 ### `Surface`

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -20,6 +20,8 @@ import useLocale from '../hooks/useLocale';
 import useThemeTranslation from '../hooks/useThemeTranslation';
 import path from 'path';
 import { rgba } from 'polished';
+import { SPLITS } from '../utils/constants';
+import SplitColorButton from './SplitColorButton';
 
 const action = css`
   color: var(--secondary-text-color);
@@ -395,15 +397,16 @@ const GlobalHeader = ({ className }) => {
                 display: flex;
               `}
             >
-              <Button
+              <SplitColorButton
                 as={ExternalLink}
                 href="https://newrelic.com/signup"
                 size={Button.SIZE.EXTRA_SMALL}
                 variant={Button.VARIANT.PRIMARY}
                 instrumentation={{ component: 'GlobalHeader' }}
+                treatmentName={SPLITS.FREE_ACCOUNT_BUTTON_COLOR}
               >
                 <span>{t('button.signUp')}</span>
-              </Button>
+              </SplitColorButton>
             </li>
           </ul>
         </div>

--- a/packages/gatsby-theme-newrelic/src/components/SplitColorButton.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitColorButton.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import { useTreatments, SplitContext } from '@splitsoftware/splitio-react';
+import Button from './Button';
+import Spinner from './Spinner';
+
+const renderButton = (treatmentWithConfig, children, props) => {
+  const { treatment, config } = treatmentWithConfig;
+  const btnColor = JSON.parse(config)?.color;
+
+  if (treatment !== 'off' && btnColor) {
+    return (
+      <Button
+        css={css`
+          background-color: ${btnColor};
+        `}
+        {...props}
+      >
+        {children}
+      </Button>
+    );
+  }
+
+  return <Button {...props}>{children}</Button>;
+};
+
+const SplitColorButton = ({ children, treatmentName, ...props }) => {
+  const { isReady } = React.useContext(SplitContext);
+  const treatments = useTreatments([treatmentName]);
+
+  return isReady ? (
+    renderButton(treatments[treatmentName], children, props)
+  ) : (
+    <Spinner />
+  );
+};
+
+SplitColorButton.propTypes = {
+  children: PropTypes.node,
+  treatmentName: PropTypes.string.isRequired,
+};
+
+export default SplitColorButton;

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SplitColorButton.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SplitColorButton.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { SplitFactory } from '@splitsoftware/splitio-react';
+import SplitColorButton from '../SplitColorButton';
+import Button from '../Button';
+
+test('renders default button with no split', async () => {
+  const config = createSplitConfig();
+
+  const element = () => (
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitColorButton treatmentName="test_feature" variant={Button.VARIANT.PRIMARY} size={Button.SIZE.EXTRA_SMALL}>
+        <span>Test</span>
+      </SplitColorButton>
+    </SplitFactory>
+  );
+
+  let root = element();
+  let tree;
+  await TestRenderer.act(async () => {
+    tree = TestRenderer.create(root);
+  });
+
+  await TestRenderer.act(async () => {
+    tree.update(root);
+  });
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('renders button with color defined in split', async () => {
+  const config = createSplitConfig("red");
+
+  const element = () => (
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitColorButton treatmentName="test_feature" variant={Button.VARIANT.PRIMARY} size={Button.SIZE.EXTRA_SMALL}>
+        <span>Test</span>
+      </SplitColorButton>
+    </SplitFactory>
+  );
+
+  let root = element();
+  let tree;
+  await TestRenderer.act(async () => {
+    tree = TestRenderer.create(root);
+  });
+
+  await TestRenderer.act(async () => {
+    tree.update(root);
+  });
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('renders spinner before split.io is ready', async () => {
+  const config = createSplitConfig("red");
+
+  const element = () => (
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitColorButton treatmentName="test_feature" variant={Button.VARIANT.PRIMARY} size={Button.SIZE.EXTRA_SMALL}>
+        <span>Test</span>
+      </SplitColorButton>
+    </SplitFactory>
+  );
+
+  let root = element();
+  let tree;
+  await TestRenderer.act(async () => {
+    tree = TestRenderer.create(root);
+  });
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+test('renders children', async () => {
+  const config = createSplitConfig('blue');
+
+  const element = () => (
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitColorButton treatmentName="test_feature" variant={Button.VARIANT.PRIMARY} size={Button.SIZE.EXTRA_SMALL}>
+        <span>Test child text must match</span>
+      </SplitColorButton>
+    </SplitFactory>
+  );
+
+  let root = element();
+  let tree;
+  await TestRenderer.act(async () => {
+    tree = TestRenderer.create(root);
+  });
+
+  await TestRenderer.act(async () => {
+    tree.update(root);
+  });
+
+  expect(tree.toJSON()).toMatchSnapshot();
+});
+
+const createSplitConfig = (color) => {
+  return {
+    core: {
+      authorizationKey: 'localhost',
+      key: 'user',
+    },
+    features: {
+      test_feature: color ? { treatment: 'testcolor', config: `{ "color": "${color}" }` } : 'off',
+    },
+    scheduler: {
+      offlineRefreshRate: 15
+    },
+    debug: false,
+  }
+};

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/SplitColorButton.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/SplitColorButton.test.js.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders button with color defined in split 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border: 1px solid transparent;
+  -webkit-transition: all 0.15s ease-out;
+  transition: all 0.15s ease-out;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
+  background-color: red;
+}
+
+.emotion-0:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+<button
+  className="emotion-0 emotion-1"
+  size="extraSmall"
+>
+  <span>
+    Test
+  </span>
+</button>
+`;
+
+exports[`renders children 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border: 1px solid transparent;
+  -webkit-transition: all 0.15s ease-out;
+  transition: all 0.15s ease-out;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
+  background-color: blue;
+}
+
+.emotion-0:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+<button
+  className="emotion-0 emotion-1"
+  size="extraSmall"
+>
+  <span>
+    Test child text must match
+  </span>
+</button>
+`;
+
+exports[`renders default button with no split 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  font-family: var(--primary-font-family);
+  line-height: 1;
+  cursor: pointer;
+  border: 1px solid transparent;
+  -webkit-transition: all 0.15s ease-out;
+  transition: all 0.15s ease-out;
+  white-space: nowrap;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: var(--color-white);
+  background-color: var(--color-brand-600);
+  font-size: 0.625rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.125rem;
+}
+
+.emotion-0:hover {
+  color: var(--color-white);
+  background-color: var(--color-brand-500);
+}
+
+<button
+  className="emotion-0 emotion-1"
+  size="extraSmall"
+>
+  <span>
+    Test
+  </span>
+</button>
+`;
+
+exports[`renders spinner before split.io is ready 1`] = `
+@keyframes animation-0 {
+  to {
+    -webkit-transform: rotate(1turn);
+    -moz-transform: rotate(1turn);
+    -ms-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+
+.emotion-0 {
+  --spinner-size: 1rem;
+  display: inline-block;
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.emotion-0:after {
+  -webkit-animation: animation-0 0.5s linear infinite;
+  animation: animation-0 0.5s linear infinite;
+  border-radius: 50%;
+  border-right: 1px solid transparent;
+  border-top: 1px solid;
+  content: '';
+  left: calc(50% + 1px);
+  margin-left: calc(var(--spinner-size) / 2 * -1);
+  margin-top: calc(var(--spinner-size) / 2 * -1);
+  position: absolute;
+  top: calc(50% + 1px);
+  width: var(--spinner-size);
+  height: var(--spinner-size);
+}
+
+<div
+  aria-busy={true}
+  aria-label="Loading"
+  className="emotion-0"
+/>
+`;

--- a/packages/gatsby-theme-newrelic/src/utils/constants.js
+++ b/packages/gatsby-theme-newrelic/src/utils/constants.js
@@ -2,6 +2,7 @@ const prefixStorageKey = (name) => ['gatsby-theme-newrelic', name].join(':');
 
 export const SPLITS = {
   GLOBAL_HEADER_GITHUB_BUTTONS: 'developer-website_global-header-gh-buttons',
+  FREE_ACCOUNT_BUTTON_COLOR: 'free_account_button_color',
 };
 
 export const SPLIT_TRACKING_EVENTS = {


### PR DESCRIPTION
# Summary
Adds a `SplitColorButton` component that wraps the `Button` component and overrides the `background-color` according to a split in Split.io.

Example:

https://user-images.githubusercontent.com/70179303/116735081-e7948b00-a9a2-11eb-9432-9f664a2a6fa2.mov

