### PR TITLE
Add option to disable auto localization of internal links

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -400,7 +400,17 @@ nr1 create --type nerdpack --name pageviews-app
         </section>
         <section>
           <h2>Internal Links</h2>
-          <Link to="/">Internal Link</Link>
+          <p>
+            This <Link to="/build-apps">Internal Link</Link> automatically uses
+            localized path if on translated site.
+          </p>
+          <p>
+            This{' '}
+            <Link to="/build-apps" shouldAutoLocalize={false}>
+              Internal Link
+            </Link>{' '}
+            does not automatically use localized path if on translated site.
+          </p>
         </section>
         <section>
           <h2>External Links</h2>

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -1632,17 +1632,17 @@ depending on whether it is a relative or absolute URL.
 
 ```js
 // Can be used as a relative link to other pages in the site
-<Link to="/page-2">
+<Link to="/page-2">Page 2</Link>
 
 // Link to other pages in the site without auto localizing the URL
-<Link to="/page-2" shouldAutoLocalize={false}>
+<Link to="/page-2" shouldAutoLocalize={false}>Page 2 (not localized)</Link>
 
 // Can also be used to link to external URLs
-<Link to="https://gatsbyjs.com">
+<Link to="https://gatsbyjs.com">GatsbyJS</Link>
 
 // If the link is absolute, but the origin matches the `siteMetadata.siteUrl`,
 // it will smartly convert this to a relative path.
-<Link to="https://developer.newrelic.com/page-2">
+<Link to="https://developer.newrelic.com/page-2">developer page 2</Link>
 ```
 
 ### `MarkdownContainer`

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -1622,6 +1622,7 @@ import { Link } from '@newrelic/gatsby-theme-newrelic'`
 | --------------------- | ------ | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `to`                  | string | yes      |         | The URL to link to. If this is a relative path, it will use the Gatsby `Link` component. If it is an external URL, it will use a regular anchor tag. |
 | `displayExternalIcon` | bool   | no       | false   | If the `to` is external to the current site, and you want the element to include an icon showing this leads to an external site, set this to `true`  |
+| `shouldAutoLocalize`  | bool   | no       | `true`  | Optionally specify if an internal link's URL path should be auto localized when on a translated version of the site.                                 |
 
 All additional props are forwarded to either the
 [`Link`](https://www.gatsbyjs.com/docs/gatsby-link/) component or the anchor tag
@@ -1632,6 +1633,9 @@ depending on whether it is a relative or absolute URL.
 ```js
 // Can be used as a relative link to other pages in the site
 <Link to="/page-2">
+
+// Link to other pages in the site without auto localizing the URL
+<Link to="/page-2" shouldAutoLocalize={false}>
 
 // Can also be used to link to external URLs
 <Link to="https://gatsbyjs.com">
@@ -2822,7 +2826,7 @@ import { useInstrumentedHandler } from '@newrelic/gatsby-theme-newrelic';
   - `eventName` - Needs to be in [Camel Case](https://en.wikipedia.org/wiki/Camel_case)
   - `category` - Needs to be in [Title Case](https://en.wikipedia.org/wiki/Title_case)
   - `name`
-...otherwise the handler will not be instrumented. All other attributes will be attached to the `attributes` property of the page action. You can pass a function to instrument dynamic data. If this is a function, the function will be called with the same arguments passed to the handler.
+    ...otherwise the handler will not be instrumented. All other attributes will be attached to the `attributes` property of the page action. You can pass a function to instrument dynamic data. If this is a function, the function will be called with the same arguments passed to the handler.
 
 **Returns**
 

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -19,7 +19,14 @@ const isImageLink = (className) => className === 'gatsby-resp-image-link';
 
 const Link = forwardRef(
   (
-    { to, onClick, instrumentation = {}, displayExternalIcon, ...props },
+    {
+      to,
+      onClick,
+      instrumentation = {},
+      displayExternalIcon,
+      shouldAutoLocalize = true,
+      ...props
+    },
     ref
   ) => {
     const locale = useLocale();
@@ -118,10 +125,14 @@ const Link = forwardRef(
 
     return (
       <GatsbyLink
-        to={localizePath({
-          path: forceTrailingSlashes ? addTrailingSlash(to) : to,
-          locale,
-        })}
+        to={
+          shouldAutoLocalize
+            ? localizePath({
+                path: forceTrailingSlashes ? addTrailingSlash(to) : to,
+                locale,
+              })
+            : addTrailingSlash(to)
+        }
         ref={ref}
         onClick={handleInternalLinkClick}
         {...props}
@@ -136,6 +147,7 @@ Link.propTypes = {
   instrumentation: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.node,
+  shouldAutoLocalize: PropTypes.bool,
   displayExternalIcon: PropTypes.bool,
 };
 

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -123,15 +123,17 @@ const Link = forwardRef(
       return <a {...props} href={to} />;
     }
 
+    const finalPath = forceTrailingSlashes ? addTrailingSlash(to) : to;
+
     return (
       <GatsbyLink
         to={
           shouldAutoLocalize
             ? localizePath({
-                path: forceTrailingSlashes ? addTrailingSlash(to) : to,
+                path: finalPath,
                 locale,
               })
-            : addTrailingSlash(to)
+            : finalPath
         }
         ref={ref}
         onClick={handleInternalLinkClick}


### PR DESCRIPTION
## Description

Adds an option to the `Link` component to disable auto localizing the link's path if on localized version of site. This supports machine translation disclaimer work where we need to add the link to the english version of a page in the disclaimer text at the top of localized pages.

## Related issues / PRs
Unblocks https://github.com/newrelic/docs-website/issues/2537