### PR TITLE
fix: add default export for `useLoggedIn`

### DIFF
--- a/packages/gatsby-theme-newrelic/src/hooks/useLoggedIn.js
+++ b/packages/gatsby-theme-newrelic/src/hooks/useLoggedIn.js
@@ -55,6 +55,8 @@ export const useLoggedIn = () => {
   return { loading, loggedIn };
 };
 
+export default useLoggedIn;
+
 /**
  * Makes a call to NerdGraph and returns whether the user
  * is logged in via the NR cookie hitting Service Gateway.


### PR DESCRIPTION
i forgor this didn't have a default export and so i reexported nothing in gatsby-theme-newrelic/index.js