### PR TITLE
Add ability to custom-set active sites in `<GlobalHeader />`

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -1270,63 +1270,20 @@ import { GlobalHeader } from '@newrelic/gatsby-theme-newrelic';
 
 **Props**
 | Prop | Type | Required | Default | Description |
-| --------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `editUrl` | string | no | | Used by the edit page link in the global header to link to a GitHub URL where a user can edit the page's source. If omitted, the edit page link will be excluded. |
+| - | - | - | - | - |
+| `activeSite` | enum | no | | The New Relic site that we should present as "active". This should come from `NR_SITES`, which is exported. |
 
-**Gatsby configuration**
-
-The `GlobalHeader` component consumes configuration defined for the theme. In
-order to make the most of the `GlobalHeader` component, it is recommended that
-you configure the following values in `gatsby-config.js`:
-
-```js
-// gatsby-config.js
-
-module.exports = {
-  siteMetadata: {
-    // Used to set the link that matches the current site as active
-    siteUrl: 'https://developer.newrelic.com',
-    // Used to create a link to the issues page from the global header
-    repository: 'https://github.com/newrelic/gatsby-theme-newrelic',
-  },
-  plugins: [
-    {
-      resolve: '@newrelic/gatsby-theme-newrelic',
-      options: {
-        // Define the layout properties to ensure the global header aligns
-        // nicely with the rest of the content
-        layout: {
-          maxWidth: '',
-          contentPadding: '',
-        },
-      },
-    },
-  ],
-};
-```
 
 **Examples**
 
 ```js
-import { graphql, useStaticQuery } from 'gatsby';
+import { GlobalHeader } from '@newrelic/gatsby-theme-newrelic';
 
-const Layout = () => {
-  const { data } = useStaticQuery(graphql`
-    query {
-      site {
-        siteMetadata {
-          repository
-        }
-      }
-    }
-  `);
+// Normal use
+return <GlobalHeader />;
 
-  return (
-    <GlobalHeader
-      editUrl={`${data.site.siteMetadata.repository}/src/components/layout.js`}
-    />
-  );
-};
+// With a custom-set active page
+return <GlobalHeader activeSite={GlobalHeader.NR_SITES.IO} />;
 ```
 
 ### `HamburgerMenu`

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -12,7 +12,10 @@ export { default as EditPageButton } from './src/components/EditPageButton';
 export { default as ExternalLink } from './src/components/ExternalLink';
 export { default as FeatherSVG } from './src/components/FeatherSVG';
 export { default as GlobalFooter } from './src/components/GlobalFooter';
-export { default as GlobalHeader } from './src/components/GlobalHeader';
+export {
+  default as GlobalHeader,
+  NR_SITES,
+} from './src/components/GlobalHeader';
 export { default as GitHubIssueButton } from './src/components/GitHubIssueButton';
 export { default as HamburgerMenu } from './src/components/HamburgerMenu';
 export { default as Icon } from './src/components/Icon';

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -33,6 +33,36 @@ const action = css`
   }
 `;
 
