### PR TITLE
feat(signup): replace signup modal with link to storefront signup

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -437,11 +437,10 @@ const GlobalHeader = ({
               >
                 <span>{t('button.login')}</span>
               </Button>
+
               <Button
+                as={ExternalLink}
                 className={className}
-                onClick={() => setIsModalOpen(true)}
-                size={Button.SIZE.SMALL}
-                variant={Button.VARIANT.LINK}
                 css={css`
                   font-size: 18px;
                   white-space: nowrap;
@@ -449,6 +448,13 @@ const GlobalHeader = ({
                     color: var(--brand-button-primary-accent);
                   }
                 `}
+                href="https://newrelic.com/signup"
+                size={Button.SIZE.SMALL}
+                variant={Button.VARIANT.LINK}
+                instrumentation={{
+                  component: 'SignUpButton',
+                  layoutElement: 'globalHeader',
+                }}
               >
                 <span>{t('button.startNow')}</span>
               </Button>


### PR DESCRIPTION
## Description

Experiment to switch `Start now` signup modal back to link to newrelic.com/signup page to see what affect that has on numbers
