### PR TITLE
Add `customer_user_id` in all tessen calls

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -1,5 +1,6 @@
 import warning from 'warning';
 import { canTrack } from './tracking';
+import Cookies from 'js-cookie';
 
 const warnAboutNoop = ({ config, action, name, category }) => {
   warning(
@@ -38,6 +39,8 @@ const tessenAction = (action, config) => (name, category, properties = {}) => {
     );
   }
 
+  const customerId = Cookies.get('ajs_user_id') || '';
+
   if (canTrack()) {
     window.Tessen[action](
       name,
@@ -47,6 +50,7 @@ const tessenAction = (action, config) => (name, category, properties = {}) => {
         nr_product: config.product,
         nr_subproduct: config.subproduct,
         location: 'Public',
+        customer_user_id: customerId,
       },
       {
         Segment: {


### PR DESCRIPTION
## Description

Gets the value of `ajs_user_id` if available and sends along with all `tessen.page()` and `tessen.track()` calls. If no value available, sends empty string.

Note: we only use tessen when a user has agreed to cookie usage.

## Review notes

Testing is a little tricky since the `ajs_user_id` cookie is set to newrelic domains. Need to verify once one of the sites incorporates it. I tested locally with `ajs_anonymous_id` and it did work.

## Related issues
Closes https://github.com/newrelic/docs-website/issues/1668