### PR TITLE
fix: use `display` instead of `visibility`

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -377,6 +377,15 @@ const IndexPage = () => {
             <Collapser title="This one is open by default" defaultOpen>
               And you can see everything inside of it!
             </Collapser>
+            <Collapser
+              id="example-4"
+              title="Collapsers can even have collapsers inside of them"
+            >
+              <p>Here's some text</p>
+              <Collapser id="example-5" title="and another collapser!">
+                😃
+              </Collapser>
+            </Collapser>
           </CollapserGroup>
         </section>
         <section>

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -158,10 +158,9 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
           css={css`
             border-top: 1px solid var(--border-color);
             padding: 1rem;
-            visibility: visible;
             ${!isOpen &&
             `
-            visibility: hidden;
+              display: none;
             `}
           `}
         >


### PR DESCRIPTION
`visibility: hidden` won't cause children elements to be hidden if they have `visibility: visible`, as is the case when a collapser is inside of another collapser.
this change uses `display: none` instead which will hide all children