### PR TITLE
[Tessen] Update env value, add to track events as well

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -46,6 +46,7 @@ const tessenAction =
       name,
       {
         ...properties,
+        env: config.env || '',
         category,
         nr_product: config.product,
         nr_subproduct: config.subproduct,

--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -47,6 +47,7 @@ const trackViaTessen = ({ location, prevLocation }, themeOptions) => {
 
 const trackPageView = ({ config, env, location, prevLocation }) => {
   const { pageView } = config;
+  config.env = env;
   const { name, category, ...properties } = pageView;
 
   const tessen = createTessen(config);
@@ -56,7 +57,7 @@ const trackPageView = ({ config, env, location, prevLocation }) => {
   }
 
   tessen.page(name, category, {
-    env: env === 'production' ? 'prod' : env,
+    env: env || 'development',
     path: location.pathname,
     referrer: prevLocation?.href,
     ...properties,


### PR DESCRIPTION
## Description

Per Slack convo, a team uses the `env`property we send in Tessen events for some NR1 queries/dashboards in the Tessen account. They expect the value to be `production` instead of `prod`.

Additionally, we weren't sending this `env` property in `tessen.track()` events, so this adds that.
