### PR TITLE
fix: make search return 7 results and not fetch any more

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/ScrollContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/ScrollContainer.js
@@ -1,26 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
-import { useIntersection } from 'react-use';
-import usePrevious from '../../hooks/usePrevious';
 
-const ScrollContainer = ({ children, onIntersection, monitor = true }) => {
-  const intersectionRef = useRef();
+const ScrollContainer = ({ children }) => {
   const root = useRef();
-  const intersection = useIntersection(intersectionRef, {
-    root: root.current,
-    rootMargin: '0px 0px 200px 0px',
-    threshold: 1,
-  });
-
-  const isIntersecting = intersection?.isIntersecting;
-  const wasIntersecting = usePrevious(isIntersecting);
-
-  useEffect(() => {
-    if (isIntersecting && !wasIntersecting) {
-      onIntersection();
-    }
-  }, [wasIntersecting, isIntersecting, onIntersection]);
 
   return (
     <div
@@ -36,7 +19,6 @@ const ScrollContainer = ({ children, onIntersection, monitor = true }) => {
       `}
     >
       {children}
-      {monitor && <div ref={intersectionRef} />}
     </div>
   );
 };

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/ScrollContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/ScrollContainer.js
@@ -25,8 +25,6 @@ const ScrollContainer = ({ children }) => {
 
 ScrollContainer.propTypes = {
   children: PropTypes.node.isRequired,
-  onIntersection: PropTypes.func.isRequired,
-  monitor: PropTypes.bool,
 };
 
 export default ScrollContainer;

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/SearchModal.js
@@ -43,7 +43,7 @@ const SearchModal = ({ onClose, isOpen }) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [filters, setFilters] = useState(DEFAULT_FILTER_TYPES);
   const [searchTerm, setSearchTerm] = useSearchQuery(filters);
-  const { status, results, fetchNextPage } = useSearch({
+  const { status, results } = useSearch({
     searchTerm,
     filters,
   });
@@ -74,10 +74,6 @@ const SearchModal = ({ onClose, isOpen }) => {
   useEffect(() => {
     setSelectedIndex(0);
   }, [searchTerm]);
-
-  const onIntersection = useCallback(() => {
-    fetchNextPage();
-  }, [fetchNextPage]);
 
   const handleSelectIndex = useCallback((idx) => {
     setSelectedIndex(idx);
@@ -202,10 +198,7 @@ const SearchModal = ({ onClose, isOpen }) => {
                 >
                   {Boolean(results?.length) && (
                     <>
-                      <ScrollContainer
-                        onIntersection={onIntersection}
-                        monitor={status === 'success'}
-                      >
+                      <ScrollContainer>
                         <ResultList
                           results={results}
                           selectedIndex={selectedIndex}

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearch.js
@@ -80,7 +80,7 @@ const useSearch = ({ searchTerm, filters }) => {
         defaultSources,
         filters,
         page,
-        perPage: 20,
+        perPage: 7,
       }),
     {
       enabled: Boolean(debouncedSearchTerm),


### PR DESCRIPTION
This PR will make the search modal contain only 7 results and will not fetch more when a user hovers in the Scroll Container