### PR TITLE
Add whitespace wrap to code blocks

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -136,6 +136,7 @@ const GlobalStyles = ({ layout }) => (
       code,
       var {
         font-family: var(--code-font);
+        white-space: pre-wrap;
       }
 
       *:not(pre) > code,


### PR DESCRIPTION
Partially addresses https://github.com/newrelic/docs-website/issues/1138

This adds `white-space: pre-wrap` to code blocks. if a line is exceeding the width of the container it will automatically wrap. I haven't noticed any issues with this other than it looking a bit odd with long comments. comments that auto wrap don't have comment syntax on each line (like: `//first line` `//second line`) but they still copy/paste in the correct format

also thank you to hero @nr-kkenney 🏆 

<img width="500" alt="Screen Shot 2021-05-10 at 3 13 47 PM" src="https://user-images.githubusercontent.com/39655074/117731720-76738580-b1a3-11eb-884e-12bb05716eb3.png">
<img width="500" alt="Screen Shot 2021-05-10 at 3 13 17 PM" src="https://user-images.githubusercontent.com/39655074/117731723-77a4b280-b1a3-11eb-86a2-b296f5c9c450.png">
