### PR TITLE
fix(header): remove unused SignupModal from global header

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import useMedia from 'use-media';
 import path from 'path';
@@ -19,7 +19,6 @@ import useQueryParams from '../hooks/useQueryParams';
 import useThemeTranslation from '../hooks/useThemeTranslation';
 import useHasMounted from '../hooks/useHasMounted';
 import useInstrumentedHandler from '../hooks/useInstrumentedHandler';
-import SignupModal from './SignupModal';
 
 export const NR_SITES = {
   DOCS: 'DOCS',
@@ -90,7 +89,6 @@ const GlobalHeader = ({ className, activeSite, hideSearch = false }) => {
   const location = useLocation();
   const { queryParams, setQueryParam, deleteQueryParam } = useQueryParams();
   const { t } = useThemeTranslation();
-  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const {
     allLocale: { nodes: locales },

--- a/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalHeader.js
@@ -475,10 +475,6 @@ const GlobalHeader = ({ className, activeSite, hideSearch = false }) => {
               </Button>
             </li>
           </ul>
-          <SignupModal
-            onClose={() => setIsModalOpen(false)}
-            isOpen={isModalOpen}
-          />
         </div>
       </div>
     </>

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -66,7 +66,6 @@ BarItem.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
-  className: PropTypes.string,
 };
 
 export default BarItem;


### PR DESCRIPTION
## Description

We don't actively use sign up modal, so remove from global header

Other 🧹 up of linting errors