### PR TITLE
create license key component

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -34,6 +34,7 @@ import {
   ExternalLink,
   SignupModal,
   Lightbox,
+  LicenseKey,
 } from '@newrelic/gatsby-theme-newrelic';
 import config from '../content/configFiles/javaConfig';
 import tallImage from '../images/nr-one-ajax-browser.png';
@@ -835,6 +836,14 @@ const IndexPage = () => {
               finished
             </Walkthrough.Step>
           </Walkthrough>
+        </section>
+        <section>
+          <h2>License Key</h2>
+          here's some text that tells you to look at your <LicenseKey />. here's
+          some text after it to make sure the <code>
+            &lt;LicenseKey&gt;
+          </code>{' '}
+          component stays inline and doesn't break formatting.
         </section>
       </Layout.Content>
       <Layout.PageTools

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -1627,6 +1627,27 @@ used for the site.
 </Layout.Sidebar>
 ```
 
+### `LicenseKey`
+
+Renders a button with the text "account license key", with a tooltip that provides
+additional information and helpful links regarding license keys.
+
+```jsx
+import { LicenseKey } from '@newrelic/gatsby-theme-newrelic'
+```
+
+**Props**
+
+None.
+
+**Example**
+
+```jsx
+import { LicenseKey } from '@newrelic/gatsby-theme-newrelic'
+
+This copy directs you to your <LicenseKey />.
+```
+
 ### `Link`
 
 Provides a "smart" link to link to other URLs. This provides a unified component

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -24,6 +24,7 @@ export { default as Icon } from './src/components/Icon';
 export { default as InteractiveForm } from './src/components/InteractiveForm';
 export { default as InteractiveOutput } from './src/components/InteractiveOutput';
 export { default as Layout } from './src/components/Layout';
+export { default as LicenseKey } from './src/components/LicenseKey';
 export { default as Lightbox } from './src/components/Lightbox';
 export { default as Link } from './src/components/Link';
 export { default as NavLink } from './src/components/NavLink';

--- a/packages/gatsby-theme-newrelic/src/components/Button.js
+++ b/packages/gatsby-theme-newrelic/src/components/Button.js
@@ -81,7 +81,9 @@ const Button = styled.button`
   line-height: 1;
   cursor: pointer;
   border: 1px solid transparent;
-  transition: all 0.15s ease-out;
+  transition-duration: 0.15s;
+  transition-property: color, background;
+  transition-timing-function: ease-out;
   white-space: nowrap;
   text-decoration: none;
 

--- a/packages/gatsby-theme-newrelic/src/components/LicenseKey.js
+++ b/packages/gatsby-theme-newrelic/src/components/LicenseKey.js
@@ -15,10 +15,12 @@ import {
   useInstrumentedHandler,
   useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
+import useThemeTranslation from '../hooks/useThemeTranslation';
 
 const LicenseKey = () => {
   // `useId` from React 18 would be better here
   const { current: popoverId } = useRef(Math.random().toString());
+  const { t } = useThemeTranslation();
   const clicked = useRef(false);
   const [opened, setOpened] = useState(false);
   const hide = () => setOpened(false);
@@ -75,7 +77,7 @@ const LicenseKey = () => {
         }}
         type="button"
       >
-        account license key{' '}
+        {t('licenseKey.buttonText')}{' '}
         <Icon
           css={css`
             margin-left: 0.25em;
@@ -104,6 +106,7 @@ const slideFadeIn = keyframes`
 `;
 
 const Popover = forwardRef(({ id, hidden = false }, ref) => {
+  const { t } = useThemeTranslation();
   const onLearnMore = useInstrumentedHandler(() => {}, {
     eventName: 'learnMoreClick',
     category: 'LicenseKey',
@@ -217,7 +220,7 @@ const Popover = forwardRef(({ id, hidden = false }, ref) => {
             margin: 0;
           `}
         >
-          License key
+          {t('licenseKey.popover.header')}
         </p>
         <p
           css={css`
@@ -225,8 +228,7 @@ const Popover = forwardRef(({ id, hidden = false }, ref) => {
             margin: 0 0 8px;
           `}
         >
-          Your license key is used to associate your incoming data with your
-          account.{' '}
+          {t('licenseKey.popover.explainer')}{' '}
           <a
             css={css`
               color: currentColor;
@@ -240,7 +242,7 @@ const Popover = forwardRef(({ id, hidden = false }, ref) => {
             onClick={onLearnMore}
             tabIndex={0}
           >
-            Learn more
+            {t('licenseKey.popover.learnMore')}
           </a>
         </p>
         <Button
@@ -250,7 +252,7 @@ const Popover = forwardRef(({ id, hidden = false }, ref) => {
           tabIndex={0}
           variant={Button.VARIANT.PRIMARY}
         >
-          Get your key{' '}
+          {t('licenseKey.popover.getYourKey')}{' '}
           <Icon
             css={css`
               margin-left: 4px;
@@ -273,7 +275,7 @@ const Popover = forwardRef(({ id, hidden = false }, ref) => {
           tabIndex={0}
           variant={Button.VARIANT.OUTLINE}
         >
-          Create account
+          {t('licenseKey.popover.createAccount')}
         </Button>
       </div>
     </div>

--- a/packages/gatsby-theme-newrelic/src/components/LicenseKey.js
+++ b/packages/gatsby-theme-newrelic/src/components/LicenseKey.js
@@ -1,0 +1,287 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+import { css, keyframes } from '@emotion/react';
+import { useClickAway, useWindowSize } from 'react-use';
+
+import {
+  Button,
+  Icon,
+  useInstrumentedHandler,
+  useTessen,
+} from '@newrelic/gatsby-theme-newrelic';
+
+const LicenseKey = () => {
+  // `useId` from React 18 would be better here
+  const { current: popoverId } = useRef(Math.random().toString());
+  const clicked = useRef(false);
+  const [opened, setOpened] = useState(false);
+  const hide = () => setOpened(false);
+  const show = () => setOpened(true);
+
+  const popover = useRef();
+  useClickAway(popover, () => {
+    clicked.current = false;
+    hide();
+  });
+
+  const tessen = useTessen();
+  useEffect(() => {
+    if (!opened) return;
+
+    tessen.track({ category: 'LicenseKey', eventName: 'opened' });
+  }, [show, tessen]);
+
+  return (
+    <div
+      css={css`
+        display: inline-flex;
+        justify-content: center;
+        position: relative;
+      `}
+      onMouseEnter={show}
+      onMouseLeave={() => {
+        // if the Popover was opened via click,
+        // we only want to close it via click.
+        if (clicked.current) return;
+        hide();
+      }}
+    >
+      <button
+        aria-describedby={`license-key-explainer-${popoverId}`}
+        css={css`
+          align-items: center;
+          background: none;
+          border: 0;
+          border-bottom: 1px solid var(--primary-text-color);
+          color: var(--primary-text-color);
+          cursor: pointer;
+          display: flex;
+          justify-content: center;
+          padding-bottom: 1px;
+          padding-right: 1px;
+        `}
+        onClick={(e) => {
+          if (e.target !== e.currentTarget) return;
+
+          clicked.current = true;
+          if (!opened) show();
+          if (clicked.current && opened) hide();
+        }}
+        type="button"
+      >
+        account license key{' '}
+        <Icon
+          css={css`
+            margin-left: 0.25em;
+          `}
+          name="fe-info"
+          size="1.25em"
+        />
+      </button>
+
+      <Popover id={popoverId} hidden={!opened} ref={popover} />
+    </div>
+  );
+};
+
+// `--overflow-offset` is set in a `useCallback` below.
+// it's used to shift the popover left or right so it doesn't overflow the screen.
+const slideFadeIn = keyframes`
+  from {
+    opacity: 0;
+    translate: var(--overflow-offset) 12%;
+  }
+  to {
+    opacity: 1;
+    translate: var(--overflow-offset) 0%;
+  }
+`;
+
+const Popover = forwardRef(({ id, hidden = false }, ref) => {
+  const onLearnMore = useInstrumentedHandler(() => {}, {
+    eventName: 'learnMoreClick',
+    category: 'LicenseKey',
+  });
+  const onCreateAccount = useInstrumentedHandler(() => {}, {
+    eventName: 'createAccountClick',
+    category: 'LicenseKey',
+  });
+  const onGetYourKey = useInstrumentedHandler(() => {}, {
+    eventName: 'getYourKeyClick',
+    category: 'LicenseKey',
+  });
+
+  const { width } = useWindowSize();
+  const setOffsetRef = useCallback(
+    (node) => {
+      if (!node) return;
+
+      const box = node.getBoundingClientRect();
+      const overflowLeft = Math.abs(Math.min(0, box.left));
+      const overflowRight = Math.min(0, window.innerWidth - box.right);
+
+      const offset = (overflowLeft + overflowRight).toFixed(2);
+      ref.current.style.setProperty('--overflow-offset', `${offset}px`);
+    },
+    [width]
+  );
+
+  return (
+    // this container `div` is so we can reliably calculate the offset.
+    // `.getBoundingClientRect()` takes transforms into account, so we would
+    // get the wrong offset after the first measurement if we measured
+    // the same `div` we transformed.
+    <div
+      className={!hidden && 'visible'}
+      css={css`
+        bottom: 200%;
+        position: absolute;
+        visibility: hidden;
+
+        &.visible {
+          visibility: visible;
+        }
+      `}
+      ref={setOffsetRef}
+    >
+      <div
+        className={!hidden && 'visible'}
+        css={css`
+          body.dark-mode & {
+            --popover-background: var(
+              --system-background-selected-low-contrast-dark
+            );
+          }
+
+          --popover-background: var(--system-text-primary-light);
+
+          background: var(--popover-background);
+          border-radius: 4px;
+          bottom: 0;
+          color: var(--system-text-primary-dark);
+          cursor: default;
+          display: grid;
+          gap: 8px;
+          grid-template-columns: 1fr 1fr;
+          justify-items: center;
+          padding: 1rem;
+          text-align: left;
+          translate: var(--overflow-offset) 0;
+          visibility: hidden;
+
+          &::before {
+            --size: 1rem;
+            background: var(--popover-background);
+            border-bottom-right-radius: 4px;
+            content: '';
+            bottom: calc(var(--size) / -2);
+            grid-column: 1 / 3;
+            height: var(--size);
+            position: absolute;
+            rotate: 45deg;
+            transform-origin: center;
+            translate: calc(var(--overflow-offset) * -1) 0;
+            width: var(--size);
+          }
+
+          /* this is to bridge to the hoverable area between
+           * the popover and the triggering button.
+           */
+          &::after {
+            content: '';
+            height: 14%;
+            position: absolute;
+            top: 100%;
+            width: 100%;
+          }
+
+          &.visible {
+            animation: 360ms ${slideFadeIn} cubic-bezier(0, 0.3, 0.4, 1);
+            visibility: visible;
+          }
+        `}
+        id={`license-key-explainer-${id}`}
+        ref={ref}
+        role="status"
+      >
+        <p
+          css={css`
+            font-weight: 500;
+            justify-self: start;
+            margin: 0;
+          `}
+        >
+          License key
+        </p>
+        <p
+          css={css`
+            grid-column: 1 / 3;
+            margin: 0 0 8px;
+          `}
+        >
+          Your license key is used to associate your incoming data with your
+          account.{' '}
+          <a
+            css={css`
+              color: currentColor;
+              text-decoration: underline;
+
+              &:hover {
+                color: currentColor;
+              }
+            `}
+            href="https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys"
+            onClick={onLearnMore}
+            tabIndex={0}
+          >
+            Learn more
+          </a>
+        </p>
+        <Button
+          as="a"
+          href="https://one.newrelic.com/api-keys"
+          onClick={onGetYourKey}
+          tabIndex={0}
+          variant={Button.VARIANT.PRIMARY}
+        >
+          Get your key{' '}
+          <Icon
+            css={css`
+              margin-left: 4px;
+            `}
+            name="fe-external-link"
+          />
+        </Button>
+        <Button
+          as="a"
+          css={css`
+            border-color: var(--system-background-app-light);
+            color: var(--system-background-app-light);
+
+            &:hover {
+              color: currentColor;
+            }
+          `}
+          href="https://newrelic.com/signup"
+          onClick={onCreateAccount}
+          tabIndex={0}
+          variant={Button.VARIANT.OUTLINE}
+        >
+          Create account
+        </Button>
+      </div>
+    </div>
+  );
+});
+Popover.propTypes = {
+  hidden: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+};
+
+export default LicenseKey;

--- a/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/Icon.test.js.snap
+++ b/packages/gatsby-theme-newrelic/src/components/__tests__/__snapshots__/Icon.test.js.snap
@@ -384,17 +384,14 @@ exports[`fe-info icon matches its snapshot 1`] = `
     cx="12"
     cy="12"
     r="10"
-    stroke="#0095a9"
   />
   <line
-    stroke="#0095a9"
     x1="12"
     x2="12"
     y1="16"
     y2="12"
   />
   <line
-    stroke="#0095a9"
     x1="12"
     x2="12.01"
     y1="8"

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -54,6 +54,16 @@
     "cookiePolicy": "Cookie Policy",
     "ukSlaveryAct": "UK Slavery Act"
   },
+  "licenseKey": {
+    "buttonText": "account license key",
+    "popover": {
+      "header": "License Key",
+      "explainer": "Your license key is used to associate your incoming data with your account.",
+      "learnMore": "Learn More",
+      "getYourKey": "Get your key",
+      "createAccount": "Create account"
+    }
+  },
   "mobileNav": {
     "header": "Pages"
   },

--- a/packages/gatsby-theme-newrelic/src/icons/feather.js
+++ b/packages/gatsby-theme-newrelic/src/icons/feather.js
@@ -72,9 +72,9 @@ export default {
   ),
   info: (
     <>
-      <circle cx="12" cy="12" r="10" stroke="#0095a9" />
-      <line x1="12" y1="16" x2="12" y2="12" stroke="#0095a9" />
-      <line x1="12" y1="8" x2="12.01" y2="8" stroke="#0095a9" />
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="16" x2="12" y2="12" />
+      <line x1="12" y1="8" x2="12.01" y2="8" />
     </>
   ),
   loader: (


### PR DESCRIPTION
## known issues
- you can tab to the "account license key" text and hit enter to open the popover, but can't tab to the buttons inside it
- clicking the "account license key" text after hovering over it causes the animation to play again. this isn't as important but still looks silly

## screenshots:

<img width="590" alt="Screen Shot 2023-01-27 at 5 47 38 PM" src="https://user-images.githubusercontent.com/14365008/215226541-bafff8cb-a076-4304-bae1-74d4325cf713.png">
<img width="555" alt="Screen Shot 2023-01-27 at 5 47 45 PM" src="https://user-images.githubusercontent.com/14365008/215226544-05d6819a-a9f5-4ad9-b207-8cc7276c9565.png">
