### PR TITLE
fix: auto-fill search query from URL

### DIFF
--- a/packages/gatsby-theme-newrelic/src/pages/404.js
+++ b/packages/gatsby-theme-newrelic/src/pages/404.js
@@ -49,9 +49,7 @@ const NotFoundPage = ({
     (term) => {
       const termsToIgnore = ['docs', pageLocale];
 
-      if (!term || termsToIgnore.includes(term)) {
-        return false;
-      }
+      return term && !termsToIgnore.includes(term);
     },
     [pageLocale]
   );


### PR DESCRIPTION
the filter only ever returned `false` or `undefined`, so all parts of the URL path were getting filtered out and not being used as the query string

when testing this in dev, clicking on the search input caused the browser to navigate to `?q=apache/`, causing the trailing slash to display in the input as well. it looks like this is happening in [gatsby-link](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-link/src/rewrite-link-path.js#L47). in the minified code from the npm package, the check on [this line](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-link/src/rewrite-link-path.js#L11) is being minified to just `true`, so the trailing slash is added. i don't see this behavior in production, so i think this is a separate issue