### PR TITLE
add split event for default state

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTextButton.js
@@ -42,6 +42,7 @@ const SplitTextButton = () => {
       size={Button.SIZE.EXTRA_SMALL}
       variant={Button.VARIANT.PRIMARY}
       instrumentation={{ component: 'SplitTextButton' }}
+      onClick={clickCallback}
     >
       <span>{t('button.signUp')}</span>
     </Button>


### PR DESCRIPTION
## Description
The current `SplitTextButton` does not include an event for clicking on the default, "free account", state. This adds an event so we can properly track clicks.
