### PR TITLE
Release fix for search links

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -136,6 +136,7 @@ const GlobalStyles = ({ layout }) => (
       code,
       var {
         font-family: var(--code-font);
+        white-space: pre-wrap;
       }
 
       *:not(pre) > code,

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -25,6 +25,7 @@ const ATTRIBUTES = [
   'type',
   'children',
   'role',
+  'dangerouslySetInnerHTML',
 ];
 
 const Link = ({ to, onClick, instrumentation = {}, ...props }) => {


### PR DESCRIPTION
## Description
Bring in a fix for search result links (and the commits below).

## Commits
- feat(tessen): add customer id via segment cookie with all tessen calls
- feat(analytics): track when users agree to cookie usage
- refactor: separate tessen and newrelic blocks
- fix(sitemap): update sitemap plugin version and explicitly set output path
- fix: add proper split.io tracking
- fix: only adding valid props to anchor tags
- fix: add 'env' to tessen call
- chore: using `first-of-type` to suppress warnings
- chore: only use _layout_ effects when we have access to window
- chore: ensuring that keys are unique
- chore: adds learn link to global header
- Revert "chore: using `first-of-type` to suppress warnings"
- fix: ensuring that link text is present
- fix: added `role` to the acceptable attributes for a link
- chore: adding page url to key index
- chore: Add word-break to code/var/mark tags
- chore: Add whitespace wrap to code blocks
- fix(Link): Ensure className gets forwarded to the underlying link components
- fix: updating links to allow for dangerouslySetInnerHTML
