### PR TITLE
Explicilty set referrer URL path for Tessen

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -66,24 +66,24 @@ const trackPageView = ({ config, env, prevLocation }) => {
   });
 };
 
-const initializeTessenTracking = ({ config, env, location, prevLocation }) => (
-  options = {}
-) => {
-  if (canTrack() && !initialized) {
-    initialized = true;
-    const { segmentWriteKey } = config;
-    window.Tessen.load(['Segment', 'NewRelic'], {
-      Segment: {
-        identifiable: true,
-        writeKey: segmentWriteKey,
-      },
-    });
+const initializeTessenTracking =
+  ({ config, env, location, prevLocation }) =>
+  (options = {}) => {
+    if (canTrack() && !initialized) {
+      initialized = true;
+      const { segmentWriteKey } = config;
+      window.Tessen.load(['Segment', 'NewRelic'], {
+        Segment: {
+          identifiable: true,
+          writeKey: segmentWriteKey,
+        },
+      });
 
-    window.Tessen.identify({});
+      window.Tessen.identify({});
 
-    options.trackPageView &&
-      trackPageView({ config, env, location, prevLocation });
-  }
-};
+      options.trackPageView &&
+        trackPageView({ config, env, location, prevLocation });
+    }
+  };
 
 export default trackViaTessen;

--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -20,7 +20,7 @@ const warnAboutNoop = (pageView) => {
 const canSendPageView = (pageView) =>
   pageView && pageView.name && pageView.category;
 
-const trackViaTessen = ({ location }, themeOptions) => {
+const trackViaTessen = ({ location, prevLocation }, themeOptions) => {
   const env = getResolvedEnv(themeOptions);
   const tessenConfig = getTessenConfig(themeOptions);
 
@@ -32,6 +32,7 @@ const trackViaTessen = ({ location }, themeOptions) => {
     config: tessenConfig,
     env,
     location,
+    prevLocation,
   });
 
   if (!canTrack()) {
@@ -43,12 +44,12 @@ const trackViaTessen = ({ location }, themeOptions) => {
   // wrap inside a timeout to make sure react-helmet is done with its changes (https://github.com/gatsbyjs/gatsby/issues/11592)
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
-      trackPageView({ config: tessenConfig, env, location });
+      trackPageView({ config: tessenConfig, env, location, prevLocation });
     });
   });
 };
 
-const trackPageView = ({ config, env, location }) => {
+const trackPageView = ({ config, env, location, prevLocation }) => {
   const { pageView } = config;
   const { name, category, ...properties } = pageView;
 
@@ -60,28 +61,30 @@ const trackPageView = ({ config, env, location }) => {
 
   tessen.page(name, category, {
     env: env === 'production' ? 'prod' : env,
-    location: location.pathname,
+    pathname: location.pathname,
+    referrer: prevLocation,
     ...properties,
   });
 };
 
-const initializeTessenTracking =
-  ({ config, env, location }) =>
-  (options = {}) => {
-    if (canTrack() && !initialized) {
-      initialized = true;
-      const { segmentWriteKey } = config;
-      window.Tessen.load(['Segment', 'NewRelic'], {
-        Segment: {
-          identifiable: true,
-          writeKey: segmentWriteKey,
-        },
-      });
+const initializeTessenTracking = ({ config, env, location, prevLocation }) => (
+  options = {}
+) => {
+  if (canTrack() && !initialized) {
+    initialized = true;
+    const { segmentWriteKey } = config;
+    window.Tessen.load(['Segment', 'NewRelic'], {
+      Segment: {
+        identifiable: true,
+        writeKey: segmentWriteKey,
+      },
+    });
 
-      window.Tessen.identify({});
+    window.Tessen.identify({});
 
-      options.trackPageView && trackPageView({ config, env, location });
-    }
-  };
+    options.trackPageView &&
+      trackPageView({ config, env, location, prevLocation });
+  }
+};
 
 export default trackViaTessen;

--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -49,7 +49,7 @@ const trackViaTessen = ({ location, prevLocation }, themeOptions) => {
   });
 };
 
-const trackPageView = ({ config, env, location, prevLocation }) => {
+const trackPageView = ({ config, env, prevLocation }) => {
   const { pageView } = config;
   const { name, category, ...properties } = pageView;
 
@@ -61,8 +61,7 @@ const trackPageView = ({ config, env, location, prevLocation }) => {
 
   tessen.page(name, category, {
     env: env === 'production' ? 'prod' : env,
-    pathname: location.pathname,
-    referrer: prevLocation,
+    referrer: prevLocation?.pathname,
     ...properties,
   });
 };


### PR DESCRIPTION
## Description

Tessen is seemingly not capturing most referrer URL paths if a user has loaded the site and then clicks on any links for other pages on the site. We can explicitly set that, because we already send a "pageview" event for each route change. This just adds a `referrer` value to the `properties` in the tessen payload.

Also includes remove superfluous `location.pathname` since that's captured via `gatsby-config.js` properties function. Also, it seems `location` is used by tessen to indicate it's a `Public` site, so it was being overridden anyway.

## Related issues / PRs
Related to https://github.com/newrelic/docs-website/issues/2841