### PR TITLE
fix: add feedback data to the gql schema

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -85,7 +85,6 @@ module.exports = {
             process.env.FEEDBACK_RECAPTCHA_TOKEN ||
             '6Lfn8wUiAAAAANBY-ZtKg4V9b4rdGZtJuAng62jo',
         },
-
         shouldUpdateScroll: {
           routes: ['/'],
         },

--- a/packages/gatsby-theme-newrelic/gatsby/type-defs.js
+++ b/packages/gatsby-theme-newrelic/gatsby/type-defs.js
@@ -38,6 +38,7 @@ const SCHEMA_CUSTOMIZATION_TYPES = `
     tessen: NewRelicThemeTessenConfig
     signup: NewRelicThemeSignupConfig
     shouldUpdateScroll: RoutesAllowingScroll
+    feedback: NewRelicThemeFeedbackConfig
   }
 
   type NewRelicThemeRelatedResourceConfig {
@@ -58,6 +59,11 @@ const SCHEMA_CUSTOMIZATION_TYPES = `
     environment: String!
     reCaptchaToken: String!
     signupURL: String! 
+  }
+
+  type NewRelicThemeFeedbackConfig {
+    environment: String!
+    reCaptchaToken: String!
   }
 
   type RoutesAllowingScroll {


### PR DESCRIPTION
We were running into an error where the I/O site was looking for `feedback` in both the gatsby config and gql schema but not finding it in either, this alleviates that situation.