### PR TITLE
Fix: Bump SearchModal z-index up higher

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
@@ -86,7 +86,7 @@ const SearchModal = ({ onClose, isOpen, onChange, value }) => {
               bottom: 0;
               left: 0;
               padding: var(--site-content-padding);
-              z-index: 100;
+              z-index: 900;
               background: ${rgba('#d5d7d7', 0.5)};
 
               .dark-mode & {


### PR DESCRIPTION
## Description

On PR review for opensource, there are some elements that have a 300 z-index, causing to float over the search modal. This bumps z-index up much higher to avoid that since it needs to float over most things.

## Screenshot

![Screen Shot 2021-05-19 at 11 34 17 AM](https://user-images.githubusercontent.com/1946433/118865776-2b89fa00-b896-11eb-94ad-828df9e75dad.png)

## Related PR
https://github.com/newrelic/opensource-website/pull/784