### PR TITLE
fix(sitemap): exclude embed pages from sitemap always

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -19,6 +19,22 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
+        sitemap: process.env.ENVIRONMENT === 'production',
+        robots: {
+          resolveEnv: () => process.env.ENVIRONMENT || 'development',
+          env: {
+            staging: {
+              host: 'https://docs-dev.newrelic.com',
+              policy: [{ userAgent: '*', disallow: ['/'] }],
+            },
+            development: {
+              policy: [{ userAgent: '*', disallow: ['/'] }],
+            },
+            production: {
+              policy: [{ userAgent: '*', allow: '/' }],
+            },
+          },
+        },
         i18n: {
           translationsPath: `${__dirname}/src/i18n/translations`,
           additionalLocales: ['jp', 'kr'],

--- a/packages/gatsby-theme-newrelic/gatsby-config.js
+++ b/packages/gatsby-theme-newrelic/gatsby-config.js
@@ -7,6 +7,7 @@ module.exports = ({ layout, newrelic, robots = {}, sitemap = true }) => {
         resolve: 'gatsby-plugin-sitemap',
         options: {
           output: '/',
+          excludes: ['*/embed/'],
         },
       },
       'gatsby-plugin-use-dark-mode',
@@ -17,7 +18,6 @@ module.exports = ({ layout, newrelic, robots = {}, sitemap = true }) => {
           defaults: {},
         },
       },
-
       layout &&
         layout.component && {
           resolve: `gatsby-plugin-layout`,


### PR DESCRIPTION
## Description

Adds option to `gatsby-plugin-sitemap` config to always exclude `/embed` pages from sitemaps for good measure. On docs site these pages already have a meta `robots` tag set to `noindex`.

Example:
https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/introduction-new-relic-platform/embed/
