### PR TITLE
Add prop `isEmbedPageLink` to add `siteUrl` to all relative paths

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -24,6 +24,7 @@ const Link = forwardRef(
       instrumentation = {},
       displayExternalIcon,
       shouldAutoLocalize = true,
+      isEmbedPageLink = false,
       ...props
     },
     ref
@@ -83,7 +84,11 @@ const Link = forwardRef(
       );
     }
 
-    if (isExternal(to)) {
+    if (isExternal(to) || isEmbedPageLink) {
+      if (isEmbedPageLink && !isExternal(to)) {
+        to = siteUrl + to;
+      }
+
       const rel = isNewRelicDomain(to) ? 'noopener' : 'noopener noreferrer';
 
       return (
@@ -144,6 +149,7 @@ Link.propTypes = {
   children: PropTypes.node,
   shouldAutoLocalize: PropTypes.bool,
   displayExternalIcon: PropTypes.bool,
+  isEmbedPageLink: PropTypes.bool,
 };
 
 export default Link;

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -15,6 +15,7 @@ const isNewRelicDomain = (to) =>
   to.endsWith('newrelic.com') || to.includes('newrelic.com/');
 const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 const isImageLink = (className) => className === 'gatsby-resp-image-link';
+const isRelativePath = (to) => !to.startsWith('http') && to.startsWith('/');
 
 const Link = forwardRef(
   (
@@ -85,7 +86,7 @@ const Link = forwardRef(
     }
 
     if (isExternal(to) || isEmbedPageLink) {
-      if (isEmbedPageLink && !isExternal(to)) {
+      if (isRelativePath(to)) {
         to = siteUrl + to;
       }
 


### PR DESCRIPTION
In the iframe for embeds, we want to make sure that all relative links for the site turn into external links (to keep parity with the current experience for the nr1 help xp). This change needed to be made in the gatsby theme because the link component we created actually replaces any links that contain the siteUrl with the relative path. 

Once this is released, I can update this PR https://github.com/newrelic/docs-website/pull/9639 to ensure that all links have the `isEmbedPageLink` prop to be true on all MDX content rendered on an embed page. 