### PR TITLE
Fix to open image links in new tab

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -14,7 +14,7 @@ const isNewRelic = (to) => to.startsWith('https://newrelic.com');
 const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 
 const Link = forwardRef(
-  ({ to, onClick, instrumentation = {}, ...props }, ref) => {
+  ({ to, onClick, instrumentation = {}, className, ...props }, ref) => {
     const locale = useLocale();
 
     const {
@@ -49,7 +49,7 @@ const Link = forwardRef(
     }
 
     if (isHash(to)) {
-      return <a ref={ref} href={to} {...props} />;
+      return <a ref={ref} href={to} className={className} {...props} />;
     }
 
     if (isSignup(to)) {
@@ -59,6 +59,7 @@ const Link = forwardRef(
           href={to}
           onClick={handleExternalLinkClick}
           instrumentation={instrumentation}
+          className={className}
           ref={ref}
         />
       );
@@ -72,6 +73,7 @@ const Link = forwardRef(
       return (
         <a
           {...props}
+          className={className}
           href={link}
           onClick={handleExternalLinkClick}
           target="_blank"
@@ -81,8 +83,8 @@ const Link = forwardRef(
       );
     }
 
-    if (props.className === 'gatsby-resp-image-link') {
-      return <a {...normalizedProps} href={to} />;
+    if (className === 'gatsby-resp-image-link') {
+      return <a {...props} className={className} href={to} />;
     }
 
     return (
@@ -92,6 +94,7 @@ const Link = forwardRef(
           locale,
         })}
         ref={ref}
+        className={className}
         {...props}
       />
     );
@@ -102,6 +105,7 @@ Link.propTypes = {
   onClick: PropTypes.func,
   to: PropTypes.string.isRequired,
   instrumentation: PropTypes.object,
+  className: PropTypes.string,
 };
 
 export default Link;

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -81,6 +81,10 @@ const Link = forwardRef(
       );
     }
 
+    if (props.className === 'gatsby-resp-image-link') {
+      return <a {...normalizedProps} href={to} />;
+    }
+
     return (
       <GatsbyLink
         to={localizePath({

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -12,9 +12,10 @@ const isHash = (to) => to.startsWith('#');
 const isExternal = (to) => to.startsWith('http');
 const isNewRelic = (to) => to.startsWith('https://newrelic.com');
 const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
+const isImageLink = (className) => className === 'gatsby-resp-image-link';
 
 const Link = forwardRef(
-  ({ to, onClick, instrumentation = {}, className, ...props }, ref) => {
+  ({ to, onClick, instrumentation = {}, ...props }, ref) => {
     const locale = useLocale();
 
     const {
@@ -49,7 +50,7 @@ const Link = forwardRef(
     }
 
     if (isHash(to)) {
-      return <a ref={ref} href={to} className={className} {...props} />;
+      return <a ref={ref} href={to} {...props} />;
     }
 
     if (isSignup(to)) {
@@ -59,7 +60,6 @@ const Link = forwardRef(
           href={to}
           onClick={handleExternalLinkClick}
           instrumentation={instrumentation}
-          className={className}
           ref={ref}
         />
       );
@@ -73,7 +73,6 @@ const Link = forwardRef(
       return (
         <a
           {...props}
-          className={className}
           href={link}
           onClick={handleExternalLinkClick}
           target="_blank"
@@ -83,8 +82,8 @@ const Link = forwardRef(
       );
     }
 
-    if (className === 'gatsby-resp-image-link') {
-      return <a {...props} className={className} href={to} />;
+    if (isImageLink(props.className)) {
+      return <a {...props} href={to} />;
     }
 
     return (
@@ -94,7 +93,6 @@ const Link = forwardRef(
           locale,
         })}
         ref={ref}
-        className={className}
         {...props}
       />
     );


### PR DESCRIPTION
## Description

Adds a check for the class that the `gatsby-remark-images` plugin adds to `<a>` tags that wrap images and returns straight up `<a>` instead of a Gatsby `<Link />` component.

Since we're explicitly using `className` now, had to set that explicitly in all returns otherwise it does not get passed via `...props`

## Screenshots

https://user-images.githubusercontent.com/2952843/119009206-bd9e0b00-b947-11eb-8457-fb0f45d1e2c8.mp4

## Related issues

https://github.com/newrelic/docs-website/issues/2363