### PR TITLE
chore: only display edit button for english pages

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
+++ b/packages/gatsby-theme-newrelic/src/components/ContributingGuidelines.js
@@ -8,6 +8,7 @@ import { graphql, useStaticQuery } from 'gatsby';
 import CreateIssueButton from './CreateIssueButton';
 import EditPageButton from './EditPageButton';
 import Trans from './Trans';
+import useLocale from '../hooks/useLocale';
 
 const ContributingGuidelines = ({
   className,
@@ -28,6 +29,7 @@ const ContributingGuidelines = ({
       }
     }
   `);
+  const { locale } = useLocale();
 
   return (
     <PageTools.Section
@@ -59,7 +61,7 @@ const ContributingGuidelines = ({
           labels={issueLabels}
         />
 
-        {fileRelativePath && (
+        {fileRelativePath && locale === 'en' && (
           <EditPageButton
             fileRelativePath={fileRelativePath}
             variant={Button.VARIANT.OUTLINE}


### PR DESCRIPTION
This uses the [useLocale](https://github.com/newrelic/gatsby-theme-newrelic/tree/develop/packages/gatsby-theme-newrelic#uselocale) hook to get what locale the current page is, and only display the `Edit Page` button if the locale is `en` (English)

<img width="1018" alt="Screenshot 2021-11-22 at 14 47 06" src="https://user-images.githubusercontent.com/17122543/142881782-35b78e45-28ea-48e3-9157-3b5eb53ea0dc.png">
