### PR TITLE
[Analytics] Improve debounced search term reporting to avoid tracking incomplete searches

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -119,14 +119,20 @@ const useSearchQuery = () => {
     () => {
       if (hasQParam) {
         setQueryParam('q', searchTerm);
-        if (typeof window !== 'undefined' && window.newrelic && searchTerm) {
+        if (
+          typeof window !== 'undefined' &&
+          window.newrelic &&
+          searchTerm &&
+          searchTerm.length > 2
+        ) {
+          console.log('search term:', searchTerm);
           window.newrelic.addPageAction('swiftypeSearch_input', {
             searchTerm,
           });
         }
       }
     },
-    200,
+    400,
     [searchTerm, setQueryParam, hasQParam]
   );
 

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -125,7 +125,6 @@ const useSearchQuery = () => {
           searchTerm &&
           searchTerm.length > 2
         ) {
-          console.log('search term:', searchTerm);
           window.newrelic.addPageAction('swiftypeSearch_input', {
             searchTerm,
           });


### PR DESCRIPTION
- Add a longer debounce time to match search on IO page
- Add conditional to only send analytics via `pageAction` if search query string is 3 or greater