### PR TITLE
Generate correct path on Windows

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -288,7 +288,7 @@ exports.onCreatePage = (helpers, themeOptions) => {
       ) {
         createPage({
           ...transformedPage,
-          path: path.join(
+          path: path.posix.join(
             `/${locale}`,
             transformedPage.path,
             forceTrailingSlashes ? '/' : ''


### PR DESCRIPTION
`path.join` is platform-dependent: it uses backslashes as separators on Windows.

So pages generated with this theme have incorrect URLs.