### PR TITLE
fix: adjust header buttons in mobile

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -243,6 +243,7 @@ nr1 create --type nerdpack --name pageviews-app
           <div
             css={css`
               display: flex;
+              flex-wrap: wrap;
               gap: 1rem;
               margin-bottom: 2rem;
               align-items: start;

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -11,6 +11,7 @@ import NewRelicLogo from './NewRelicLogo';
 import Icon from './Icon';
 import GlobalNavLink from './GlobalNavLink';
 import SearchInput from './SearchInput';
+import useMedia from 'use-media';
 import { useLocation } from '@reach/router';
 import useQueryParams from '../hooks/useQueryParams';
 import useLocale from '../hooks/useLocale';
@@ -100,10 +101,10 @@ const createNavList = (listType, activeSite = null) => {
 const CONDENSED_BREAKPOINT = '815px';
 
 // swaps out logo into collapsable nav
-const NAV_BREAKPOINT = '700px';
+const NAV_BREAKPOINT = '770px';
 
 // changes layout for mobile view
-const MOBILE_BREAKPOINT = '545px';
+const MOBILE_BREAKPOINT = '600px';
 
 const actionLink = css`
   ${action};
@@ -169,6 +170,8 @@ const GlobalHeader = ({ className, activeSite }) => {
       }
     }
   `);
+
+  const hideLogoText = useMedia({ maxWidth: '350px' });
 
   const matchLocalePath = new RegExp(
     `^\\/(${locales.map(({ locale }) => locale).join('|')})`
@@ -295,12 +298,13 @@ const GlobalHeader = ({ className, activeSite }) => {
                 `}
               >
                 <NewRelicLogo
-                  size="104px"
+                  size={hideLogoText ? '24px' : '104px'}
                   css={css`
                     .logo-text {
                       fill: var(--color-neutrals-050);
                     }
                   `}
+                  omitText={hideLogoText}
                 />
               </Dropdown.Toggle>
               <Dropdown.Menu>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -96,8 +96,13 @@ const createNavList = (listType, activeSite = null) => {
   return navList;
 };
 
+// hides searchbar
 const CONDENSED_BREAKPOINT = '815px';
+
+// swaps out logo into collapsable nav
 const NAV_BREAKPOINT = '700px';
+
+// changes layout for mobile view
 const MOBILE_BREAKPOINT = '545px';
 
 const actionLink = css`
@@ -357,7 +362,7 @@ const GlobalHeader = ({ className, activeSite }) => {
             <li
               css={css`
                 flex: 1;
-                padding: 0rem 1rem;
+                margin: 0rem 1rem;
 
                 @media screen and (max-width: ${CONDENSED_BREAKPOINT}) {
                   flex: unset;
@@ -486,7 +491,11 @@ const GlobalHeader = ({ className, activeSite }) => {
                   actionIcon,
                   action,
                   css`
-                    margin: 24px;
+                    margin: 0 24px;
+
+                    @media screen and (max-width: 450px) {
+                      margin: 0;
+                    }
                   `,
                 ]}
                 size="1.5rem"


### PR DESCRIPTION
fixed margin for mobile display (specifically when width is at `375px`)

Co-authored-by: LizBaker <lbaker@newrelic.com>