### PR TITLE
Fixing console errors

### DIFF
--- a/demo/src/layouts/MainLayout.js
+++ b/demo/src/layouts/MainLayout.js
@@ -24,8 +24,8 @@ const MainLayout = (props) => {
       <SEO location={location} />
       <GlobalHeader />
       <MobileHeader>
-        {nav.map((page) => (
-          <NavItem key={page.url} page={page} />
+        {nav.map((page, index) => (
+          <NavItem key={`mobile${index}${page}`} page={page} />
         ))}
       </MobileHeader>
       <Layout>
@@ -44,8 +44,8 @@ const MainLayout = (props) => {
             `}
           />
           <Navigation searchTerm={searchTerm}>
-            {nav.map((page) => (
-              <NavItem key={page.url} page={page} />
+            {nav.map((page, index) => (
+              <NavItem key={`nav${index}${page}`} page={page} />
             ))}
           </Navigation>
         </Layout.Sidebar>

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -9,6 +9,7 @@ import {
   CollapserGroup,
   ContributingGuidelines,
   Layout,
+  Link,
   PageTools,
   SearchInput,
   SimpleFeedback,
@@ -355,6 +356,26 @@ nr1 create --type nerdpack --name pageviews-app
               `}
             >
               Interactive
+            </Surface>
+          </div>
+          <h2>Surfaces as other elements</h2>
+          <div
+            css={css`
+              display: grid;
+              grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+              grid-gap: 2rem;
+              padding: 1rem;
+            `}
+          >
+            <Surface
+              base={Surface.BASE.PRIMARY}
+              to="foobar"
+              as={Link}
+              css={css`
+                padding: 2rem;
+              `}
+            >
+              I'm a link!
             </Surface>
           </div>
         </section>

--- a/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
+++ b/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
@@ -45,7 +45,7 @@ const ContributingGuidelines = ({
           margin-bottom: 0.5rem;
 
           @supports not (gap: 1rem) {
-            > :first-child {
+            > :first-of-type {
               margin-right: 0.5rem;
             }
           }

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -13,6 +13,17 @@ const isExternal = (to) => to.startsWith('http');
 const isNewRelic = (to) => to.startsWith('https://newrelic.com');
 const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+const ATTRIBUTES = [
+  'download',
+  'href',
+  'hreflang',
+  'ping',
+  'rel',
+  'target',
+  'type',
+];
+
 const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
   const locale = useLocale();
 
@@ -47,14 +58,18 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
     to = to || '/';
   }
 
+  const normalizedProps = Object.entries(props)
+    .filter(([attribute]) => ATTRIBUTES.includes(attribute))
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+
   if (isHash(to)) {
-    return <a href={to} {...props} />;
+    return <a href={to} {...normalizedProps} />;
   }
 
   if (isSignup(to)) {
     return (
       <SignUpLink
-        {...props}
+        {...normalizedProps}
         href={to}
         onClick={handleExternalLinkClick}
         instrumentation={instrumentation}
@@ -69,7 +84,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
 
     return (
       <a
-        {...props}
+        {...normalizedProps}
         href={link}
         onClick={handleExternalLinkClick}
         target="_blank"
@@ -84,7 +99,7 @@ const Link = ({ to, onClick, instrumentation = {}, ...props }) => {
         path: forceTrailingSlashes ? addTrailingSlash(to) : to,
         locale,
       })}
-      {...props}
+      {...normalizedProps}
     />
   );
 };

--- a/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
@@ -15,7 +15,7 @@ const MarkdownContainer = ({
         --block-element-spacing: 1.5rem;
         --text-spacing: var(--paragraph-spacing);
 
-        > *:first-child {
+        > *:first-of-type {
           margin-top: 0;
         }
 
@@ -39,13 +39,13 @@ const MarkdownContainer = ({
           margin-bottom: var(--text-spacing);
         }
 
-        h2:not(:first-child) {
+        h2:not(:first-of-type) {
           margin-top: 2rem;
         }
 
         h3,
         h4 {
-          &:not(:first-child) {
+          &:not(:first-of-type) {
             margin-top: 1.5rem;
           }
         }

--- a/packages/gatsby-theme-newrelic/src/components/NavItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/NavItem.js
@@ -10,6 +10,9 @@ import useNavigation from '../hooks/useNavigation';
 import { graphql, useStaticQuery } from 'gatsby';
 import { stripTrailingSlash } from '../utils/location';
 
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 const NavItem = ({ page, __parent: parent, __depth: depth = 0 }) => {
   const locale = useLocale();
   const location = useLocation();
@@ -57,7 +60,7 @@ const NavItem = ({ page, __parent: parent, __depth: depth = 0 }) => {
     }
   }, [matchesSearch, shouldExpand, searchTerm]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!searchTerm) {
       setIsExpanded(shouldExpand);
     }

--- a/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
+++ b/packages/gatsby-theme-newrelic/src/components/PageTools/Section.js
@@ -9,7 +9,7 @@ const Section = ({ children, className }) => (
     css={css`
       padding: 1rem;
 
-      &:first-child {
+      &:first-of-type {
         ${borderRadius('top', '0.25rem')};
       }
 

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -48,7 +48,7 @@ const SimpleFeedback = ({ pageTitle, labels = [] }) => {
         gap: 1rem;
 
         @supports not (gap: 1rem) {
-          > :first-child {
+          > :first-of-type {
             margin-right: 1rem;
           }
         }

--- a/packages/gatsby-theme-newrelic/src/components/Table.js
+++ b/packages/gatsby-theme-newrelic/src/components/Table.js
@@ -28,7 +28,7 @@ const Table = ({ className, children }) => (
           border: 1px solid transparent;
         }
 
-        thead + tbody tr:first-child {
+        thead + tbody tr:first-of-type {
           border-top: 3px solid var(--color-brand-600);
         }
 

--- a/packages/gatsby-theme-newrelic/src/components/Terminal/Shell.js
+++ b/packages/gatsby-theme-newrelic/src/components/Terminal/Shell.js
@@ -12,6 +12,9 @@ import MenuBar from './MenuBar';
 import { useIntersection } from 'react-use';
 import useClipboard from '../../hooks/useClipboard';
 
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 const Shell = ({ animate, className, copyable, highlight, code }) => {
   const { tokens, getTokenProps } = highlight;
   const lines = translateLines(tokens, code);
@@ -36,7 +39,7 @@ const Shell = ({ animate, className, copyable, highlight, code }) => {
     }
   }, [animate, intersection, send]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const { height } = shellRef.current.getBoundingClientRect();
     setHeight(height);
 


### PR DESCRIPTION
## Description
A lot of console errors & warnings come up while browsing the docs site. It turns out that many of these are coming from the theme itself. This PR aims to address some of these issues. You should be able to check out this branch, run `yarn start` and not run into any _errors_. There are a couple warnings that I've been unable to remedy:

* For some reason, eslint is not respecting our rules about `react/jsx-pascal-case`
* There is some random file that's importing a variable with the name `version`. I've been unable to find it.

In addition to those two warnings, there's also an occasional bug in the console about a `<div>` that doesn't have a matching `</div>`. I'm still working to track that down, but I haven't been able to find the exact location yet.

## Related Issue(s)
* Relates to newrelic/docs-website#997

## Screenshot(s)
Here's a few of the errors that we should not longer be seeing:
![Screen Shot 2021-05-06 at 1 49 14 PM](https://user-images.githubusercontent.com/1946433/117376602-56338600-ae86-11eb-91ee-96168a4bd920.png)
![Screen Shot 2021-05-06 at 4 01 05 PM](https://user-images.githubusercontent.com/1946433/117376606-59c70d00-ae86-11eb-8fe0-9c50d925a309.png)
![Screen Shot 2021-05-06 at 4 01 19 PM](https://user-images.githubusercontent.com/1946433/117376623-62b7de80-ae86-11eb-9cd3-df1209395612.png)
![Screen Shot 2021-05-06 at 4 04 04 PM](https://user-images.githubusercontent.com/1946433/117376633-65b2cf00-ae86-11eb-98a4-d95845019d7a.png)

