### PR TITLE
Fixing search result links

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -25,6 +25,7 @@ const ATTRIBUTES = [
   'type',
   'children',
   'role',
+  'dangerouslySetInnerHTML',
 ];
 
 const Link = ({ to, onClick, instrumentation = {}, ...props }) => {


### PR DESCRIPTION
## Description
A fix that allows us to set the innerHTML for links. This is necessary to resolve an issue with the search results not showing link text.
