### PR TITLE
Pass all props to navlink

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/NavLink.js
+++ b/packages/gatsby-theme-newrelic/src/components/NavLink.js
@@ -18,6 +18,7 @@ const NavLink = ({
   onClick,
   onToggle,
   mobileBreakpoint,
+  ...props
 }) => {
   const tessen = useTessen();
 
@@ -62,6 +63,7 @@ const NavLink = ({
           background: var(--nav-highlight);
         `}
       `}
+      {...props}
     >
       {icon && (
         <Icon


### PR DESCRIPTION
This way we can pass a name prop which will be used by react-scroll to scroll to the current page in the nav