### PR TITLE
chore: update referrer to use full url (#489)

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -56,7 +56,7 @@ const trackPageView = ({ config, env, prevLocation }) => {
 
   tessen.page(name, category, {
     env: env === 'production' ? 'prod' : env,
-    referrer: prevLocation?.pathname,
+    referrer: prevLocation?.href,
     ...properties,
   });
 };


### PR DESCRIPTION
* instead of only grabbing only the pathname, referrer is now set with
the whole url string.

Relates to: #489 