### PR TITLE
Fix styles on Link component

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -15,6 +15,7 @@ const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 const ATTRIBUTES = [
+  'className',
   'download',
   'href',
   'hreflang',


### PR DESCRIPTION
Closes #390

## Description

Fix the link styles for anything using the `Link` component. The `className` was not properly forwarded.

## Screenshots

**Before**
<img width="1790" alt="Screen Shot 2021-05-10 at 1 21 44 PM" src="https://user-images.githubusercontent.com/70179303/117720185-3dcbb000-b193-11eb-9899-b1a050ea0f42.png">

**After**

<img width="1548" alt="Screen Shot 2021-05-10 at 4 31 14 PM" src="https://user-images.githubusercontent.com/565661/117736744-31545100-b1ad-11eb-888b-5aa7e96597ff.png">

