### PR TITLE
feat(tessen): add segment anonymous id to tessen calls

### DIFF
--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
@@ -58,7 +58,8 @@ test('instruments tessen and calls original handler with all arguments', () => {
       nr_product: 'THEME',
       nr_subproduct: 'TTHEME',
       location: 'Public',
-      customer_user_id: '',
+      customer_user_id: null,
+      anonymousId: null,
       env: '',
     },
     {

--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -40,7 +40,8 @@ const tessenAction =
       );
     }
 
-    const customerId = Cookies.get('ajs_user_id') || '';
+    const customerId = JSON.parse(Cookies.get('ajs_user_id') || 'null');
+    const anonymousId = JSON.parse(Cookies.get('ajs_anonymous_id') || 'null');
 
     window.Tessen[action](
       name,
@@ -52,6 +53,7 @@ const tessenAction =
         nr_subproduct: config.subproduct,
         location: 'Public',
         customer_user_id: customerId,
+        anonymousId,
       },
       {
         Segment: {


### PR DESCRIPTION
## Description

If available reads the `ajs_anonymous_id` cookie set by segment and adds that value as the `anonymousId` property in all tessen calls.

This value is stored with encoded quotes (`%22`), so we use `JSON.parse()` to parse it (similar to the PLG code the ticket linked to. Also did that to `ajs_user_id` just in case (even though that value seems to stored without encoding.

## Related issues / PRs
Closes https://github.com/newrelic/gatsby-theme-newrelic/issues/563
