### PR TITLE
feat: generic split component

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -64,6 +64,10 @@ module.exports = {
               treatment: 'start_now',
               config: '{ "text": "Start now" }',
             },
+            SplitComponentTest: {
+              treatment: 'green',
+              config: { text: 'Start now' },
+            },
           },
           core: {
             authorizationKey: process.env.SPLITIO_AUTH_KEY || 'localhost',

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -22,6 +22,7 @@ import {
   Video,
   useTranslation,
   ExternalLink,
+  SplitTester,
 } from '@newrelic/gatsby-theme-newrelic';
 
 const codeSample = `
@@ -118,6 +119,29 @@ const IndexPage = () => {
         <h1>{t('home.welcome')}</h1>
         <p>{t('home.intro')}</p>
         <section>
+          <h2>Split Test</h2>
+          <SplitTester splitEventName="SplitComponentTest">
+                <SplitTester.Treatment treatmentName="red" as={Link}>
+                  <ExternalLink to="https://newrelic.com/signup">
+                    Start now
+                  </ExternalLink>
+                </SplitTester.Treatment>
+                <SplitTester.Treatment treatmentName="green">
+                  <ExternalLink to="https://newrelic.com/signup">
+                    Join us
+                  </ExternalLink>
+                </SplitTester.Treatment>
+                <SplitTester.Default treatmentName="default">
+                  <Button
+                    as={ExternalLink}
+                    size={Button.SIZE.SMALL}
+                    variant={Button.VARIANT.PRIMARY}
+                    href="https://newrelic.com/signup"
+                  >
+                    Sign up
+                  </Button>
+                </SplitTester.Default>
+              </SplitTester>
           <h2>Search inputs</h2>
           <SearchInput
             style={{ margin: '1rem 0', maxWidth: '500px' }}

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -43,6 +43,7 @@ export { default as RelatedResources } from './src/components/RelatedResources';
 export { default as SearchInput } from './src/components/SearchInput';
 export { default as SEO } from './src/components/SEO';
 export { default as SimpleFeedback } from './src/components/SimpleFeedback';
+export { default as SplitTester } from './src/components/SplitTester';
 export { default as Surface } from './src/components/Surface';
 export { default as Spinner } from './src/components/Spinner';
 export { default as Table } from './src/components/Table';

--- a/packages/gatsby-theme-newrelic/src/components/SplitTester/SplitDefault.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTester/SplitDefault.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import useThemeTranslation from '../../hooks/useThemeTranslation';
+import SplitProps from './splitProps';
+
+const SplitDefault = ({
+  treatmentName,
+  children,
+  chosenTreatment,
+  onClick,
+  isReady,
+  config,
+  instrumentation,
+  translate = true,
+}) => {
+  const { t } = useThemeTranslation();
+
+  return (
+    !isReady ||
+    (treatmentName === chosenTreatment && (
+      <>
+        {React.Children.map(children, (child) =>
+          React.cloneElement(child, {
+            onClick,
+            instrumentation,
+            children: translate
+              ? t(child.props.children)
+              : child.props.children,
+            ...config,
+          })
+        )}
+      </>
+    ))
+  );
+};
+
+SplitDefault.propTypes = SplitProps;
+
+export default SplitDefault;

--- a/packages/gatsby-theme-newrelic/src/components/SplitTester/SplitTester.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTester/SplitTester.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SplitTreatment from './SplitTreatment';
+import SplitDefault from './SplitDefault';
+import {
+  useTreatments,
+  useTrack,
+  SplitContext,
+} from '@splitsoftware/splitio-react';
+
+const SplitTester = ({ splitEventName, children, ...rest }) => {
+  const track = useTrack();
+
+  const treatments = useTreatments([splitEventName]);
+  const { treatment: chosenTreatment, config } = treatments[splitEventName];
+  const { isReady } = React.useContext(SplitContext);
+
+  const splitInstrumentation = {
+    eventName: 'splitTestClick',
+    category: 'SplitTestComponent',
+    treatmentName: chosenTreatment,
+    splitEventName,
+  };
+  const handleSplitClick = () => {
+    track(splitEventName);
+  };
+
+  return (
+    children && (
+      <>
+        {React.Children.map(children, (child) =>
+          React.cloneElement(child, {
+            chosenTreatment,
+            splitEventName,
+            onClick: handleSplitClick,
+            instrumentation: splitInstrumentation,
+            config,
+            isReady,
+            ...rest,
+          })
+        )}
+      </>
+    )
+  );
+};
+
+SplitTester.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+  treatmentName: PropTypes.string,
+  splitEventName: PropTypes.string,
+  rest: PropTypes.object,
+};
+
+SplitTester.Treatment = SplitTreatment;
+SplitTester.Default = SplitDefault;
+
+export default SplitTester;

--- a/packages/gatsby-theme-newrelic/src/components/SplitTester/SplitTreatment.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTester/SplitTreatment.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import useThemeTranslation from '../../hooks/useThemeTranslation';
+import SplitProps from './splitProps';
+
+const SplitTreatment = ({
+  treatmentName,
+  children,
+  chosenTreatment,
+  onClick,
+  isReady,
+  config,
+  instrumentation,
+  translate = true,
+}) => {
+  const { t } = useThemeTranslation();
+  const isTreatmentOn = treatmentName === chosenTreatment;
+
+  return (
+    isReady &&
+    isTreatmentOn &&
+    children && (
+      <>
+        {React.Children.map(children, (child) =>
+          React.cloneElement(child, {
+            onClick,
+            instrumentation,
+            children: translate
+              ? t(child.props.children)
+              : child.props.children,
+            ...config,
+          })
+        )}
+      </>
+    )
+  );
+};
+
+SplitTreatment.propTypes = SplitProps;
+
+export default SplitTreatment;

--- a/packages/gatsby-theme-newrelic/src/components/SplitTester/index.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTester/index.js
@@ -1,0 +1,1 @@
+export { default } from './SplitTester';

--- a/packages/gatsby-theme-newrelic/src/components/SplitTester/splitProps.js
+++ b/packages/gatsby-theme-newrelic/src/components/SplitTester/splitProps.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+
+export default {
+  children: PropTypes.node,
+  treatmentName: PropTypes.string,
+  chosenTreatment: PropTypes.string,
+  onClick: PropTypes.func,
+  isReady: PropTypes.bool,
+  config: PropTypes.object,
+  instrumentation: PropTypes.object,
+  translate: PropTypes.bool,
+};


### PR DESCRIPTION
Implementation example as follows:

```html
<SplitTester splitEventName="SplitComponentTest">
 <SplitTester.Treatment treatmentName="red" as={Link}>
   <ExternalLink to="https://newrelic.com/signup">
      Start now
   </ExternalLink>
  </SplitTester.Treatment>
   <SplitTester.Treatment treatmentName="green">
      <ExternalLink to="https://newrelic.com/signup">
         Join us
      </ExternalLink>
    </SplitTester.Treatment>
    <SplitTester.Default treatmentName="default">
       <Button
          as={ExternalLink}
          size={Button.SIZE.SMALL}
          variant={Button.VARIANT.PRIMARY}
          href="https://newrelic.com/signup"
        >
         Sign up
        </Button>
     </SplitTester.Default>
</SplitTester>
```

I'm not sure if the approach i took is a valid one, I also couldn't seem to get `config` working correctly (but do we need that? I don't think so)

Also translate isn't working but i may be misunderstanding how that works anyway