### PR TITLE
fix: small padding tweak to give content in NavItem space

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/NavItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/NavItem.js
@@ -78,7 +78,7 @@ const NavItem = ({
         --icon-spacing: 0.5rem;
         --nav-link-padding: 1rem;
         display: ${matchesSearch || !searchTerm ? 'block' : 'none'};
-        padding-left: ${parent == null ? '0' : 'var(--nav-link-padding)'};
+        padding-left: ${parent == null ? '8px' : 'var(--nav-link-padding)'};
 
         ${mobileBreakpoint &&
         css`

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -59,6 +59,7 @@ const BarItem = ({
 BarItem.propTypes = {
   index: PropTypes.number,
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,


### PR DESCRIPTION
BEFORE:

![Screen Shot 2023-01-26 at 5 16 01 PM](https://user-images.githubusercontent.com/26727669/214973068-43233c52-c808-454b-a89b-b804fd9a5e6e.png)

AFTER:

![Screen Shot 2023-01-26 at 5 15 53 PM](https://user-images.githubusercontent.com/26727669/214973070-c46b4cc1-4c79-40b0-ad93-777f8284b29f.png)
