### PR TITLE
Make year dynamic in global footer

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -16,6 +16,7 @@ import useLocale from '../hooks/useLocale';
 // string and escaped by React, therefore rendering the literal &copy; text in
 // the footer
 const copyrightSymbol = String.fromCharCode(169);
+const year = new Date().getFullYear();
 
 const GlobalFooter = ({
   fileRelativePath,
@@ -155,7 +156,7 @@ const GlobalFooter = ({
               letter-spacing: 0.1rem;
             `}
           >
-            Copyright {{ copyrightSymbol }} 2021 New Relic Inc.
+            Copyright {{ copyrightSymbol }} {{ year }} New Relic Inc.
           </Trans>
           <div
             css={css`

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -39,7 +39,7 @@
     "negative": "No"
   },
   "footer": {
-    "copyright": "Copyright {{copyrightSymbol}} 2021 New Relic Inc.",
+    "copyright": "Copyright {{copyrightSymbol}} {{year}} New Relic Inc.",
     "careers": "Careers",
     "terms": "Terms of Service",
     "dcmaPolicy": "DCMA Policy",

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/jp.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/jp.json
@@ -41,7 +41,7 @@
     "title": "フィードバック"
   },
   "footer": {
-    "copyright": "Copyright {{copyrightSymbol}} 2020 New Relic Inc.",
+    "copyright": "Copyright {{copyrightSymbol}} {{year}} New Relic Inc.",
     "careers": "採用情報",
     "terms": "サービス利用規約",
     "dcmaPolicy": "DCMAポリシー",


### PR DESCRIPTION
makes the year in the global footer dynamic so we don't have to update it 🎉 

addresses https://github.com/newrelic/gatsby-theme-newrelic/issues/625

<img width="236" alt="Screen Shot 2022-01-19 at 11 42 09 AM" src="https://user-images.githubusercontent.com/39655074/150202566-a08c195f-4412-41d6-ad21-336059d14926.png">
