### PR TITLE
fix Popover offset not working

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -36,6 +36,7 @@ const GlobalStyles = ({ layout }) => (
         color: var(--primary-text-color);
         background-color: var(--primary-background-color);
         line-height: 1.5;
+        overflow-x: hidden;
       }
 
       a {

--- a/packages/gatsby-theme-newrelic/src/components/Popover/Popover.js
+++ b/packages/gatsby-theme-newrelic/src/components/Popover/Popover.js
@@ -22,7 +22,7 @@ const Popover = ({ bottom, children, id, left, onClose, show }) => {
       if (overflowOffset === offset) return;
       setOverflowOffset(offset);
     },
-    [width, overflowOffset]
+    [overflowOffset, show, width]
   );
   useClickAway(ref, onClose);
 
@@ -88,7 +88,7 @@ const Popover = ({ bottom, children, id, left, onClose, show }) => {
               position: absolute;
               rotate: 45deg;
               transform-origin: center;
-              translate: calc(var(--overflow-offset) + 50% * -1) 0;
+              translate: calc(var(--overflow-offset) * -1 + 50%) 0;
               width: var(--size);
             }
 
@@ -118,7 +118,7 @@ const Popover = ({ bottom, children, id, left, onClose, show }) => {
   );
 };
 
-// `--overflow-offset` is set in a `useCallback` below.
+// `--overflow-offset` is set in a `useCallback` above.
 // it's used to shift the popover left or right so it doesn't overflow the screen.
 const slideFadeIn = keyframes`
   from {


### PR DESCRIPTION
the `useCallback` didn't have `show` as a dependency, so it wasn't recalculating the offset correctly. this fixes that and adds `overflow-x: hidden` to the body so that overflowing Popovers don't increase the document size