### PR TITLE
Update feedback form to send full url to Jira

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/ComplexFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/ComplexFeedback.js
@@ -68,7 +68,7 @@ const ComplexFeedback = ({ pageTitle }) => {
       title: pageTitle,
       description: userComments,
       rating: feedbackType,
-      pageUrl: location.pathname,
+      pageUrl: location.href,
       email: userEmail,
       recaptchaToken,
     };


### PR DESCRIPTION
Before we only sent the pathname of the doc page. This sends the full url which will be formatted in Jira as a clickable link by default. 