### PR TITLE
Add amplitude setting when loading tessen

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -76,6 +76,7 @@ const initializeTessenTracking =
         Segment: {
           identifiable: true,
           writeKey: segmentWriteKey,
+          useAmplitudeSessions: true,
         },
       });
 


### PR DESCRIPTION
## Description

Confirmed with Rafael in #external-amplitude-team that we need to add an amplitude setting when using latest tessen version.

