### PR TITLE
Remove IO from header nav

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -39,7 +39,6 @@ export const NR_SITES = {
   OSS: 'OSS',
   COMMUNITY: 'COMMUNITY',
   LEARN: 'LEARN',
-  IO: 'IO',
 };
 
 const HEADER_LINKS = new Map();
@@ -63,10 +62,6 @@ HEADER_LINKS.set(NR_SITES.DOCS, {
   .set(NR_SITES.LEARN, {
     text: 'Learn',
     href: 'https://learn.newrelic.com/',
-  })
-  .set(NR_SITES.IO, {
-    text: 'Instant Observability',
-    href: 'https://developer.newrelic.com/instant-observability',
   });
 
 const createNavList = (listType, activeSite = null) => {


### PR DESCRIPTION
## Description
Simply removes the I/O nav item in the `GlobalHeader` so we can continue non-IO theme releases