### PR TITLE
Properly setting Tessen values from Cookies

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -55,8 +55,8 @@ const tessenAction =
       );
     }
 
-    const customerId = JSON.parse(Cookies.get('ajs_user_id') || 'null');
-    const anonymousId = JSON.parse(Cookies.get('ajs_anonymous_id') || 'null');
+    const customerId = Cookies.get('ajs_user_id') || null;
+    const anonymousId = Cookies.get('ajs_anonymous_id') || null;
 
     window.Tessen[action](
       eventName,

--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -2,6 +2,17 @@ import warning from 'warning';
 import Cookies from 'js-cookie';
 import { CAMEL_CASE, TITLE_CASE } from './constants';
 
+/**
+ * Helper function to get string-based cookies given a specific key. This will
+ * strip URL-encoded quotes (`%22`) if present.
+ *
+ * @example const id = getCookie('ajs_user_id'); // "12345"
+ *
+ * @param {string} key
+ * @returns {string | null} The value of the cookie or `null`
+ */
+const getCookie = (key) => Cookies.get(key).replace(/%22/g, '') || null;
+
 const warnAboutNoop = ({ config, action, name, category }) => {
   warning(
     config,
@@ -55,8 +66,8 @@ const tessenAction =
       );
     }
 
-    const customerId = Cookies.get('ajs_user_id') || null;
-    const anonymousId = Cookies.get('ajs_anonymous_id') || null;
+    const customerId = getCookie('ajs_user_id');
+    const anonymousId = getCookie('ajs_anonymous_id');
 
     window.Tessen[action](
       eventName,

--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -11,7 +11,7 @@ import { CAMEL_CASE, TITLE_CASE } from './constants';
  * @param {string} key
  * @returns {string | null} The value of the cookie or `null`
  */
-const getCookie = (key) => Cookies.get(key).replace(/%22/g, '') || null;
+const getCookie = (key) => Cookies.get(key)?.replace(/%22/g, '') || null;
 
 const warnAboutNoop = ({ config, action, name, category }) => {
   warning(


### PR DESCRIPTION
## Description
Previously, we were using `JSON.parse` after reading the cookie value for `ajs_user_id` and `ajs_anonymous_id`. Since those values are strings already, this was throwing an error:

```
Uncaught SyntaxError: Unexpected non-whitespace character after JSON at position [...]
```

## Related Issue(s)
* NR-54405