### PR TITLE
Tabatha/splitio signup text

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -59,7 +59,12 @@ module.exports = {
         splitio: {
           // Mocked features only used when in localhost mode
           // https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#localhost-mode
-          features: {},
+          features: {
+            gatsby_theme_signup_button: {
+              treatment: 'start_now',
+              config: '{ "text": "Start now" }',
+            },
+          },
           core: {
             authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',
           },

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -60,7 +60,7 @@ module.exports = {
           // Mocked features only used when in localhost mode
           // https://help.split.io/hc/en-us/articles/360020448791-JavaScript-SDK#localhost-mode
           features: {
-            gatsby_theme_signup_button: {
+            deven_signupbutton_text: {
               treatment: 'start_now',
               config: '{ "text": "Start now" }',
             },

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -22,6 +22,8 @@ import SearchModal from './SearchModal';
 import { useDebounce } from 'react-use';
 import useHasMounted from '../hooks/useHasMounted';
 
+import SplitTextButton from './SplitTextButton';
+
 const action = css`
   color: var(--secondary-text-color);
   transition: all 0.2s ease-out;
@@ -451,15 +453,7 @@ const GlobalHeader = ({ className, activeSite }) => {
                 display: flex;
               `}
             >
-              <Button
-                as={ExternalLink}
-                href="https://newrelic.com/signup"
-                size={Button.SIZE.EXTRA_SMALL}
-                variant={Button.VARIANT.PRIMARY}
-                instrumentation={{ component: 'GlobalHeader' }}
-              >
-                <span>{t('button.signUp')}</span>
-              </Button>
+              <SplitTextButton />
             </li>
           </ul>
         </div>

--- a/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+  useTreatments,
+  SplitContext,
+  useTrack,
+} from '@splitsoftware/splitio-react';
+import { SPLITS, SPLIT_TRACKING_EVENTS } from '../utils/constants';
+import Button from './Button';
+import ExternalLink from './ExternalLink';
+import useThemeTranslation from '../hooks/useThemeTranslation';
+
+const SplitTextButton = () => {
+  const { t } = useThemeTranslation();
+  const { deven_signupbutton_text } = useTreatments([
+    SPLITS.SIGNUP_BUTTON_TEXT,
+  ]);
+  const track = useTrack();
+  const clickCallback = () => {
+    track(SPLIT_TRACKING_EVENTS.SIGNUP_BUTTON_CLICK);
+  };
+  const splitText = deven_signupbutton_text?.treatment;
+
+  const { isReady } = React.useContext(SplitContext);
+
+  return isReady ? (
+    <Button
+      as={ExternalLink}
+      href="https://newrelic.com/signup"
+      size={Button.SIZE.EXTRA_SMALL}
+      variant={Button.VARIANT.PRIMARY}
+      instrumentation={{ component: 'GlobalHeader' }}
+      onClick={clickCallback}
+    >
+      <span>
+        {t(splitText === 'start_now' ? 'button.startNow' : 'button.signUp')}
+      </span>
+    </Button>
+  ) : (
+    <Button
+      as={ExternalLink}
+      href="https://newrelic.com/signup"
+      size={Button.SIZE.EXTRA_SMALL}
+      variant={Button.VARIANT.PRIMARY}
+      instrumentation={{ component: 'GlobalHeader' }}
+    >
+      <span>{t('button.signUp')}</span>
+    </Button>
+  );
+};
+
+export default SplitTextButton;

--- a/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
@@ -28,7 +28,7 @@ const SplitTextButton = () => {
       href="https://newrelic.com/signup"
       size={Button.SIZE.EXTRA_SMALL}
       variant={Button.VARIANT.PRIMARY}
-      instrumentation={{ component: 'GlobalHeader' }}
+      instrumentation={{ component: 'SplitTextButton' }}
       onClick={clickCallback}
     >
       <span>

--- a/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
@@ -41,7 +41,7 @@ const SplitTextButton = () => {
       href="https://newrelic.com/signup"
       size={Button.SIZE.EXTRA_SMALL}
       variant={Button.VARIANT.PRIMARY}
-      instrumentation={{ component: 'GlobalHeader' }}
+      instrumentation={{ component: 'SplitTextButton' }}
     >
       <span>{t('button.signUp')}</span>
     </Button>

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
@@ -1,97 +1,68 @@
 import React from 'react';
-import TestRenderer from 'react-test-renderer';
-import rerender from '@testing-library/react';
 import { SplitFactory } from '@splitsoftware/splitio-react';
 import SplitTextButton from '../SplitTextButton';
-import { renderWithProviders } from '../../test-utils/renderHelpers';
+import {  renderWithProviders} from '../../test-utils/renderHelpers';
 import { screen } from '@testing-library/react';
 
-import useThemeTranslation from '../../hooks/useThemeTranslation';
-import Button from '../Button';
 
-// jest.mock('../../hooks/useThemeTranslation', () =>
-//   jest.fn(() => ({ t: jest.fn((s) => s) }))
-// );
-
-// jest.mock('../Button', () => ({ children }) => <button>{children}</button>);
-
-// jest.mock('gatsby', () => ({
-//   __esModule: true,
-//   graphql: () => {},
-//   Link: ({ to, ...props }) => <a href={to} {...props} />,
-//   useStaticQuery: () => ({
-//     allLocale: {
-//       nodes: [
-//         {
-//           name: 'English',
-//           locale: 'en',
-//           localizedPath: '/en',
-//           isDefault: true,
-//         },
-//       ],
-//     },
-//     site: {
-//       siteMetadata: {
-//         siteUrl: 'https://github.com/foo/bar',
-//         repository: 'https://foobar.net',
-//       },
-//     },
-//     newRelicThemeConfig: {
-//       tessen: {
-//         product: 'foo',
-//         subproduct: 'foobar',
-//       },
-//     },
-//   }),
-// }));
-
-export const renderWithTranslation = (component, options) => {
-  i18n.init({
-    ...i18nextOptions,
-    lng: 'en',
-    resources: {
-      en: {
-        [themeNamespace]: translations,
-      },
-    },
-  });
-
-  return render(
-    <I18nextProvider i18n={i18n}>
-      <LocaleProvider i18n={i18n}>{component}</LocaleProvider>
-    </I18nextProvider>,
-    options
-  );
-};
+jest.mock('gatsby', () => ({
+ __esModule: true,
+ graphql: () => {},
+ Link: ({ to, ...props }) => <a href={to} {...props} />,
+ useStaticQuery: () => ({
+   allLocale: {
+     nodes: [
+       {
+         name: 'English',
+         locale: 'en',
+         localizedPath: '/en',
+         isDefault: true,
+       },
+     ],
+   },
+   site: {
+     siteMetadata: {
+       siteUrl: 'https://github.com/foo/bar',
+       repository: 'https://foobar.net',
+     },
+   },
+   newRelicThemeConfig: {
+     tessen: {
+       product: 'foo',
+       subproduct: 'foobar',
+     },
+   },
+ }),
+}));
 
 test('renders default button text with no split', async () => {
-  const config = createSplitConfig('start_now');
-  //   console.log(config);
+  const config = createSplitConfig();
 
-  const element = renderWithProviders(
+  renderWithProviders(
     <SplitFactory config={config} updateOnSdkTimedout={true}>
       <SplitTextButton />
     </SplitFactory>
   );
 
-  await TestRenderer.act(async () => {
-    rerender(element);
-  });
-
-  expect(screen.getByText('Free account')).toBeTruthy();
+  expect(screen.queryByText('Start now')).not.toBeInTheDocument();
+  expect(await screen.findByText('Free account')).toBeInTheDocument();
 });
 
 const createSplitConfig = (text) => {
+  let treatment = {};
+  if (text) {
+    treatment = (text === 'start_now')
+      ? { treatment: 'start_now', config: '{ "text": "Start now" }' }
+      : { treatment: 'free_account', config: '{ "text": "Free account" }' };
+  }
+
   return {
     core: {
       authorizationKey: 'localhost',
       key: 'user',
     },
     features: {
-      deven_signupbutton_text:
-        text === 'start_now'
-          ? { treatment: 'start_now', config: '{ "text": "Start now" }' }
-          : { treatment: 'free_account', config: '{ "text": "Free account" }' },
+      deven_signupbutton_text: treatment
     },
     scheduler: {
       offlineRefreshRate: 15,

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import rerender from '@testing-library/react';
+import { SplitFactory } from '@splitsoftware/splitio-react';
+import SplitTextButton from '../SplitTextButton';
+import { renderWithProviders } from '../../test-utils/renderHelpers';
+import { screen } from '@testing-library/react';
+
+import useThemeTranslation from '../../hooks/useThemeTranslation';
+import Button from '../Button';
+
+// jest.mock('../../hooks/useThemeTranslation', () =>
+//   jest.fn(() => ({ t: jest.fn((s) => s) }))
+// );
+
+// jest.mock('../Button', () => ({ children }) => <button>{children}</button>);
+
+// jest.mock('gatsby', () => ({
+//   __esModule: true,
+//   graphql: () => {},
+//   Link: ({ to, ...props }) => <a href={to} {...props} />,
+//   useStaticQuery: () => ({
+//     allLocale: {
+//       nodes: [
+//         {
+//           name: 'English',
+//           locale: 'en',
+//           localizedPath: '/en',
+//           isDefault: true,
+//         },
+//       ],
+//     },
+//     site: {
+//       siteMetadata: {
+//         siteUrl: 'https://github.com/foo/bar',
+//         repository: 'https://foobar.net',
+//       },
+//     },
+//     newRelicThemeConfig: {
+//       tessen: {
+//         product: 'foo',
+//         subproduct: 'foobar',
+//       },
+//     },
+//   }),
+// }));
+
+export const renderWithTranslation = (component, options) => {
+  i18n.init({
+    ...i18nextOptions,
+    lng: 'en',
+    resources: {
+      en: {
+        [themeNamespace]: translations,
+      },
+    },
+  });
+
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <LocaleProvider i18n={i18n}>{component}</LocaleProvider>
+    </I18nextProvider>,
+    options
+  );
+};
+
+test('renders default button text with no split', async () => {
+  const config = createSplitConfig('start_now');
+  //   console.log(config);
+
+  const element = renderWithProviders(
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitTextButton />
+    </SplitFactory>
+  );
+
+  await TestRenderer.act(async () => {
+    rerender(element);
+  });
+
+  expect(screen.getByText('Free account')).toBeTruthy();
+});
+
+const createSplitConfig = (text) => {
+  return {
+    core: {
+      authorizationKey: 'localhost',
+      key: 'user',
+    },
+    features: {
+      deven_signupbutton_text:
+        text === 'start_now'
+          ? { treatment: 'start_now', config: '{ "text": "Start now" }' }
+          : { treatment: 'free_account', config: '{ "text": "Free account" }' },
+    },
+    scheduler: {
+      offlineRefreshRate: 15,
+    },
+    debug: false,
+  };
+};

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
@@ -5,33 +5,33 @@ import { renderWithProviders } from '../../test-utils/renderHelpers';
 import { screen } from '@testing-library/react';
 
 jest.mock('gatsby', () => ({
- __esModule: true,
- graphql: () => {},
- Link: ({ to, ...props }) => <a href={to} {...props} />,
- useStaticQuery: () => ({
-   allLocale: {
-     nodes: [
-       {
-         name: 'English',
-         locale: 'en',
-         localizedPath: '/en',
-         isDefault: true,
-       },
-     ],
-   },
-   site: {
-     siteMetadata: {
-       siteUrl: 'https://github.com/foo/bar',
-       repository: 'https://foobar.net',
-     },
-   },
-   newRelicThemeConfig: {
-     tessen: {
-       product: 'foo',
-       subproduct: 'foobar',
-     },
-   },
- }),
+  __esModule: true,
+  graphql: () => {},
+  Link: ({ to, ...props }) => <a href={to} {...props} />,
+  useStaticQuery: () => ({
+    allLocale: {
+      nodes: [
+        {
+          name: 'English',
+          locale: 'en',
+          localizedPath: '/en',
+          isDefault: true,
+        },
+      ],
+    },
+    site: {
+      siteMetadata: {
+        siteUrl: 'https://github.com/foo/bar',
+        repository: 'https://foobar.net',
+      },
+    },
+    newRelicThemeConfig: {
+      tessen: {
+        product: 'foo',
+        subproduct: 'foobar',
+      },
+    },
+  }),
 }));
 
 test('renders default button text with no split', async () => {
@@ -84,8 +84,7 @@ test('renders if no features are returned from Split.io', async () => {
       offlineRefreshRate: 15,
     },
     debug: false,
-
-  }
+  };
   renderWithProviders(
     <SplitFactory config={config} updateOnSdkTimedout={true}>
       <SplitTextButton />
@@ -99,9 +98,10 @@ test('renders if no features are returned from Split.io', async () => {
 const createSplitConfig = (text) => {
   let treatment = {};
   if (text) {
-    treatment = (text === 'start_now')
-      ? { treatment: 'start_now', config: '{ "text": "Start now" }' }
-      : { treatment: 'free_account', config: '{ "text": "Free account" }' };
+    treatment =
+      text === 'start_now'
+        ? { treatment: 'start_now', config: '{ "text": "Start now" }' }
+        : { treatment: 'free_account', config: '{ "text": "Free account" }' };
   }
 
   return {
@@ -110,7 +110,7 @@ const createSplitConfig = (text) => {
       key: 'user',
     },
     features: {
-      deven_signupbutton_text: treatment
+      deven_signupbutton_text: treatment,
     },
     scheduler: {
       offlineRefreshRate: 15,

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/SplitTextButton.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { SplitFactory } from '@splitsoftware/splitio-react';
 import SplitTextButton from '../SplitTextButton';
-import {  renderWithProviders} from '../../test-utils/renderHelpers';
+import { renderWithProviders } from '../../test-utils/renderHelpers';
 import { screen } from '@testing-library/react';
-
 
 jest.mock('gatsby', () => ({
  __esModule: true,
@@ -44,8 +43,57 @@ test('renders default button text with no split', async () => {
     </SplitFactory>
   );
 
-  expect(screen.queryByText('Start now')).not.toBeInTheDocument();
   expect(await screen.findByText('Free account')).toBeInTheDocument();
+  expect(screen.queryByText('Start now')).not.toBeInTheDocument();
+});
+
+test('renders start_now treatment', async () => {
+  const config = createSplitConfig('start_now');
+
+  renderWithProviders(
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitTextButton />
+    </SplitFactory>
+  );
+
+  expect(await screen.findByText('Start now')).toBeInTheDocument();
+  expect(screen.queryByText('Free account')).not.toBeInTheDocument();
+});
+
+test('renders free account treatment', async () => {
+  const config = createSplitConfig('free_account');
+
+  renderWithProviders(
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitTextButton />
+    </SplitFactory>
+  );
+
+  expect(await screen.findByText('Free account')).toBeInTheDocument();
+  expect(screen.queryByText('Start now')).not.toBeInTheDocument();
+});
+
+test('renders if no features are returned from Split.io', async () => {
+  const config = {
+    core: {
+      authorizationKey: 'localhost',
+      key: 'user',
+    },
+    features: {},
+    scheduler: {
+      offlineRefreshRate: 15,
+    },
+    debug: false,
+
+  }
+  renderWithProviders(
+    <SplitFactory config={config} updateOnSdkTimedout={true}>
+      <SplitTextButton />
+    </SplitFactory>
+  );
+
+  expect(await screen.findByText('Free account')).toBeInTheDocument();
+  expect(screen.queryByText('Start now')).not.toBeInTheDocument();
 });
 
 const createSplitConfig = (text) => {

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/SplitTextButton.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/SplitTextButton.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`renders default button with no split 1`] = `null`;

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/SplitTextButton.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/SplitTextButton.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders default button with no split 1`] = `null`;

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -11,7 +11,8 @@
     "copied": "Copied",
     "copy": "Copy",
     "login": "Log in",
-    "signUp": "Free account"
+    "signUp": "Free account",
+    "startNow": "Start now"
   },
   "callout": {
     "tip": "Tip",

--- a/packages/gatsby-theme-newrelic/src/utils/constants.js
+++ b/packages/gatsby-theme-newrelic/src/utils/constants.js
@@ -11,9 +11,19 @@ const DEV_SEGMENT_WRITE_KEY = 'oMdv2YZCnzuC1iTVi9iCnFn6F9ycYb5v';
 
 const SWIFTYPE_ENGINE_KEY = 'Ad9HfGjDw4GRkcmJjUut';
 
+const SPLITS = {
+  SIGNUP_BUTTON_TEXT: 'deven_signupbutton_text',
+};
+
+const SPLIT_TRACKING_EVENTS = {
+  SIGNUP_BUTTON_CLICK: 'DEVEN_signuptext_click',
+};
+
 module.exports = {
   STORAGE_KEYS,
   TRACKING_COOKIE_NAME,
   DEV_SEGMENT_WRITE_KEY,
   SWIFTYPE_ENGINE_KEY,
+  SPLITS,
+  SPLIT_TRACKING_EVENTS,
 };


### PR DESCRIPTION
Created a new component to replace the signup button in the theme header that receives Split IO treatments with text that reads "Start now" or "Free account." Also added a unit test for this component.

Closes https://github.com/newrelic/gatsby-theme-newrelic/issues/508