### PR TITLE
Add function to ensure no trail slash in q param

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -3,6 +3,7 @@ require('dotenv').config({
 });
 
 module.exports = {
+  trailingSlash: 'always',
   flags: {
     DEV_SSR: true,
   },

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearchQuery.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearchQuery.js
@@ -10,6 +10,17 @@ const useSearchQuery = (filters) => {
   const hasQParam = queryParams.has('q');
   const tessen = useTessen();
 
+  // when 'trailingSlash = "always"' is set in the gatsby-config
+  // it adds a slash to query params on the 404 page, this
+  // ensures no slash is set at the end of the search term
+  const handleSearchTerm = (term) => {
+    if (term && term.substr(-1) === '/') {
+      setSearchTerm(term.substr(0, term.length - 1));
+      return;
+    }
+    setSearchTerm(term);
+  };
+
   const filtersUsedForSearch = filters.flatMap((filter) => {
     const selectedFilterObjects = filter.defaultFilters.filter(
       (f) => f.isSelected === true
@@ -39,7 +50,7 @@ const useSearchQuery = (filters) => {
   );
 
   useEffect(() => {
-    setSearchTerm(searchQueryParam);
+    handleSearchTerm(searchQueryParam);
   }, [searchQueryParam]);
 
   return [searchTerm, setSearchTerm];


### PR DESCRIPTION
We were having an issue where the 404 page would update the query params based on the slug that lead the user to get a page that doesn't exist. Gatsby was adding a trailing slash to this param.  I've added a function that, if there is a trailing slash in the search term, it will be removed.  Also, updated the gatsby-config to match the functionality of the docs site, this enabled me to replicate the bug locally.

to test, visit `/apache` and click into the search bar