### PR TITLE
fix: add `eslint-disable` comment to attribute

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/OneTrust.js
+++ b/packages/gatsby-theme-newrelic/src/components/OneTrust.js
@@ -17,6 +17,7 @@ const OneTrust = ({ id }) => {
     <script
       src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
       type="text/javascript"
+      // eslint-disable-next-line react/no-unknown-property
       charset="UTF-8"
       data-domain-script={id}
     />


### PR DESCRIPTION
i'm pretty sure this script tag was copy-pasted.
this change makes ESLint stop complaining about it