### PR TITLE
chore: tessen instrumentation for global header

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/DarkModeToggle.js
+++ b/packages/gatsby-theme-newrelic/src/components/DarkModeToggle.js
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import Icon from './Icon';
 import useDarkMode from 'use-dark-mode';
 import isLocalStorageAvailable from '../utils/isLocalStorageAvailable';
+import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
 
 const DarkModeToggle = ({ className, size, onClick }) => {
   const isDarkDefault = false;
@@ -14,6 +15,16 @@ const DarkModeToggle = ({ className, size, onClick }) => {
     : { storageProvider: false };
   const darkMode = useDarkMode(isDarkDefault, darkModeOptions);
 
+  const handleDarkModeClick = useInstrumentedHandler(
+    null,
+    ({ darkModeValue }) => ({
+      eventName: 'darkModeToggleClick',
+      category: 'DarkModeToggle',
+      origin: 'gatsbyTheme',
+      mode: darkModeValue,
+    })
+  );
+
   return (
     <Icon
       name={darkMode.value ? 'fe-sun' : 'fe-moon'}
@@ -21,6 +32,10 @@ const DarkModeToggle = ({ className, size, onClick }) => {
       size={size}
       onClick={(e) => {
         darkMode.toggle();
+
+        handleDarkModeClick({
+          darkModeValue: darkMode.value ? 'dark' : 'light',
+        });
 
         if (window.newrelic) {
           window.newrelic.setCustomAttribute(

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -23,6 +23,7 @@ import { useDebounce } from 'react-use';
 import useHasMounted from '../hooks/useHasMounted';
 import useTessen from '../hooks/useTessen';
 import SplitTextButton from './SplitTextButton';
+import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
 
 const action = css`
   color: var(--secondary-text-color);
@@ -79,6 +80,7 @@ const createNavList = (listType, activeSite = null) => {
             <GlobalNavLink
               href={href}
               activeSite={activeSite && HEADER_LINKS.get(activeSite)}
+              instrumentation={{ component: 'globalHeader' }}
             >
               {text}
             </GlobalNavLink>
@@ -178,6 +180,13 @@ const GlobalHeader = ({ className, activeSite }) => {
   );
 
   const locale = useLocale();
+
+  const handleLocaleClick = useInstrumentedHandler(null, ({ locale }) => ({
+    eventName: 'localeDropDownClick',
+    category: 'LocaleDropDown',
+    origin: 'gatsbyTheme',
+    locale,
+  }));
 
   return (
     <>
@@ -481,6 +490,7 @@ const GlobalHeader = ({ className, activeSite }) => {
                           isDefault ? '' : `/${locale}`,
                           location.pathname.replace(matchLocalePath, '')
                         )}
+                        onClick={() => handleLocaleClick({ locale })}
                       >
                         {localName}
                       </Dropdown.MenuItem>
@@ -529,6 +539,7 @@ const GlobalHeader = ({ className, activeSite }) => {
                     display: none;
                   }
                 `}
+                instrumentation={{ component: 'headerLogInButton' }}
               >
                 <span>{t('button.login')}</span>
               </Button>

--- a/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalNavLink.js
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { graphql, Link, useStaticQuery } from 'gatsby';
 import ExternalLink from './ExternalLink';
 
-const GlobalNavLink = ({ children, href, activeSite }) => {
+const GlobalNavLink = ({ children, href, activeSite, instrumentation }) => {
   const {
     site: {
       siteMetadata: { siteUrl },
@@ -62,6 +62,7 @@ const GlobalNavLink = ({ children, href, activeSite }) => {
         }
       `}
       instrumentation={{
+        ...instrumentation,
         navInteractionType: 'globalNavLinkClick',
       }}
     >
@@ -77,6 +78,7 @@ GlobalNavLink.propTypes = {
     text: PropTypes.string.isRequired,
     href: PropTypes.string.isRequired,
   }),
+  instrumentation: PropTypes.object,
 };
 
 export default GlobalNavLink;


### PR DESCRIPTION
1. Global Header navLinks already have `href` but i've added the `component: 'globalHeader'` attribute to be able to identify them more easily
2. New event created:
    - `eventName: 'localeDropDownClick',
    category: 'LocaleDropDown',
    origin: 'gatsbyTheme',
    locale,`
3. New Event:
    - `eventName: 'darkModeToggleClick',
      category: 'DarkModeToggle',
      origin: 'gatsbyTheme',
      mode: darkModeValue,`
4. Added instrumentation `component: 'headerLogInButton'` to Login Button