### PR TITLE
Update feedback styles

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/ComplexFeedback.js
+++ b/packages/gatsby-theme-newrelic/src/components/ComplexFeedback.js
@@ -102,7 +102,7 @@ const ComplexFeedback = ({ pageTitle }) => {
         border: none;
         flex-direction: column;
         max-width: 320px;
-        background: var(--erno-yellow);
+        background: #afe2e3;
         gap: 1rem;
         p {
           color: var(--system-text-primary-light);
@@ -143,6 +143,7 @@ const ComplexFeedback = ({ pageTitle }) => {
           <h4
             css={css`
               margin-bottom: 0;
+              text-align: center;
             `}
           >
             {t('feedback.question')}
@@ -154,6 +155,12 @@ const ComplexFeedback = ({ pageTitle }) => {
               justify-content: space-around;
               align-items: flex-start;
 
+              button {
+                width: 45%;
+                font-size: 14px;
+                border: none;
+              }
+
               @supports not (gap: 0.5rem) {
                 a:first-of-type {
                   margin-right: 0.25rem;
@@ -163,13 +170,13 @@ const ComplexFeedback = ({ pageTitle }) => {
           >
             <Button
               variant={Button.VARIANT.OUTLINE}
-              size={Button.SIZE.SMALL}
+              size={Button.SIZE.LARGE}
               onClick={() => handleFeedbackClick('yes')}
               css={css`
                 height: 3rem;
                 margin-bottom: 0.5rem;
                 color: var(--system-text-primary-light);
-                border-color: var(--system-text-primary-light);
+                background: var(--system-background-app-light);
 
                 ${feedbackType === 'yes' &&
                 css`
@@ -181,7 +188,7 @@ const ComplexFeedback = ({ pageTitle }) => {
               <div
                 css={css`
                   margin-right: 0.5rem;
-                  font-size: 0.75rem;
+                  font-size: 14px;
                 `}
               >
                 😁
@@ -196,7 +203,7 @@ const ComplexFeedback = ({ pageTitle }) => {
                 height: 3rem;
                 margin-bottom: 0.5rem;
                 color: var(--system-text-primary-light);
-                border-color: var(--system-text-primary-light);
+                background: var(--system-background-app-light);
 
                 ${feedbackType === 'no' &&
                 css`
@@ -208,40 +215,12 @@ const ComplexFeedback = ({ pageTitle }) => {
               <div
                 css={css`
                   margin-right: 0.5rem;
-                  font-size: 0.75rem;
+                  font-size: 14px;
                 `}
               >
                 🙁
               </div>
               {t('feedback.no')}
-            </Button>
-
-            <Button
-              variant={Button.VARIANT.OUTLINE}
-              size={Button.SIZE.SMALL}
-              onClick={() => handleFeedbackClick('somewhat')}
-              css={css`
-                height: 3rem;
-                margin-bottom: 0.5rem;
-                color: var(--system-text-primary-light);
-                border-color: var(--system-text-primary-light);
-
-                ${feedbackType === 'somewhat' &&
-                css`
-                  background: var(--system-text-primary-light);
-                  color: var(--system-text-primary-dark);
-                `}
-              `}
-            >
-              <div
-                css={css`
-                  margin-right: 0.5rem;
-                  font-size: 0.75rem;
-                `}
-              >
-                😐
-              </div>
-              {t('feedback.somewhat')}
             </Button>
           </div>
           {feedbackType && (
@@ -258,7 +237,7 @@ const ComplexFeedback = ({ pageTitle }) => {
                   padding: 0.5rem;
                   min-height: 100px;
                   border-radius: 4px;
-                  border: 1px solid;
+                  border: none;
                 `}
               />
               <p>{t('feedback.email')}</p>
@@ -284,7 +263,7 @@ const ComplexFeedback = ({ pageTitle }) => {
                   font-size: 0.75rem;
                   padding: 0.5rem;
                   border-radius: 4px;
-                  border: 1px solid;
+                  border: none;
                 `}
               />
               {userEmail && !isValidEmail(userEmail) && (

--- a/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
+++ b/packages/gatsby-theme-newrelic/src/i18n/translations/en.json
@@ -36,7 +36,6 @@
     "question": "Was this doc helpful?",
     "yes": "Yes",
     "no": "No",
-    "somewhat": "Somewhat",
     "comments": "Tell us more (optional)",
     "email": "Your email (optional)",
     "emailDisclaimer": "We'll only use this email for follow-up questions about your feedback.",


### PR DESCRIPTION
The pagetools width is defined in the docs site but these screenshots are examples with a smaller width:

<img width="239" alt="Screen Shot 2023-04-17 at 2 32 44 PM" src="https://user-images.githubusercontent.com/39655074/232617053-b8bbe8d6-6830-46ac-a26e-9a4b785fe4a6.png">
<img width="246" alt="Screen Shot 2023-04-17 at 2 41 22 PM" src="https://user-images.githubusercontent.com/39655074/232617148-ff17ea50-6ccd-476b-aef3-b92a4b34fed3.png">
