### PR TITLE
fix: can't exit search modal on mobile

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
@@ -138,11 +138,6 @@ const SearchModal = ({ onClose, isOpen, onChange, value }) => {
                 display: flex;
                 flex-direction: column;
                 position: relative;
-
-                @media screen and (max-width: 760px) {
-                  max-height: 100vh;
-                  height: 100vh;
-                }
               `}
             >
               <Input


### PR DESCRIPTION
I just removed the set heightsbeing applied to the animated Divs when on Mobile, this was preventing the ability to click outside of the SearchModal component to close it because it took up the entire screen