+export const NR_SITES = {
+  DOCS: 'DOCS',
+  DEVELOPER: 'DEVELOPER',
+  OSS: 'OSS',
+  COMMUNITY: 'COMMUNITY',
+  LEARN: 'LEARN',
+  IO: 'IO',
+};
+
+export const HEADER_LINKS = {
+  [NR_SITES.DOCS]: { text: 'Docs', href: 'https://developer.newrelic.com/' },
+  [NR_SITES.DEVELOPER]: {
+    text: 'Developer',
+    href: 'https://developer.newrelic.com/',
+  },
+  [NR_SITES.OSS]: {
+    text: 'Open Source',
+    href: 'https://opensource.newrelic.com/',
+  },
+  [NR_SITES.COMMUNITY]: {
+    text: 'Community',
+    href: 'https://discuss.newrelic.com/',
+  },
+  [NR_SITES.LEARN]: { text: 'Learn', href: 'https://learn.newrelic.com/' },
+  [NR_SITES.IO]: {
+    text: 'Instant Observability',
+    href: 'https://developer.newrelic.com/instant-observability',
+  },
+};
+
 const CONDENSED_BREAKPOINT = '760px';
 
 const actionLink = css`
@@ -217,21 +247,11 @@ const GlobalHeader = ({ className }) => {
                 <Icon name="logo-newrelic" size="1.125rem" />
               </Dropdown.Toggle>
               <Dropdown.Menu>
-                <Dropdown.MenuItem href="https://docs.newrelic.com/">
-                  Docs
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem href="https://developer.newrelic.com/">
-                  Developer
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem href="https://opensource.newrelic.com/">
-                  Open Source
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem href="https://discuss.newrelic.com/">
-                  Community
-                </Dropdown.MenuItem>
-                <Dropdown.MenuItem href="https://learn.newrelic.com/">
-                  Learn
-                </Dropdown.MenuItem>
+                {HEADER_LINKS.map(({ text, href }) => (
+                  <Dropdown.MenuItem key={href} href={href}>
+                    {text}
+                  </Dropdown.MenuItem>
+                ))}
               </Dropdown.Menu>
             </Dropdown>
 
@@ -258,31 +278,16 @@ const GlobalHeader = ({ className }) => {
                 }
               `}
             >
-              <li>
-                <GlobalNavLink href="https://docs.newrelic.com/">
-                  Docs
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://developer.newrelic.com/">
-                  Developers
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://opensource.newrelic.com/">
-                  Open Source
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://discuss.newrelic.com/">
-                  Community
-                </GlobalNavLink>
-              </li>
-              <li>
-                <GlobalNavLink href="https://learn.newrelic.com/">
-                  Learn
-                </GlobalNavLink>
-              </li>
+              {HEADER_LINKS.map(({ text, href }) => (
+                <li key={href}>
+                  <GlobalNavLink
+                    href={href}
+                    activeSite={activeSite && HEADER_LINKS[activeSite]}
+                  >
+                    {text}
+                  </GlobalNavLink>
+                </li>
+              ))}
             </ul>
           </nav>
 

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -105,7 +105,7 @@ const useSearchQuery = () => {
   return [searchTerm, setSearchTerm];
 };
 
