### PR TITLE
fix(SEO): change hreflang on alt link if default language

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SEO.js
+++ b/packages/gatsby-theme-newrelic/src/components/SEO.js
@@ -123,7 +123,7 @@ const SEO = ({ title, location, type, children }) => {
             key={locale}
             rel="alternate"
             href={url.href}
-            hrefLang={hrefLang}
+            hrefLang={isDefault ? 'x-default' : hrefLang}
           />
         );
       })}


### PR DESCRIPTION
# Description
if on a page that is the default language (english in our case), change alt link `hreflang` to `x-default`. this _might_ address issue reported recently where some pages at localized URLs with English content surface for en-us based searches.

BEFORE

![2023-01-27_09-57-23](https://user-images.githubusercontent.com/2952843/215160059-336d9120-a327-4dc3-9097-1cc0d1fe4063.png)

AFTER

![2023-01-27_08-59-36](https://user-images.githubusercontent.com/2952843/215159836-81ac6386-f849-4420-8b54-044e07643c85.png)

# Closes
https://issues.newrelic.com/browse/NR-83012
