### PR TITLE
chore: fixed no results text

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/NoResults.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/NoResults.js
@@ -21,10 +21,9 @@ const NoResults = () => (
     <h5
       css={css`
         font-size: 0.875rem;
-        text-transform: uppercase;
       `}
     >
-      No Results Found
+      We didn't find any results
     </h5>
     <p
       css={css`
@@ -34,12 +33,8 @@ const NoResults = () => (
         text-align: center;
       `}
     >
-      Make a{' '}
-      <Link to="https://github.com/newrelic/docs-website/issues/new?assignees=&labels=content&template=content-issue.md&title=Summarize+your+docs+request">
-        request
-      </Link>{' '}
-      for new documentation or start a conversation on our{' '}
-      <Link to="https://discuss.newrelic.com/">Explorer's Hub</Link>!
+      Try searching for different keywords or start a conversation on our{' '}
+      <Link to="https://discuss.newrelic.com/">Explorers Hub</Link>!
     </p>
   </div>
 );

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/NoResults.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/NoResults.js
@@ -34,7 +34,7 @@ const NoResults = () => (
       `}
     >
       Try searching for different keywords or start a conversation on our{' '}
-      <Link to="https://discuss.newrelic.com/">Explorers Hub</Link>!
+      <Link to="https://discuss.newrelic.com/">Explorers Hub</Link>.
     </p>
   </div>
 );


### PR DESCRIPTION
This PR replaces the no results message with the approved language. 

<img width="1029" alt="Screen Shot 2021-09-13 at 5 08 11 PM" src="https://user-images.githubusercontent.com/1395158/133168597-95582f82-6344-4ea8-9b42-194e0bcbea96.png">
