### PR TITLE
fix: handle lack of access to local storage

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby/on-client-entry.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-client-entry.js
@@ -1,4 +1,5 @@
 import getLocale from './utils/getLocale';
+import isLocalStorageAvailable from '../src/utils/isLocalStorageAvailable';
 
 const onClientEntry = (_, themeOptions) => {
   if (window.newrelic) {
@@ -11,10 +12,12 @@ const onClientEntry = (_, themeOptions) => {
 };
 
 const isDarkMode = () => {
-  const localStorageTheme = localStorage.getItem('darkMode');
+  if (isLocalStorageAvailable()) {
+    const localStorageTheme = localStorage.getItem('darkMode');
 
-  if (localStorageTheme) {
-    return JSON.parse(localStorageTheme);
+    if (localStorageTheme) {
+      return JSON.parse(localStorageTheme);
+    }
   }
 
   return document.body.classList.contains('dark-mode');

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -83,6 +83,7 @@
     "terser": "^5.6.1",
     "ua-parser-js": "^0.7.28",
     "use-dark-mode": "^2.3.1",
+    "use-local-storage-state": "^9.0.2",
     "use-media": "^1.4.0",
     "util": "^0.12.3",
     "warning": "^4.0.3",

--- a/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
+++ b/packages/gatsby-theme-newrelic/src/components/AnnouncementBanner.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import Banner from './Banner';
 import Icon from './Icon';
-import createPersistedState from 'use-persisted-state';
+import { createLocalStorageStateHook } from 'use-local-storage-state';
 import { graphql, useStaticQuery } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import { MDXRenderer } from 'gatsby-plugin-mdx';
@@ -9,7 +9,7 @@ import { STORAGE_KEYS } from '../utils/constants';
 import { parseISO, endOfDay, isBefore, isAfter } from 'date-fns';
 import useHasMounted from '../hooks/useHasMounted';
 
-const useLastAnnouncementDismissed = createPersistedState(
+const useLastAnnouncementDismissed = createLocalStorageStateHook(
   STORAGE_KEYS.LAST_ANNOUNCEMENT_DISMISSED
 );
 

--- a/packages/gatsby-theme-newrelic/src/components/DarkModeToggle.js
+++ b/packages/gatsby-theme-newrelic/src/components/DarkModeToggle.js
@@ -3,9 +3,23 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import Icon from './Icon';
 import useDarkMode from 'use-dark-mode';
+import isLocalStorageAvailable from '../utils/isLocalStorageAvailable';
+
+const localStorageMock = () => {
+  const store = {};
+  return {
+    getItem: (key) => store[key],
+    setItem: (key, val) => {
+      store[key] = val;
+    },
+  };
+};
 
 const DarkModeToggle = ({ className, size, onClick }) => {
-  const darkMode = useDarkMode();
+  const darkModeOptions = isLocalStorageAvailable()
+    ? {}
+    : { storageProvider: localStorageMock() };
+  const darkMode = useDarkMode(false, darkModeOptions);
 
   return (
     <Icon

--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useUserId.test.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useUserId.test.js
@@ -21,7 +21,7 @@ test('sets the generated user ID in local storage for persistence', () => {
 
   const { result } = renderHook(() => useUserId());
 
-  expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+  expect(localStorage.setItem).toHaveBeenCalledTimes(2);
   expect(localStorage.setItem).toHaveBeenLastCalledWith(
     STORAGE_KEYS.USER_ID,
     JSON.stringify(result.current)

--- a/packages/gatsby-theme-newrelic/src/hooks/useUserId.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useUserId.js
@@ -1,22 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useLocalStorageState } from 'use-local-storage-state';
 import generateUUID from '../utils/generateUUID';
 import { STORAGE_KEYS } from '../utils/constants';
 
-const useLocalStorage = (key, defaultValue = null) => {
-  const stored =
-    typeof window !== 'undefined' && window.localStorage.getItem(key);
-  const initial = stored ? JSON.parse(stored) : defaultValue;
-  const [value, setValue] = useState(initial);
-
-  useEffect(() => {
-    window.localStorage.setItem(key, JSON.stringify(value));
-  }, [key, value]);
-
-  return [value, setValue];
-};
-
 const useUserId = () => {
-  const [userId, setValue] = useLocalStorage(STORAGE_KEYS.USER_ID);
+  const [userId, setValue] = useLocalStorageState(STORAGE_KEYS.USER_ID);
   if (userId == null) {
     const uuid = generateUUID();
     setValue(uuid);

--- a/packages/gatsby-theme-newrelic/src/utils/isLocalStorageAvailable.js
+++ b/packages/gatsby-theme-newrelic/src/utils/isLocalStorageAvailable.js
@@ -1,0 +1,12 @@
+const isLocalStorageAvailable = () => {
+  try {
+    localStorage.setItem('test', 'value');
+    localStorage.getItem('test');
+    localStorage.removeItem('test');
+  } catch (error) {
+    return false;
+  }
+  return true;
+};
+
+export default isLocalStorageAvailable;

--- a/packages/gatsby-theme-newrelic/src/utils/isLocalStorageAvailable.js
+++ b/packages/gatsby-theme-newrelic/src/utils/isLocalStorageAvailable.js
@@ -1,12 +1,12 @@
 const isLocalStorageAvailable = () => {
   try {
-    localStorage.setItem('test', 'value');
-    localStorage.getItem('test');
-    localStorage.removeItem('test');
+    return (
+      typeof window !== 'undefined' &&
+      'setItem' in localStorage &&
+      'getItem' in localStorage
+    );
   } catch (error) {
     return false;
   }
-  return true;
 };
-
 export default isLocalStorageAvailable;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18716,6 +18716,11 @@ use-isomorphic-layout-effect@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
   integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
 
+use-local-storage-state@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/use-local-storage-state/-/use-local-storage-state-9.0.2.tgz#77ace2fd72c8d17d3da5be74cf6aa3e25b6e321c"
+  integrity sha512-loNVFqrzfsNoNVtM/3RJbjKVhSgTX15vPC5Tcuk7oflF0nonldRivMGAgFU3toi9v6hfTT/x8M+o6ifDN2n0OQ==
+
 use-media@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.4.0.tgz#e777bf1f382a7aacabbd1f9ce3da2b62e58b2a98"


### PR DESCRIPTION
# Summary
* Remove direct interaction with local storage in useUserId and use
  `use-local-storage-state`
* Replace use of `use-persisted-state` in the AnnouncementBanner with
  `use-local-storage-state`
* `on-client-entry.js` add check for local storage before accessing it
* Add check for local storage and in-memory store to DarkModeToggle
* Uses of `use-persisted-state` were removed because the library does
  not have a fallback if local storage is unavailable