### PR TITLE
Search term undefined doesn't destroy navigation

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Navigation.js
+++ b/packages/gatsby-theme-newrelic/src/components/Navigation.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import NavigationContext from './NavigationContext';
 
 const sanitizeSearchTerm = (searchTerm) =>
-  searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').trim();
+  searchTerm?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').trim();
 
 const Navigation = ({ className, children, searchTerm }) => {
   const value = useMemo(


### PR DESCRIPTION
Since `searchTerm` is not a required prop of `Navigation`, we need to anticipate when it might be undefined