### PR TITLE
create `useLoggedIn` hook and `LoggedInProvider`

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -88,6 +88,7 @@ module.exports = {
         shouldUpdateScroll: {
           routes: ['/'],
         },
+        newRelicRequestingServicesHeader: 'gatsby-theme-newrelic-demo',
       },
     },
     {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "jest": "^26.4.0",
     "jest-emotion": "^10.0.32",
+    "jest-fetch-mock": "^3.0.3",
     "jest-localstorage-mock": "^2.4.3",
     "lerna": "^5.6.2",
     "prettier": "^2.0.5",

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -27,6 +27,7 @@ websites](https://opensource.newrelic.com).
       - [`signup`](#signup)
       - [`oneTrustID`](#onetrustid)
         - [Environment-specific configuration](#environment-specific-configuration)
+      - [`newRelicRequestingServicesHeader`](#newRelicRequestingServicesHeader)
     - [Layouts](#layouts)
   - [Components](#components)
     - [`Banner`](#banner)
@@ -593,6 +594,14 @@ module.exports = {
   ],
 };
 ```
+#### `newRelicRequestingServicesHeader`
+
+Configure the name reported to NerdGraph in the `NewRelic-Requesting-Services` header.
+The value should be formatted like a slug, dash-separated and all lowercase, like `'io-website'`.
+This header is only used in the call to check the current user's logged in status.
+Currently, Tessen and the `useLoggedIn` hook are the only places this is used.
+If this isn't configured, Tessen won't include the `loggedIn` field on any events,
+and `useLoggedIn().loggedIn` will always be `null`.
 
 ### Layouts
 This theme supports Layout components in a similar way to Gatsby `V1` through the [`gatsby-plugin-layout`](https://www.gatsbyjs.com/plugins/gatsby-plugin-layout/). This plugin allows you to persist the layout between page changes, as well as state.

--- a/packages/gatsby-theme-newrelic/gatsby/on-client-entry.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-client-entry.js
@@ -25,6 +25,11 @@ const onClientEntry = (_, themeOptions) => {
       segmentKey: `${themeOptions.tessen.segmentWriteKey}`,
     };
   }
+
+  if (themeOptions.newRelicRequestingServicesHeader) {
+    window.newRelicRequestingServicesHeader =
+      themeOptions.newRelicRequestingServicesHeader;
+  }
 };
 
 const isDarkMode = () => {

--- a/packages/gatsby-theme-newrelic/src/components/LoggedInContext.js
+++ b/packages/gatsby-theme-newrelic/src/components/LoggedInContext.js
@@ -1,0 +1,49 @@
+import React, { createContext } from 'react';
+import PropTypes from 'prop-types';
+import { useLoggedIn } from '../hooks/useLoggedIn';
+
+/**
+ * Don't use this directly!
+ * Use the `useLoggedIn` hook instead,
+ * optionally with `LoggedInProvider`.
+ */
+export const LoggedInContext = createContext(null);
+
+/**
+ * Handles calling `useLoggedIn` and passing
+ * the resulting value down through the Context API.
+ * If you have multiple components that might need the user's logged in state,
+ * wrap them with `LoggedInProvider` to avoid multiple calls to NerdGraph.
+ *
+ * @example
+ * ```jsx
+ *   const App = () => (
+ *     <LoggedInProvider>
+ *       <INeedToKnowIfTheUserIsLoggedIn />
+ *       <MeToo />
+ *       <MeThree />
+ *     </LoggedInProvider>
+ *   )
+ *
+ *   const MeToo = () => {
+ *     // These values will come from the provider,
+ *     // so the call isn't duplicated between components.
+ *     const { loading, loggedIn } = useLoggedIn()
+ *
+ *     return <div>{loggedIn.toString()}</div>
+ *   }
+ * ```
+ */
+export const LoggedInProvider = ({ children }) => {
+  const { loading, loggedIn } = useLoggedIn();
+
+  return (
+    <LoggedInContext.Provider value={{ loading, loggedIn }}>
+      {children}
+    </LoggedInContext.Provider>
+  );
+};
+
+LoggedInProvider.propTypes = {
+  children: PropTypes.node,
+};

--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
@@ -24,6 +24,7 @@ const SEGMENT_OBJECT = {
   },
 };
 
+global.newRelicRequestingServicesHeader = 'gatsby-theme-newrelic-demo'
 global.Tessen = {
   track: jest.fn(),
 };

--- a/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/__tests__/useInstrumentedHandler.js
@@ -1,5 +1,7 @@
 import useInstrumentedHandler from '../useInstrumentedHandler';
 import { renderHook } from '@testing-library/react-hooks';
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();
 
 const originalError = console.error;
 const TESSEN_OBJECT = {
@@ -8,6 +10,7 @@ const TESSEN_OBJECT = {
   nr_product: 'THEME',
   nr_subproduct: 'TTHEME',
   location: 'Public',
+  loggedIn: true,
   customer_user_id: null,
   anonymousId: null,
   env: '',
@@ -30,7 +33,7 @@ afterEach(() => {
   global.Tessen.track.mockClear();
 });
 
-test('instruments tessen and calls original handler with all arguments', () => {
+test('instruments tessen and calls original handler with all arguments', async () => {
   const originalHandler = jest.fn();
   const { result } = renderHook(() =>
     useInstrumentedHandler(originalHandler, {
@@ -42,6 +45,7 @@ test('instruments tessen and calls original handler with all arguments', () => {
 
   result.current(1, 2);
 
+  await result.current.tessenResult;
   expect(originalHandler).toHaveBeenCalledTimes(1);
   expect(originalHandler).toHaveBeenCalledWith(1, 2);
   expect(global.Tessen.track).toHaveBeenCalledTimes(1);
@@ -52,7 +56,7 @@ test('instruments tessen and calls original handler with all arguments', () => {
   );
 });
 
-test('attaches any additional fields in config as attributes', () => {
+test('attaches any additional fields in config as attributes', async () => {
   const { result } = renderHook(() =>
     useInstrumentedHandler(jest.fn(), {
       eventName: 'eventName',
@@ -63,6 +67,7 @@ test('attaches any additional fields in config as attributes', () => {
   );
 
   result.current();
+  await result.current.tessenResult;
 
   expect(global.Tessen.track).toHaveBeenCalledWith(
     'eventName',
@@ -71,7 +76,7 @@ test('attaches any additional fields in config as attributes', () => {
   );
 });
 
-test('allows config argument to be a function called with the handler arguments', () => {
+test('allows config argument to be a function called with the handler arguments', async () => {
   const { result } = renderHook(() =>
     useInstrumentedHandler(jest.fn(), (a, b) => ({
       eventName: 'eventName',
@@ -81,6 +86,8 @@ test('allows config argument to be a function called with the handler arguments'
     }))
   );
   result.current(2, 2);
+  await result.current.tessenResult;
+
   expect(global.Tessen.track).toHaveBeenCalledWith(
     'eventName',
     { ...TESSEN_OBJECT, sum: 4 },

--- a/packages/gatsby-theme-newrelic/src/hooks/useLoggedIn.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useLoggedIn.js
@@ -58,7 +58,7 @@ export const useLoggedIn = (serviceName) => {
  *
  * @returns {Promise<Boolean>}
  */
-const checkIfUserLoggedIn = (serviceName) =>
+export const checkIfUserLoggedIn = (serviceName) =>
   fetch(NERDGRAPH_URL, {
     method: 'POST',
     credentials: 'include',
@@ -85,7 +85,7 @@ const checkIfUserLoggedIn = (serviceName) =>
  *
  * @returns {Boolean | null} A boolean if the key is set, otherwise returns null.
  */
-const getSavedStatus = () => {
+export const getSavedStatus = () => {
   if (typeof window === 'undefined') return null;
   const status = window.sessionStorage.getItem(SAVED_STATUS_KEY);
   if (status != null) return status === 'true';

--- a/packages/gatsby-theme-newrelic/src/hooks/useLoggedIn.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useLoggedIn.js
@@ -1,0 +1,74 @@
+import { useContext, useEffect, useState } from 'react';
+import { LoggedInContext } from '../components/LoggedInContext';
+
+const NERDGRAPH_URL = 'https://nerd-graph.service.newrelic.com/graphql';
+
+/**
+ * Asynchronously checks whether the current user is logged in.
+ * Returns an object with `loading` and `loggedIn` properties.
+ *
+ * If you have multiple components which need the user's logged in state,
+ * wrap them with `LoggedInProvider` to avoid making duplicate checks.
+ *
+ * @example
+ * ```jsx
+ * const MyComponent = () => {
+ *   const { loading, loggedIn } = useLoggedIn('io-website')
+ *
+ *   if (loading) return <div>loading...</div>
+ *   if (loggedIn) return <div>hey old friend!</div>
+ *   return <div>hey new friend!</div>
+ * }
+ * ```
+ *
+ * @param {string} serviceName
+ */
+export const useLoggedIn = (serviceName) => {
+  // if `context` is null, we don't have `LoggedInProvider` as
+  // an ancestor, so we'll have to make the call ourself.
+  const context = useContext(LoggedInContext);
+  const [loading, setLoading] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if (context != null) return;
+
+    setLoading(true);
+    checkIfUserLoggedIn(serviceName)
+      .then(setLoggedIn)
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  if (context != null) return context;
+  return { loading, loggedIn };
+};
+
+/**
+ * Makes a call to NerdGraph and returns whether the user
+ * is logged in via the NR cookie hitting Service Gateway.
+ *
+ * @returns {Promise<Boolean>}
+ */
+const checkIfUserLoggedIn = (serviceName) =>
+  fetch(NERDGRAPH_URL, {
+    method: 'POST',
+    credentials: 'include',
+    redirect: 'error',
+    headers: {
+      'Content-Type': 'application/json',
+      'NewRelic-Requesting-Services': serviceName,
+    },
+    body: JSON.stringify({
+      query: `{
+        actor {
+          user {
+            name
+          }
+        }
+      }`,
+    }),
+  })
+    .then((res) => res.ok)
+    .catch(() => false);

--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -1,6 +1,10 @@
 import warning from 'warning';
 import Cookies from 'js-cookie';
 import { CAMEL_CASE, TITLE_CASE } from './constants';
+import {
+  checkIfUserLoggedIn,
+  getSavedStatus as getSavedLoggedInStatus,
+} from '../hooks/useLoggedIn';
 
 /**
  * Helper function to get string-based cookies given a specific key. This will
@@ -40,7 +44,7 @@ const canSendAction = ({ config, name, category }) =>
 
 const tessenAction =
   (action, config) =>
-  ({ eventName, category, ...properties }) => {
+  async ({ eventName, category, ...properties }) => {
     if (!canSendAction({ config, name: eventName, category })) {
       return warnAboutNoop({ config, action, name: eventName, category });
     }
@@ -68,6 +72,8 @@ const tessenAction =
 
     const customerId = getCookie('ajs_user_id');
     const anonymousId = getCookie('ajs_anonymous_id');
+    const loggedIn =
+      getSavedLoggedInStatus() ?? (await checkIfUserLoggedIn(config.product));
 
     window.Tessen[action](
       eventName,
@@ -80,6 +86,7 @@ const tessenAction =
         location: 'Public',
         customer_user_id: customerId,
         anonymousId,
+        loggedIn,
       },
       {
         Segment: {

--- a/packages/gatsby-theme-newrelic/src/utils/createTessen.js
+++ b/packages/gatsby-theme-newrelic/src/utils/createTessen.js
@@ -72,8 +72,17 @@ const tessenAction =
 
     const customerId = getCookie('ajs_user_id');
     const anonymousId = getCookie('ajs_anonymous_id');
-    const loggedIn =
-      getSavedLoggedInStatus() ?? (await checkIfUserLoggedIn(config.product));
+
+    // if a site doesn't configure this in the theme options,
+    // we don't make the call to NerdGraph and we don't send
+    // a `loggedIn` field with the request.
+    if (window.newRelicRequestingServicesHeader) {
+      const loggedIn =
+        getSavedLoggedInStatus() ?? (await checkIfUserLoggedIn(config.product));
+      // i don't like mutating this object, but it's the least ugly way
+      // to conditionally add this property.
+      properties.loggedIn = loggedIn;
+    }
 
     window.Tessen[action](
       eventName,
@@ -86,7 +95,6 @@ const tessenAction =
         location: 'Public',
         customer_user_id: customerId,
         anonymousId,
-        loggedIn,
       },
       {
         Segment: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7972,7 +7972,7 @@ cross-fetch@3.1.4:
   dependencies:
     node-fetch "2.6.1"
 
-cross-fetch@^3.1.5:
+cross-fetch@^3.0.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -13213,6 +13213,14 @@ jest-environment-node@^26.6.2:
     jest-mock "^26.6.2"
     jest-util "^26.6.2"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
@@ -16749,6 +16757,11 @@ promise-map-series@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/promise-map-series/-/promise-map-series-0.3.0.tgz#41873ca3652bb7a042b387d538552da9b576f8a1"
   integrity sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==
+
+promise-polyfill@^8.1.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
+  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 promise-retry@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
this PR takes the logic @clarkmcadoo and i wrote for [InstallButton.js](https://github.com/newrelic/instant-observability-website/blob/main/src/components/InstallButton.js) and packages it up in the `useLoggedIn` hook and `LoggedInProvider` for easy reuse

check [instant-observability-website#351](https://github.com/newrelic/instant-observability-website/pull/351) for an example usage