### PR TITLE
Make fileName in CodeBlock dynamic

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -99,8 +99,9 @@ const CodeBlock = ({
 
   const handleDownloadClick = useInstrumentedHandler(
     () => {
-      const blob = new Blob([children], { type: 'yaml' });
-      saveAs(blob, 'newrelic.yml');
+      const fileExtension = fileName.split('.')[1];
+      const blob = new Blob([children], { type: fileExtension });
+      saveAs(blob, fileName);
     },
     {
       eventName: 'downloadCodeBlockClick',

--- a/packages/gatsby-theme-newrelic/src/components/InteractiveForm.js
+++ b/packages/gatsby-theme-newrelic/src/components/InteractiveForm.js
@@ -29,6 +29,7 @@ const InteractiveForm = ({ children, inputs, config, containerId }) => {
       </div>
       <InteractiveOutput
         containerId={containerId}
+        fileName="newrelic.yml"
         inputs={inputs}
         config={config}
         css={css`

--- a/packages/gatsby-theme-newrelic/src/components/InteractiveOutput.js
+++ b/packages/gatsby-theme-newrelic/src/components/InteractiveOutput.js
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CodeBlock from './CodeBlock';
 
-const InteractiveOutput = ({ className, inputs, config, containerId }) => {
+const InteractiveOutput = ({
+  className,
+  inputs,
+  config,
+  containerId,
+  fileName,
+}) => {
   let lines = '';
   inputs.forEach((input) => (lines = lines.concat(`,${input.codeLine}`)));
 
@@ -23,7 +29,7 @@ const InteractiveOutput = ({ className, inputs, config, containerId }) => {
       altStyle
       copyable
       highlightedLines={lines}
-      fileName="newrelic.yml"
+      fileName={fileName}
       language="yml"
       className={className}
       containerId={containerId}
@@ -37,6 +43,7 @@ InteractiveOutput.propTypes = {
   className: PropTypes.string,
   inputs: PropTypes.array,
   config: PropTypes.string,
+  fileName: PropTypes.string,
   containerId: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
This will allow content creators to choose the agent config file name/type that is displayed and downloaded via the modified codeblock