### PR TITLE
chore: add referrer url to RelatedResources clicks

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -11,6 +11,7 @@ import {
   Layout,
   Link,
   PageTools,
+  RelatedResources,
   SearchInput,
   SimpleFeedback,
   Surface,
@@ -301,6 +302,16 @@ nr1 create --type nerdpack --name pageviews-app
               Extra small
             </Button>
           </div>
+        </section>
+        <section>
+          <RelatedResources
+            resources={[
+              {
+                url: 'https://developer.newrelic.com/instant-observability/',
+                title: 'developer',
+              },
+            ]}
+          />
         </section>
         <section>
           <h2>Primary surfaces</h2>

--- a/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
@@ -7,6 +7,7 @@ import Tag from './Tag';
 import Icon from './Icon';
 import Link from './Link';
 import useThemeTranslation from '../hooks/useThemeTranslation';
+import { useLocation } from '@reach/router';
 
 const isRelative = (url) => url.startsWith('/');
 
@@ -18,6 +19,7 @@ const findLabel = (url, labels) => {
 
 const RelatedResources = ({ className, resources, title }) => {
   const { t } = useThemeTranslation();
+  const location = useLocation();
   const {
     site: {
       siteMetadata: { siteUrl },
@@ -95,6 +97,7 @@ const RelatedResources = ({ className, resources, title }) => {
                   `}
                   instrumentation={{
                     navInteractionType: 'relatedResourcesLinkClick',
+                    referrer: location.pathname,
                   }}
                 >
                   <span

--- a/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/components/RelatedResources.js
@@ -97,7 +97,7 @@ const RelatedResources = ({ className, resources, title }) => {
                   `}
                   instrumentation={{
                     navInteractionType: 'relatedResourcesLinkClick',
-                    referrer: location.pathname,
+                    currentUrl: location.pathname,
                   }}
                 >
                   <span


### PR DESCRIPTION
We were already tracking the URL the user was sent to. 
- `relatedResourcesLinkClick` property: `href`

I added the referrer URL that the user came from. 
- `relatedResourcesLinkClick` property: ~~`referrer`~~ `currentUrl`

closes: https://github.com/newrelic/gatsby-theme-newrelic/issues/538
