### PR TITLE
ajs_anonymous_id failing to parse because string

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SignupModal/signup.js
+++ b/packages/gatsby-theme-newrelic/src/components/SignupModal/signup.js
@@ -13,8 +13,7 @@ const recaptchaReady = () => {
   });
 };
 
-const getSegmentAnonymousId = () =>
-  JSON.parse(Cookies.get('ajs_anonymous_id') || 'null');
+const getSegmentAnonymousId = () => Cookies.get('ajs_anonymous_id') || 'null';
 
 export const getUriParameters = () =>
   new URLSearchParams(window.location.search);


### PR DESCRIPTION
The ajs_anonymous_id is failing to parse as JSON as it is now being set as a cookie as simply a string.  This was causing the signup request to hang and not make a network request to our internal service for signups.