### PR TITLE
fix: fix wrong codeblock height in collapsers

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -162,7 +162,8 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
             padding: 1rem;
             visibility: visible;
 
-            &.collapser-hidden, .collapser-hidden & {
+            &.collapser-hidden,
+            .collapser-hidden & {
               visibility: hidden;
             }
           `}

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -8,6 +8,7 @@ import { usePrevious, useIsomorphicLayoutEffect } from 'react-use';
 import useKeyPress from '../hooks/useKeyPress';
 import useQueryParams from '../hooks/useQueryParams';
 import { useLocation } from '@reach/router';
+import cx from 'classnames';
 
 const ResizeObserver = global.ResizeObserver || class ResizeObserver {};
 
@@ -155,13 +156,15 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
         <div
           ref={ref}
           aria-hidden={!isOpen}
+          className={cx(!isOpen && 'collapser-hidden')}
           css={css`
             border-top: 1px solid var(--border-color);
             padding: 1rem;
-            ${!isOpen &&
-            `
-              display: none;
-            `}
+            visibility: visible;
+
+            &.collapser-hidden, .collapser-hidden & {
+              visibility: hidden;
+            }
           `}
         >
           {children}


### PR DESCRIPTION
this change switches the collapsers from using `display` back to using `visibility` like in `05fe6da5`, but critically, also hides collapsers that are descendants of a collapser that is closed

the change that switched from `visibility` to `display`, `0ce3a48f`, caused an issue with codeblocks inside collapsers. i'm not 100% sure on why, but according to Clark it's because that component does height calculations that fail with `display: none`

it might be useful to compare this change to the first time i tried using `visibility`. you can run this command:

```
git diff 05fe6da5..811a48a -- packages/gatsby-theme-newrelic/src/components/Collapser.js
```

to see that diff