### PR TITLE
fix: set correct sitemap url in robots.txt

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-config.js
+++ b/packages/gatsby-theme-newrelic/gatsby-config.js
@@ -29,6 +29,7 @@ module.exports = ({ layout, newrelic, robots = {}, sitemap = true }) => {
       {
         resolve: 'gatsby-plugin-robots-txt',
         options: {
+          sitemap: 'sitemap-index.xml',
           policy: [{ userAgent: '*', allow: '/' }],
           ...robots,
         },


### PR DESCRIPTION
Updated the `gatsby-plugin-robots-txt` options. When running a local build of the demo app, `localhost:9000/robots.txt` now displays the correct url:


<img width="456" alt="Screen Shot 2021-10-27 at 2 27 52 PM" src="https://user-images.githubusercontent.com/47728020/139149793-588d88ff-d55f-4731-87f2-0514fafcd7b9.png">


closes https://github.com/newrelic/gatsby-theme-newrelic/issues/512