### PR TITLE
chore: add io to global header nav

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -232,7 +232,7 @@ const GlobalHeader = ({ className }) => {
                 <Dropdown.MenuItem href="https://learn.newrelic.com/">
                   Learn
                 </Dropdown.MenuItem>
-                <Dropdown.MenuItem href="https://observabilitypacks.gatsbyjs.io/instant-observability/">
+                <Dropdown.MenuItem href="https://newrelic.com/instant-observability/">
                   Instant Observability
                 </Dropdown.MenuItem>
               </Dropdown.Menu>
@@ -287,7 +287,7 @@ const GlobalHeader = ({ className }) => {
                 </GlobalNavLink>
               </li>
               <li>
-                <GlobalNavLink href="https://observabilitypacks.gatsbyjs.io/instant-observability/">
+                <GlobalNavLink href="https://newrelic.com/instant-observability/">
                   Instant Observability
                 </GlobalNavLink>
               </li>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -232,6 +232,9 @@ const GlobalHeader = ({ className }) => {
                 <Dropdown.MenuItem href="https://learn.newrelic.com/">
                   Learn
                 </Dropdown.MenuItem>
+                <Dropdown.MenuItem href="https://observabilitypacks.gatsbyjs.io/instant-observability/">
+                  Instant Observability
+                </Dropdown.MenuItem>
               </Dropdown.Menu>
             </Dropdown>
 
@@ -281,6 +284,11 @@ const GlobalHeader = ({ className }) => {
               <li>
                 <GlobalNavLink href="https://learn.newrelic.com/">
                   Learn
+                </GlobalNavLink>
+              </li>
+              <li>
+                <GlobalNavLink href="https://observabilitypacks.gatsbyjs.io/instant-observability/">
+                  Instant Observability
                 </GlobalNavLink>
               </li>
             </ul>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql, Link, useStaticQuery } from 'gatsby';
 import ExternalLink from './ExternalLink';
+import { useLocation } from '@reach/router';
 
 const GlobalNavLink = ({ children, href }) => {
   const {
@@ -19,7 +20,12 @@ const GlobalNavLink = ({ children, href }) => {
     }
   `);
 
-  const isCurrentSite = href.startsWith(siteUrl);
+  const location = useLocation();
+  let isCurrentSite = href.startsWith(siteUrl);
+
+  if (location.pathname.includes('/instant-observability/')) {
+    isCurrentSite = href.includes('/instant-observability/');
+  }
 
   const Component = isCurrentSite ? Link : ExternalLink;
   const props = isCurrentSite ? { to: '/' } : { href };


### PR DESCRIPTION
Because the nav links to https://observabilitypacks.gatsbyjs.io/instant-observability/ it won't be possible to see the darker background until the pr is merged
<img width="1661" alt="Screenshot 2021-09-03 at 13 56 28" src="https://user-images.githubusercontent.com/17122543/132008657-408b7d09-6a2d-49dd-95ca-55082a4af8aa.png">
