### PR TITLE
Update feedback component functionality and tracking

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -30,7 +30,7 @@ const SimpleFeedback = () => {
         gap: 1rem;
 
         @supports not (gap: 1rem) {
-          > :first-child {
+          > :first-of-type {
             margin-right: 1rem;
           }
         }

--- a/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/SimpleFeedback.js
@@ -1,41 +1,23 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
 import Button from './Button';
-import GitHubIssueButton from './GitHubIssueButton';
 import Icon from './Icon';
 import PageTools from './PageTools';
 import useThemeTranslation from '../hooks/useThemeTranslation';
-import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
+import useTessen from '../hooks/useTessen';
 
-const POSITIVE_ISSUE_BODY = `
-### Tell us more about your feedback
-
-We're glad to hear this doc was helpful! We've recorded your feedback. Help us 
-improve other content by telling us what worked and what didn't:
-
-* What worked well in this doc?
-* How could we make this doc even better?
-`;
-
-const NEGATIVE_ISSUE_BODY = `
-### Tell us more about your feedback
-
-Sorry to hear this doc wasn't helpful, but we'd love to make it better! We've 
-recorded your feedback. Help us improve this content by providing more info:
-
-* How can we improve this doc?
-`;
-
-const SimpleFeedback = ({ pageTitle, labels = [] }) => {
+const SimpleFeedback = () => {
+  const [clicked, setClicked] = useState(false);
   const { t } = useThemeTranslation();
-  const issueTitle = pageTitle ? `Feedback: ${pageTitle}` : 'Docs feedback';
+  const tessen = useTessen();
 
-  const handleClick = useInstrumentedHandler(null, (feedback) => ({
-    actionName: 'feedback_click',
-    feedback,
-  }));
+  const handleClick = (feedbackType) => {
+    setClicked(true);
+    tessen.track('feedbackThumbClick', `${feedbackType}FeedbackClick`, {
+      path: location.pathname,
+    });
+  };
 
   return (
     <PageTools.Section
@@ -54,69 +36,71 @@ const SimpleFeedback = ({ pageTitle, labels = [] }) => {
         }
       `}
     >
-      <h6
-        css={css`
-          margin-bottom: 0;
-        `}
-      >
-        {t('feedback.question')}
-      </h6>
-      <div
-        css={css`
-          display: flex;
-          justify-content: center;
-          align-items: flex-start;
-          gap: 0.25rem;
+      {clicked ? (
+        <h6
+          css={css`
+            padding: 0.3rem;
+          `}
+        >
+          Thank you for your feedback!
+        </h6>
+      ) : (
+        <>
+          {' '}
+          <h6
+            css={css`
+              margin-bottom: 0;
+            `}
+          >
+            {t('feedback.question')}
+          </h6>
+          <div
+            css={css`
+              display: flex;
+              justify-content: center;
+              align-items: flex-start;
+              gap: 0.25rem;
 
-          @supports not (gap: 0.5rem) {
-            a:first-of-type {
-              margin-right: 0.25rem;
-            }
-          }
-        `}
-      >
-        <GitHubIssueButton
-          labels={[...labels, 'feedback', 'feedback-positive']}
-          issueTitle={issueTitle}
-          issueBody={POSITIVE_ISSUE_BODY}
-          variant={Button.VARIANT.LINK}
-          size={Button.SIZE.EXTRA_SMALL}
-          onClick={() => handleClick('positive')}
-        >
-          <Icon
-            size="0.75rem"
-            name="fe-thumbsup"
-            css={css`
-              margin-right: 0.5rem;
+              @supports not (gap: 0.5rem) {
+                a:first-of-type {
+                  margin-right: 0.25rem;
+                }
+              }
             `}
-          />
-          {t('feedback.positive')}
-        </GitHubIssueButton>
-        <GitHubIssueButton
-          labels={[...labels, 'feedback', 'feedback-negative']}
-          issueTitle={issueTitle}
-          issueBody={NEGATIVE_ISSUE_BODY}
-          variant={Button.VARIANT.LINK}
-          size={Button.SIZE.EXTRA_SMALL}
-          onClick={() => handleClick('negative')}
-        >
-          <Icon
-            size="0.75rem"
-            name="fe-thumbsdown"
-            css={css`
-              margin-right: 0.5rem;
-            `}
-          />
-          {t('feedback.negative')}
-        </GitHubIssueButton>
-      </div>
+          >
+            <Button
+              variant={Button.VARIANT.LINK}
+              size={Button.SIZE.EXTRA_SMALL}
+              onClick={() => handleClick('Positive')}
+            >
+              <Icon
+                size="0.75rem"
+                name="fe-thumbsup"
+                css={css`
+                  margin-right: 0.5rem;
+                `}
+              />
+              {t('feedback.positive')}
+            </Button>
+            <Button
+              variant={Button.VARIANT.LINK}
+              size={Button.SIZE.EXTRA_SMALL}
+              onClick={() => handleClick('Negative')}
+            >
+              <Icon
+                size="0.75rem"
+                name="fe-thumbsdown"
+                css={css`
+                  margin-right: 0.5rem;
+                `}
+              />
+              {t('feedback.negative')}
+            </Button>
+          </div>
+        </>
+      )}
     </PageTools.Section>
   );
-};
-
-SimpleFeedback.propTypes = {
-  pageTitle: PropTypes.string,
-  labels: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default SimpleFeedback;

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import SimpleFeedback from '../SimpleFeedback';
-import { useLocation } from '@reach/router';
 import { renderWithTranslation } from '../../test-utils/renderHelpers';
 
 jest.mock('gatsby', () => ({
@@ -26,11 +25,6 @@ jest.mock('gatsby', () => ({
   }),
 }));
 
-// Defining these here AND in the mock due to a limitation with jest
-// https://github.com/facebook/jest/issues/2567
-const REPO = 'https://foobar.net';
-const ISSUE_URL = `${REPO}/issues/new`;
-
 const renderFeedback = (props = {}) => {
   const utils = renderWithTranslation(<SimpleFeedback {...props} />);
 
@@ -44,8 +38,6 @@ jest.mock('@reach/router', () => ({
   useLocation: jest.fn(() => ({ pathname: '/foo-bar' })),
 }));
 
-const resultWithoutBody = (node) => node.getAttribute('href').split('&body')[0];
-
 describe('SimpleFeedback Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,58 +48,5 @@ describe('SimpleFeedback Component', () => {
 
     expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(screen.getByText('No')).toBeInTheDocument();
-  });
-
-  it('should render links with custom issue labels', () => {
-    const labels = ['food-feedback', 'tuesday'];
-    const { yes } = renderFeedback({ labels });
-
-    const params = new URLSearchParams();
-    params.set(
-      'labels',
-      [...labels, 'feedback', 'feedback-positive'].join(',')
-    );
-    params.set('title', 'Docs feedback');
-    const url = `${ISSUE_URL}?${params.toString()}`;
-
-    expect(resultWithoutBody(yes)).toBe(url);
-  });
-
-  it('should render links with default issue title', () => {
-    const { yes, no } = renderFeedback();
-
-    const yesParams = new URLSearchParams();
-    yesParams.set('labels', ['feedback', 'feedback-positive'].join(','));
-    yesParams.set('title', 'Docs feedback');
-    const positiveUrl = `${ISSUE_URL}?${yesParams.toString()}`;
-
-    const noParams = new URLSearchParams();
-    noParams.set('labels', ['feedback', 'feedback-negative'].join(','));
-    noParams.set('title', 'Docs feedback');
-    const negativeUrl = `${ISSUE_URL}?${noParams.toString()}`;
-
-    expect(resultWithoutBody(yes)).toBe(positiveUrl);
-    expect(resultWithoutBody(no)).toBe(negativeUrl);
-  });
-
-  it('should render links with the page title in the issue title', () => {
-    const title = 'tacos';
-    const { yes } = renderFeedback({ pageTitle: title });
-
-    const params = new URLSearchParams();
-    params.set('labels', ['feedback', 'feedback-positive'].join(','));
-    params.set('title', `Feedback: ${title}`);
-    const url = `${ISSUE_URL}?${params.toString()}`;
-
-    expect(resultWithoutBody(yes)).toBe(url);
-  });
-
-  it('should render links with page URL in the issue body', () => {
-    const pathname = '/test/page';
-    useLocation.mockImplementation(() => ({ pathname }));
-
-    const { yes } = renderFeedback();
-
-    expect(yes.getAttribute('href')).toMatch(encodeURIComponent(pathname));
   });
 });

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SimpleFeedback.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import SimpleFeedback from '../SimpleFeedback';
 import { renderWithTranslation } from '../../test-utils/renderHelpers';
 
@@ -10,12 +10,6 @@ jest.mock('gatsby', () => ({
     allLocale: {
       nodes: [{ locale: 'en', isDefault: true }],
     },
-    site: {
-      siteMetadata: {
-        siteUrl: 'https://github.com/foo/bar',
-        repository: 'https://foobar.net',
-      },
-    },
     newRelicThemeConfig: {
       tessen: {
         product: 'foo',
@@ -25,28 +19,26 @@ jest.mock('gatsby', () => ({
   }),
 }));
 
-const renderFeedback = (props = {}) => {
-  const utils = renderWithTranslation(<SimpleFeedback {...props} />);
-
-  const [yes, no] = screen.getAllByRole('button');
-
-  return { ...utils, yes, no };
-};
-
-jest.mock('@reach/router', () => ({
-  __esModule: true,
-  useLocation: jest.fn(() => ({ pathname: '/foo-bar' })),
-}));
-
 describe('SimpleFeedback Component', () => {
   beforeEach(() => {
+    window.Tessen = jest.fn();
     jest.clearAllMocks();
   });
 
   it('should render with two feedback buttons', () => {
-    renderFeedback();
+    renderWithTranslation(<SimpleFeedback />);
 
     expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('should display a message when a button is clicked', () => {
+    const message = 'Thank you for your feedback!';
+
+    renderWithTranslation(<SimpleFeedback />);
+
+    expect(screen.queryByText(message)).toBeNull();
+    fireEvent.click(screen.getAllByRole('button')[0]);
+    expect(screen.queryByText(message)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This removes the functionality of opening an issue upon leaving feedback. It also adds tessen tracking for positive or negative responses and displays a message after clicking to prevent spamming (unless you're determined and reload the page a lot)

Closes https://github.com/newrelic/gatsby-theme-newrelic/issues/373