### PR TITLE
Set darkMode in localStorage on client entry

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby/on-client-entry.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-client-entry.js
@@ -30,12 +30,14 @@ const onClientEntry = (_, themeOptions) => {
 const isDarkMode = () => {
   if (isLocalStorageAvailable()) {
     const localStorageTheme = localStorage.getItem('darkMode');
-
-    if (localStorageTheme) {
+    if (localStorageTheme === 'true' || localStorageTheme === 'false') {
       return JSON.parse(localStorageTheme);
     }
   }
-
+  window.localStorage.setItem(
+    'darkMode',
+    document.body.classList.contains('dark-mode')
+  );
   return document.body.classList.contains('dark-mode');
 };
 


### PR DESCRIPTION
darkMode is being set to undefined in localStorage somehow. we're still unsure about the why but this at least protects against that and may help the broken js issues