### PR TITLE
fix: update swiftype filter for quickstarts

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
@@ -21,7 +21,7 @@ const defaultFilters = [
   { name: 'docs', isSelected: false },
   { name: 'developer', isSelected: false },
   { name: 'opensource', isSelected: false },
-  { name: 'quick_starts', isSelected: false },
+  { name: 'quickstarts', isSelected: false },
 ];
 
 const SearchModal = ({ onClose, isOpen, onChange, value }) => {


### PR DESCRIPTION
## Descriptions

Update the `type` filter to use what we're setting on the developer site.

## Screenshots
![2021-09-29_16-57-04](https://user-images.githubusercontent.com/2952843/135364366-6741358a-db8b-48ea-977e-adca5a2e76d6.png)

