### PR TITLE
fix for tessen not loading

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby/on-pre-render-html.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-pre-render-html.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import path from 'path';
+import { withPrefix } from 'gatsby';
 import { getTessenConfig } from '../src/utils/config';
 import { getTessenPath } from './constants';
 import OneTrust from '../src/components/OneTrust';
@@ -13,7 +14,7 @@ const onPreRenderHTML = (
 
   const version = tessen ? tessen.tessenVersion : null;
 
-  const tessenPath = `/${path.basename(getTessenPath(version))}`;
+  const tessenPath = withPrefix(path.basename(getTessenPath(version)));
 
   replaceHeadComponents(
     [

--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -70,26 +70,24 @@ const trackPageView = ({ config, env, location, prevLocation }) => {
 const initializeTessenTracking =
   ({ config, env, location, prevLocation }) =>
   (options = {}) => {
-    if (!initialized) {
-      if (window.Tessen) {
-        initialized = true;
-        const { segmentWriteKey } = config;
-        window.Tessen.load(['Segment', 'NewRelic'], {
-          Segment: {
-            identifiable: true,
-            writeKey:
-              env === 'production' || env === 'prod'
-                ? segmentWriteKey
-                : DEV_SEGMENT_WRITE_KEY,
-            useAmplitudeSessions: true,
-          },
-        });
+    if (window.Tessen && !initialized) {
+      initialized = true;
+      const { segmentWriteKey } = config;
+      window.Tessen.load(['Segment', 'NewRelic'], {
+        Segment: {
+          identifiable: true,
+          writeKey:
+            env === 'production' || env === 'prod'
+              ? segmentWriteKey
+              : DEV_SEGMENT_WRITE_KEY,
+          useAmplitudeSessions: true,
+        },
+      });
 
-        window.Tessen.identify({});
+      window.Tessen.identify({});
 
-        options.trackPageView &&
-          trackPageView({ config, env, location, prevLocation });
-      }
+      options.trackPageView &&
+        trackPageView({ config, env, location, prevLocation });
     }
   };
 

--- a/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/page-tracking/tessen.js
@@ -71,23 +71,25 @@ const initializeTessenTracking =
   ({ config, env, location, prevLocation }) =>
   (options = {}) => {
     if (!initialized) {
-      initialized = true;
-      const { segmentWriteKey } = config;
-      window.Tessen.load(['Segment', 'NewRelic'], {
-        Segment: {
-          identifiable: true,
-          writeKey:
-            env === 'production' || env === 'prod'
-              ? segmentWriteKey
-              : DEV_SEGMENT_WRITE_KEY,
-          useAmplitudeSessions: true,
-        },
-      });
+      if (window.Tessen) {
+        initialized = true;
+        const { segmentWriteKey } = config;
+        window.Tessen.load(['Segment', 'NewRelic'], {
+          Segment: {
+            identifiable: true,
+            writeKey:
+              env === 'production' || env === 'prod'
+                ? segmentWriteKey
+                : DEV_SEGMENT_WRITE_KEY,
+            useAmplitudeSessions: true,
+          },
+        });
 
-      window.Tessen.identify({});
+        window.Tessen.identify({});
 
-      options.trackPageView &&
-        trackPageView({ config, env, location, prevLocation });
+        options.trackPageView &&
+          trackPageView({ config, env, location, prevLocation });
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
Two fixes were made:
* if tessen is unable to be downloaded, we dont want pages to break in the site. Added a check before each instance of usage to ensure tessen exists.
* when using path prefixes, assets are stored underneath the prefix. Currently, the code that adds tessen is looking in a static place. Updated this so that tessen script path incorporates path prefix into src script path.

## Links
Relates to: https://github.com/newrelic/instant-observability-website/issues/99