### PR TITLE
chore: update handleExternalLinkClick to pass onClick parameter

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -3,7 +3,6 @@ import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql, Link as GatsbyLink } from 'gatsby';
 import useLocale from '../hooks/useLocale';
-import useTessen from '../hooks/useTessen';
 import { localizePath } from '../utils/localization';
 import SignUpLink from './SignUpLink';
 import Icon from './Icon';
@@ -24,7 +23,6 @@ const Link = forwardRef(
     ref
   ) => {
     const locale = useLocale();
-    const tessen = useTessen();
 
     const {
       newRelicThemeConfig: { forceTrailingSlashes },
@@ -44,12 +42,16 @@ const Link = forwardRef(
       }
     `);
 
-    const handleExternalLinkClick = () => {
-      tessen.track('gatsbyTheme', 'ExternalLinkClick', {
+    const handleExternalLinkClick = useInstrumentedHandler(
+      onClick,
+      {
+        tessenEventName: 'gatsbyTheme',
+        tessenCategoryName: 'ExternalLinkClick',
         href: to,
         ...instrumentation,
-      });
-    };
+      },
+      'tessen'
+    );
 
     const handleInternalLinkClick = useInstrumentedHandler(
       onClick,


### PR DESCRIPTION
* we forgot to modify handleExternalLinkClick the same way we modified
handleInternalLinkClick by passing the onClick parameter. Updated so
they are now in parity.

Relates to: https://github.com/newrelic/developer-website/issues/1850