### PR TITLE
Explicitly define the signup schema

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby/type-defs.js
+++ b/packages/gatsby-theme-newrelic/gatsby/type-defs.js
@@ -36,6 +36,7 @@ const SCHEMA_CUSTOMIZATION_TYPES = `
     env: String!
     relatedResources: NewRelicThemeRelatedResourceConfig!
     tessen: NewRelicThemeTessenConfig
+    signup: NewRelicThemeSignupConfig
   }
 
   type NewRelicThemeRelatedResourceConfig {
@@ -50,6 +51,12 @@ const SCHEMA_CUSTOMIZATION_TYPES = `
   type NewRelicThemeTessenConfig {
     product: String
     subproduct: String
+  }
+
+  type NewRelicThemeSignupConfig {
+    environment: String!
+    reCaptchaToken: String!
+    signupURL: String! 
   }
 `;
 


### PR DESCRIPTION
# Summary
* Because the signup schema was not explicitly defined, the build was
  throwing errors for configs without the `signup` field because the `SEO` component queries for the field
* This defines that schema and makes it optional, allowing for the query
  to work as normal