### PR TITLE
Fix sitemap output

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-config.js
+++ b/packages/gatsby-theme-newrelic/gatsby-config.js
@@ -3,7 +3,12 @@ module.exports = ({ layout, newrelic, robots = {}, sitemap = true }) => {
     plugins: [
       'gatsby-plugin-emotion',
       'gatsby-plugin-react-helmet',
-      sitemap && 'gatsby-plugin-sitemap',
+      sitemap && {
+        resolve: 'gatsby-plugin-sitemap',
+        options: {
+          output: '/',
+        },
+      },
       'gatsby-plugin-use-dark-mode',
       'gatsby-transformer-sharp',
       'gatsby-plugin-sharp',

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -62,7 +62,7 @@
     "gatsby-plugin-react-helmet": "^4.3.0",
     "gatsby-plugin-robots-txt": "^1.5.5",
     "gatsby-plugin-sharp": "^3.3.0",
-    "gatsby-plugin-sitemap": "^4.0.0-next.0",
+    "gatsby-plugin-sitemap": "^4.1.0-next.1",
     "gatsby-plugin-use-dark-mode": "^1.3.0",
     "gatsby-source-filesystem": "^3.3.0",
     "gatsby-transformer-sharp": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8978,10 +8978,10 @@ gatsby-plugin-sharp@^3.3.0:
     svgo "1.3.2"
     uuid "3.4.0"
 
-gatsby-plugin-sitemap@^4.0.0-next.0:
-  version "4.0.0-next.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.0.0-next.0.tgz#23296d97120ed7cc8a7009e8834dfb204ac991c4"
-  integrity sha512-VDmnJKRwNqKnNvLWnSklGAzdU7xnwu+OQG1T3OM+bYdRFL8EtdSz4ADE5CVfGWFw0jahJ1eMOde2CDiaCcIMuQ==
+gatsby-plugin-sitemap@^4.1.0-next.1:
+  version "4.1.0-next.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.1.0-next.1.tgz#0ce464bb144a85288da31106bdf4f7b22740e668"
+  integrity sha512-zu/gN9MefYb8mb3m/iRfg+nl/BMGgz4wgBoeQpcYtEioa4LXThZiCZiJdxj8HdzI78nPlm/4cqQThSKyfrNiGg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     common-tags "^1.8.0"


### PR DESCRIPTION
## Description
Updates `gatsby-plugin-sitemap` version and explicitly sets the output path in the demo config.

## Related issues
Closes https://github.com/newrelic/docs-website/issues/2103