### PR TITLE
[Tessen] Add property to page calls to fix google analytics bounce rate issue

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -58,6 +58,7 @@ const trackPageView = ({ config, env, location, prevLocation }) => {
 
   tessen.page(name, category, {
     env: env || 'development',
+    nonInteraction: 1,
     path: location.pathname,
     referrer: prevLocation?.href,
     ...properties,


### PR DESCRIPTION
## Description

Adds a property to `tessen.page()` calls to tell Segment (and therefore Google Analytics) that it's not an interaction event so Google can accurately calculate bounce rate.

This surfaced only recently because we are now only using Tessen events to send to GA so it became more obvious

Worth noting there's a corresponding `track()` call that is also fired when a `page()` is fired. Verified locally that this prop is on both.

## Related issues / PRs
- Closes https://github.com/newrelic/docs-website/issues/4583
- Jira ONYX-1312
- https://segment.com/docs/connections/destinations/catalog/google-analytics/#non-interaction-events