### PR TITLE
fix: use `visibility` instead of `overflow`

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -151,9 +151,6 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
 
       <animated.div
         style={{ height: isOpen && previousIsOpen ? 'auto' : viewHeight }}
-        css={css`
-          overflow: hidden;
-        `}
       >
         <div
           ref={ref}
@@ -161,6 +158,11 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
           css={css`
             border-top: 1px solid var(--border-color);
             padding: 1rem;
+            visibility: visible;
+            ${!isOpen &&
+            `
+            visibility: hidden;
+            `}
           `}
         >
           {children}


### PR DESCRIPTION
this allows the `LicenseKey` component to be used within `Collapser`s. previously, the `LicenseKey` popover would be cut off, because it couldn't overflow the container

it doesn't look quite as good, but it does allow the license key popover to display normally

## screenshots

### before

![before](https://user-images.githubusercontent.com/14365008/217068912-07c5c131-9b3e-4b26-896d-70046d1cd3cf.gif)

### after
![after](https://user-images.githubusercontent.com/14365008/217068943-f3aa5ed9-1c85-4a48-b498-11873acd8598.gif)
