### PR TITLE
Pass all props to table component

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Table.js
+++ b/packages/gatsby-theme-newrelic/src/components/Table.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
-const Table = ({ className, children }) => (
+const Table = ({ className, children, ...props }) => (
   <div
+    {...props}
     className={className}
     css={css`
       width: 100%;


### PR DESCRIPTION
I added a swiftype index property to the table component in the docs site but realized we don't pass all props so it isn't getting through, this updates the component to pass all props