-const GlobalHeader = ({ className }) => {
+const GlobalHeader = ({ className, activeSite }) => {
   const hasMounted = useHasMounted();
   const location = useLocation();
   const { queryParams, setQueryParam, deleteQueryParam } = useQueryParams();
@@ -450,6 +450,7 @@ const GlobalHeader = ({ className }) => {
 
 GlobalHeader.propTypes = {
   className: PropTypes.string,
+  activeSite: PropTypes.oneOf(Object.values(NR_SITES)),
 };
 
 export default GlobalHeader;

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -42,25 +42,59 @@ export const NR_SITES = {
   IO: 'IO',
 };
 
-export const HEADER_LINKS = {
-  [NR_SITES.DOCS]: { text: 'Docs', href: 'https://developer.newrelic.com/' },
-  [NR_SITES.DEVELOPER]: {
+const HEADER_LINKS = new Map();
+
+HEADER_LINKS.set(NR_SITES.DOCS, {
+  text: 'Docs',
+  href: 'https://docs.newrelic.com/',
+})
+  .set(NR_SITES.DEVELOPER, {
     text: 'Developer',
     href: 'https://developer.newrelic.com/',
-  },
-  [NR_SITES.OSS]: {
+  })
+  .set(NR_SITES.OSS, {
     text: 'Open Source',
     href: 'https://opensource.newrelic.com/',
-  },
-  [NR_SITES.COMMUNITY]: {
+  })
+  .set(NR_SITES.COMMUNITY, {
     text: 'Community',
     href: 'https://discuss.newrelic.com/',
-  },
-  [NR_SITES.LEARN]: { text: 'Learn', href: 'https://learn.newrelic.com/' },
-  [NR_SITES.IO]: {
+  })
+  .set(NR_SITES.LEARN, {
+    text: 'Learn',
+    href: 'https://learn.newrelic.com/',
+  })
+  .set(NR_SITES.IO, {
     text: 'Instant Observability',
     href: 'https://developer.newrelic.com/instant-observability',
-  },
+  });
+
+const createNavList = (listType, activeSite = null) => {
+  const navList = [];
+  HEADER_LINKS.forEach(({ text, href }) => {
+    switch (listType) {
+      case 'main':
+        navList.push(
+          <li key={href}>
+            <GlobalNavLink
+              href={href}
+              activeSite={activeSite && HEADER_LINKS.get(activeSite)}
+            >
+              {text}
+            </GlobalNavLink>
+          </li>
+        );
+        break;
+      case 'dropdown':
+        navList.push(
+          <Dropdown.MenuItem key={href} href={href}>
+            {text}
+          </Dropdown.MenuItem>
+        );
+        break;
+    }
+  });
+  return navList;
 };
 
 const CONDENSED_BREAKPOINT = '760px';
@@ -247,11 +281,7 @@ const GlobalHeader = ({ className, activeSite }) => {
                 <Icon name="logo-newrelic" size="1.125rem" />
               </Dropdown.Toggle>
               <Dropdown.Menu>
-                {HEADER_LINKS.map(({ text, href }) => (
-                  <Dropdown.MenuItem key={href} href={href}>
-                    {text}
-                  </Dropdown.MenuItem>
-                ))}
+                {createNavList('dropdown', activeSite)}
               </Dropdown.Menu>
             </Dropdown>
 
@@ -278,16 +308,7 @@ const GlobalHeader = ({ className, activeSite }) => {
                 }
               `}
             >
-              {HEADER_LINKS.map(({ text, href }) => (
-                <li key={href}>
-                  <GlobalNavLink
-                    href={href}
-                    activeSite={activeSite && HEADER_LINKS[activeSite]}
-                  >
-                    {text}
-                  </GlobalNavLink>
-                </li>
-              ))}
+              {createNavList('main', activeSite)}
             </ul>
           </nav>
 

--- a/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { graphql, Link, useStaticQuery } from 'gatsby';
 import ExternalLink from './ExternalLink';
 
-const GlobalNavLink = ({ children, href }) => {
+const GlobalNavLink = ({ children, href, activeSite }) => {
   const {
     site: {
       siteMetadata: { siteUrl },
@@ -19,7 +19,11 @@ const GlobalNavLink = ({ children, href }) => {
     }
   `);
 
-  const isCurrentSite = href.startsWith(siteUrl);
+  // Does the href start with this URL (and we don't have a site manually set)
+  // OR do we have a site manually set and the href matches.
+  const isCurrentSite =
+    (href.startsWith(siteUrl) && !activeSite) ||
+    (activeSite && activeSite.href === href);
 
   const Component = isCurrentSite ? Link : ExternalLink;
   const props = isCurrentSite ? { to: '/' } : { href };
@@ -57,6 +61,10 @@ const GlobalNavLink = ({ children, href }) => {
 GlobalNavLink.propTypes = {
   children: PropTypes.node,
   href: PropTypes.string.isRequired,
+  activeSite: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    href: PropTypes.string.isRequired,
+  }),
 };
 
 export default GlobalNavLink;


### PR DESCRIPTION
## Description
Adds some extra flexibility to our `<GlobalHeader />` component so that we can custom-set which page we would like to show as "active" (the one with a background color). We can use this code to update specific pages on the developer website to highlight "Instant Observability".

This PR also moves the storage of the links to an array so that, if we need to change the order / items, we only have to update it in one location (rather than a few places in the JSX).

## Reviewer Notes
This PR is an alternative approach compared to solving #438 (compared to #449). I don't mind which direction we go, just wanted to move the conversation forward.
