### PR TITLE
feat: script for publishing each branch as a separate release

### DIFF
--- a/.github/branch-release.js
+++ b/.github/branch-release.js
@@ -1,7 +1,7 @@
 const { execSync } = require("child_process");
 var pjson = require("../packages/gatsby-theme-newrelic/package.json");
 const currentVersion = pjson.version;
-
+const PACKAGE_PATH = './packages/gatsby-theme-newrelic';
 /**
  * Check that the NPM_TOKEN environment variable is set
  * @returns {String} Either the latest version or ''
@@ -84,7 +84,7 @@ const getNextBranchVersion = (branchName, branchTagVersion) => {
  */
 const setYarnVersion = (version) => {
   const yarnVersion = executeCommand(
-    `yarn version --new-version "${version}" --no-git-tag-version`
+    `yarn --cwd ${PACKAGE_PATH} version --new-version "${version}" --no-git-tag-version`
   );
   console.log(`✅ Yarn version set ✅`);
   console.log(yarnVersion);
@@ -95,7 +95,7 @@ const setYarnVersion = (version) => {
  * @param {String} tag The tag to publish to
  */
 const publishYarnVersion = (tag) => {
-  const published = executeCommand(`yarn publish --access public --tag ${tag}`);
+  const published = executeCommand(`yarn --cwd ${PACKAGE_PATH} publish --access public --tag ${tag}`);
   console.log(`✅ Yarn version set ✅`);
   console.log(published);
 };

--- a/.github/branch-release.js
+++ b/.github/branch-release.js
@@ -1,5 +1,5 @@
 const { execSync } = require("child_process");
-var pjson = require("../package.json");
+var pjson = require("../packages/gatsby-theme-newrelic/package.json");
 const currentVersion = pjson.version;
 
 /**

--- a/.github/branch-release.js
+++ b/.github/branch-release.js
@@ -1,0 +1,157 @@
+const { execSync } = require("child_process");
+var pjson = require("../package.json");
+const currentVersion = pjson.version;
+const EXCLUDE_BRANCHES = ["master", "develop", "main"];
+const REQUIRED_NODE_VERSION = 16;
+
+
+/**
+ * Check that the NPM_TOKEN environment variable is set
+ * @returns {String} Either the latest version or ''
+ */
+const checkNpmToken = () => {
+  const npmToken = process.env.NPM_TOKEN;
+  if (!npmToken) {
+    console.error(`❌ NPM_TOKEN is not set ❌`);
+    process.exit(1);
+  }
+  console.log(`✅ NPM token environment variable is set ✅`);
+};
+
+/**
+ * Get the name of the current working branch
+ * @returns {String} The name of the current working branch
+ */
+const getBranchName = () => {
+  return executeCommand(`git rev-parse --abbrev-ref HEAD`);
+};
+
+/**
+ * Check the latest version on a given branch tag
+ * @param {String} tag The tag to check
+ * @returns {String} Either the latest version or ''
+ */
+const checkBranchTagExists = (tag) => {
+  return executeCommand(`npm view ruairi-test dist-tags.${tag}`);
+};
+
+/**
+ * Executes a bash command in the terminal using execSync
+ * @param {String} cmd The command to execute
+ * @returns {String} The result of the executed command
+ */
+const executeCommand = (cmd) => {
+  try {
+    const result = execSync(cmd);
+    return result.toString().trim();
+  } catch (err) {
+    console.log(`❌ Error: ${err} ❌`);
+    console.log(`❌ Stderr: ${err.stderr.toString()} ❌`);
+    process.exit(1);
+  }
+};
+
+/**
+ * Removes a redirect if the slug is in the redirects array
+ * @param {String} branchName The current working branch name
+ * @param {String} branchTagVersion The latest version from the branch tag 
+ * @returns {String} The next branch version
+ */
+const getNextBranchVersion = (branchName, branchTagVersion) => {
+  if (branchTagVersion) {
+    console.log(`ℹ️ Branch tag '${branchName}' already exists ℹ️`);
+    const baseVersion = branchTagVersion.substring(
+      0,
+      branchTagVersion.lastIndexOf(".")
+    );
+    const dotVersion = parseInt(
+      branchTagVersion.substring(branchTagVersion.lastIndexOf(".") + 1)
+    );
+    console.log({ baseVersion, dotVersion });
+    return `${baseVersion}.${dotVersion + 1}`;
+  } else {
+    console.log(`ℹ️ Branch tag '${branchName}' does not exist yet ℹ️`);
+    console.log(`Next Version: ${currentVersion}-${branchName}.1`);
+    return `${currentVersion}-${branchName}.1`;
+  }
+};
+
+/**
+ * Checks the node version you are using is correct
+ */
+const checkNodeVersion = () => {
+  const nodeVersion = process.version;
+  const nodeVersionParts = nodeVersion.split(".");
+  const majorVersion = parseInt(nodeVersionParts[0].replace("v", ""));
+  if (majorVersion !== REQUIRED_NODE_VERSION) {
+    console.error(
+      `❌ Currently using ${nodeVersion}, please run 'nvm use 16' to switch to Node 16 ❌`
+    );
+    process.exit(1);
+  } else {
+    console.log(`✅ Node version ${nodeVersion} is OK ✅`);
+  }
+};
+
+/**
+ * Checks for discrepancies between the yarn.lock and package.json
+ */
+const yarnInstall = () => {
+  try {
+    console.log("📦 Checking dependencies are up to date... 📦");
+    execSync(`yarn install --frozen-lockfile`);
+    console.log(`✅ yarn.lock is up to date ✅`);
+  } catch (err) {
+    console.log(`❌ Error: ${err} ❌`);
+    console.error(
+      `❌ yarn.lock is out of sync. Please run 'yarn install' to update! ❌`
+    );
+    process.exit(1);
+  }
+};
+
+/**
+ * Sets the yarn version to the next branch version
+ * @param {String} version The version to set
+ */
+const setYarnVersion = (version) => {
+  const yarnVersion = executeCommand(
+    `yarn version --new-version "${version}" --no-git-tag-version`
+  );
+  console.log(`✅ Yarn version set ✅`);
+  console.log(yarnVersion);
+};
+
+/**
+ * Publish the yarn version to npm
+ * @param {String} tag The tag to publish to
+ */
+const publishYarnVersion = (tag) => {
+  const published = executeCommand(`yarn publish --access public --tag ${tag}`);
+  console.log(`✅ Yarn version set ✅`);
+  console.log(published);
+};
+
+const main = async () => {
+  checkNpmToken();
+  const branchName = getBranchName();
+  if (EXCLUDE_BRANCHES.includes(branchName)) {
+    console.log(`ℹ️ Branch ${branchName} is excluded ℹ️`);
+    process.exit(0);
+  }
+  const formattedBranchName = branchName.replace("/", "-");
+  console.log({ formattedBranchName });
+  const branchTagLatest = checkBranchTagExists(formattedBranchName);
+  console.log({ branchTagLatest });
+  const nextBranchVersion = getNextBranchVersion(
+    formattedBranchName,
+    branchTagLatest
+  );
+  console.log({ nextBranchVersion });
+  checkNodeVersion();
+  yarnInstall();
+  setYarnVersion(nextBranchVersion);
+  publishYarnVersion(formattedBranchName);
+};
+
+main();

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,68 @@
+name: Release Feature Branch
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - develop
+
+env:
+  BOT_NAME: nr-opensource-bot
+  BOT_EMAIL: opensource+bot@newrelic.com
+
+jobs:
+  generate-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          # Ensure lerna can do the proper version bump
+          # https://github.com/lerna/lerna/issues/2542
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Cache dependencies
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Cache Gatsby build
+        uses: actions/cache@v2
+        with:
+          path: |
+            demo/public
+            demo/.cache
+          key: ${{ runner.os }}-gatsby-build-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gatsby-build-
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Configure NPM
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > .npmrc
+
+      - name: Test Build
+        run: yarn workspace demo build --log-pages
+        env:
+          GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
+          CI: true
+
+      - name: Lerna Publish
+        env:
+          GIT_AUTHOR_NAME: ${{ env.BOT_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ env.BOT_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ env.BOT_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ env.BOT_EMAIL }}
+          GH_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
+        run: yarn release --canary minor

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,14 +1,10 @@
-name: Release Feature Branch
+name: Release Working Branch Lerna
 
 on:
   push:
     branches-ignore:
       - main
       - develop
-
-env:
-  BOT_NAME: nr-opensource-bot
-  BOT_EMAIL: opensource+bot@newrelic.com
 
 jobs:
   generate-release:
@@ -52,17 +48,5 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > .npmrc
 
-      - name: Test Build
-        run: yarn workspace demo build --log-pages
-        env:
-          GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
-          CI: true
-
       - name: Lerna Publish
-        env:
-          GIT_AUTHOR_NAME: ${{ env.BOT_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ env.BOT_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ env.BOT_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ env.BOT_EMAIL }}
-          GH_TOKEN: ${{ secrets.OPENSOURCE_BOT_TOKEN }}
         run: yarn release --canary minor

--- a/.github/workflows/release-branch-test.yml
+++ b/.github/workflows/release-branch-test.yml
@@ -1,10 +1,6 @@
 name: Release Working Branch
 
-on:
-  push:
-    branches-ignore:
-      - main
-      - develop
+on: workflow_dispatch
 
 env:
   BOT_NAME: nr-opensource-bot

--- a/.github/workflows/release-branch-test.yml
+++ b/.github/workflows/release-branch-test.yml
@@ -41,4 +41,6 @@ jobs:
       - name: Publish
         env:
             NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: yarn branch-release
+        run: |
+          
+          yarn branch-release

--- a/.github/workflows/release-branch-test.yml
+++ b/.github/workflows/release-branch-test.yml
@@ -1,10 +1,10 @@
 name: Release Working Branch Script
 
-on: workflow_dispatch
-
-env:
-  BOT_NAME: nr-opensource-bot
-  BOT_EMAIL: opensource+bot@newrelic.com
+on:
+  push:
+    branches-ignore:
+      - main
+      - develop
 
 jobs:
   generate-release:

--- a/.github/workflows/release-branch-test.yml
+++ b/.github/workflows/release-branch-test.yml
@@ -1,4 +1,4 @@
-name: Release Working Branch
+name: Release Working Branch Script
 
 on: workflow_dispatch
 

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,48 @@
+name: Release Working Branch
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - develop
+
+env:
+  BOT_NAME: nr-opensource-bot
+  BOT_EMAIL: opensource+bot@newrelic.com
+
+jobs:
+  generate-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          # Ensure lerna can do the proper version bump
+          # https://github.com/lerna/lerna/issues/2542
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Configure NPM
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > .npmrc
+
+      - name: Cache dependencies
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Publish
+        env:
+            NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: yarn branch-release

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test:watch": "yarn test --watch",
     "lint": "lerna run lint",
-    "extract-i18n": "yarn workspace @newrelic/gatsby-theme-newrelic extract-i18n"
+    "extract-i18n": "yarn workspace @newrelic/gatsby-theme-newrelic extract-i18n",
+    "branch-release": "node ./.github/branch-release.js"
   },
   "devDependencies": {
     "@newrelic/eslint-plugin-newrelic": "^0.3.1",


### PR DESCRIPTION
Here is the approach i took. I wrote a Node script we can run locally to publish a new version of the theme to NPM.
The version is specific to the current working branch and also allows for additional versioning e.g

1. I'm working on theme `1.0.0`.
2. I create a new branch called `ru-patch` and make some updates
3. Running the script will create a new version `1.0.0-ru-patch.1` with tag `ru-patch` in NPM
4. I can install this version using the tag/branch name like `yarn add gatsby-theme-newrelic@ru-patch`
4. I make some more updates and run the script again
5. This will create a new version `1.0.0-ru-patch.2` with tag `ru-patch` in NPM
6. Running `yarn add gatsby-theme-newrelic@ru-patch` should pull the latest version `1.0.0-ru-patch.2`

<details>
<summary>Additional Features</summary>

1. Will check that the NPM_TOKEN environment variable has been set
2. Will check you are running Node 16
3. Will check for discrepancies between `yarn.lock` and `package.json`
4. Will check if you are on excluded branches like `main`/`develop`
</details>

You could test this with any repo, but i used this one: https://github.com/rudouglas/gatsby-build-newrelic
All you need is:
 - Create a new publish token in NPM
 - Change the `"name": "ruairi-test"` in `package.json` to something else

### Remaining Questions
I wasn't 100% sure how the current release works, so not sure what happens if I merge a branch with version `1.0.0-ru-patch.1` into main branch with version `1.0.0`, how does semantic versioning deal with that?