### PR TITLE
fix: add pageaction to track user search terms

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -57,6 +57,11 @@ const useSearchQuery = () => {
     () => {
       if (hasQParam) {
         setQueryParam('q', searchTerm);
+        if (typeof window !== 'undefined' && window.newrelic && searchTerm) {
+          window.newrelic.addPageAction('swiftypeSearch_input', {
+            searchTerm,
+          });
+        }
       }
     },
     200,


### PR DESCRIPTION
* added a pageaction to track user terms in the globalheader since that
has a debounce hook. this should enable search terms data populating our
dashboard again.

Relates to: https://github.com/newrelic/docs-website/issues/2598