### PR TITLE
Track when users agree to cookie usage

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
+++ b/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
@@ -42,12 +42,15 @@ const CookieConsentDialog = () => {
     Cookies.set(TRACKING_COOKIE_NAME, String(answer), options);
     setIsCookieSet(true);
 
-    if (answer && window.initializeTessenTracking) {
-      window.initializeTessenTracking({ trackPageView: true });
+    if (answer) {
       if (window.newrelic && typeof newrelic === 'object') {
         window.newrelic.addPageAction('cookieConsent', { agree: true });
       }
+      if (window.initializeTessenTracking) {
+        window.initializeTessenTracking({ trackPageView: true });
+      }
     }
+
     if (!answer && window.gtag) {
       if (window.newrelic && typeof newrelic === 'object') {
         window.newrelic.addPageAction('cookieConsent', { agree: false });

--- a/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
+++ b/packages/gatsby-theme-newrelic/src/components/CookieConsentDialog.js
@@ -44,6 +44,9 @@ const CookieConsentDialog = () => {
 
     if (answer && window.initializeTessenTracking) {
       window.initializeTessenTracking({ trackPageView: true });
+      if (window.newrelic && typeof newrelic === 'object') {
+        window.newrelic.addPageAction('cookieConsent', { agree: true });
+      }
     }
     if (!answer && window.gtag) {
       if (window.newrelic && typeof newrelic === 'object') {


### PR DESCRIPTION
## Description
Records when a user selects Yes in the `<CookieConsentDialog />`. Records via New Relic Browser `PageAction` event.

## Related issues
Closes https://github.com/newrelic/docs-website/issues/1507

## Examples
Example query:

```
SELECT * FROM PageAction where appName = 'New Relic Gatsby Theme - Demo site' and actionName = 'cookieConsent' and agree is true since 3 days ago
```
