### PR TITLE
Add word-break to code/var/mark tags

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -144,6 +144,7 @@ const GlobalStyles = ({ layout }) => (
         padding: 0.2em 0.4em;
         border-radius: 3px;
         font-size: 85%;
+        word-break: break-word;
       }
 
       blockquote {


### PR DESCRIPTION
Partially addresses https://github.com/newrelic/docs-website/issues/1138

we're seeing tables with very long side scrolls due to `code` tags with long entries. this will wrap those entries when they are _not_ direct children of `pre` tags (like our mdx codeblock). hopefully this helps less styles get affected

<img width="500" alt="Screen Shot 2021-05-10 at 2 44 16 PM" src="https://user-images.githubusercontent.com/39655074/117728376-39f15b00-b19e-11eb-9199-26967809e1aa.png">
<img width="500" alt="Screen Shot 2021-05-10 at 2 43 56 PM" src="https://user-images.githubusercontent.com/39655074/117728384-3bbb1e80-b19e-11eb-880a-048b259460a7.png">
