### PR TITLE
fix: add `height: 100%` to fix overflow

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
@@ -35,7 +35,7 @@ const getDeepestChild = (child) => {
 };
 
 const MobileTabControl = ({ children, className }) => {
-  const [[currentTab, setCurrentTab]] = useTabs();
+  const { currentTab, setCurrentTab } = useTabs();
 
   // eslint gets angry about using props from React.Children.map
   /* eslint-disable react/prop-types */
@@ -71,7 +71,7 @@ MobileTabControl.propTypes = {
 };
 
 const Bar = ({ children, className }) => {
-  const [, stacked, mobileBreakpoint] = useTabs();
+  const { containerHeight, mobileBreakpoint, stacked } = useTabs();
 
   return (
     <>
@@ -97,6 +97,7 @@ const Bar = ({ children, className }) => {
           ${stacked &&
           css`
             flex-direction: column;
+            height: ${containerHeight}px;
             min-height: 350px;
             overflow: none;
             overflow-wrap: break-word;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -13,7 +13,7 @@ const BarItem = ({
   disabled,
   onClick: onTabClick,
 }) => {
-  const [[currentTab, setCurrentTab], stacked] = useTabs();
+  const { currentTab, setCurrentTab, stacked } = useTabs();
   const isSelected =
     id === currentTab || (currentTab === undefined && index === 0);
 

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -23,6 +23,7 @@ const Page = ({ index, children, id, className, handleHeight }) => {
       css={css`
         ${stacked &&
         css`
+          height: 100%;
           max-height: 500px;
           overflow-y: scroll;
           width: 100%;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -4,14 +4,17 @@ import { css } from '@emotion/react';
 
 import useTabs from './useTabs';
 
-const Page = ({ index, children, id, className, handleHeight }) => {
-  const [[currentTab], stacked] = useTabs();
+const Page = ({ index, children, id, className }) => {
+  const { currentTab, updateHeight, stacked } = useTabs();
 
-  const page = useCallback((div) => {
-    if (!div) return;
-    const rect = div.getBoundingClientRect();
-    handleHeight(rect.height);
-  }, []);
+  const page = useCallback(
+    (div) => {
+      if (!div) return;
+      const rect = div.getBoundingClientRect();
+      updateHeight(rect.height);
+    },
+    [updateHeight]
+  );
 
   const isSelected =
     id === currentTab || (currentTab === undefined && index === 0);
@@ -52,7 +55,6 @@ Page.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
-  handleHeight: PropTypes.func,
 };
 
 export default Page;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
@@ -1,18 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
 import useTabs from './useTabs';
 
 const Pages = ({ children }) => {
-  const [height, setHeight] = useState(0);
-  const [, stacked, mobileBreakPoint] = useTabs();
-  const handleHeight = (pageHeight) => {
-    if (pageHeight > height) {
-      const maxHeight = Math.min(pageHeight, 500);
-      setHeight(maxHeight);
-    }
-  };
+  const { containerHeight, stacked, mobileBreakPoint } = useTabs();
 
   return (
     <div
@@ -21,7 +14,7 @@ const Pages = ({ children }) => {
         css`
           align-items: start;
           display: flex;
-          height: ${height}px;
+          height: ${containerHeight}px;
           justify-content: center;
           width: 70%;
           @media screen and (max-width: ${mobileBreakPoint}) {
@@ -31,7 +24,7 @@ const Pages = ({ children }) => {
       }
     >
       {React.Children.map(children, (child, index) =>
-        React.cloneElement(child, { ...child.props, index, handleHeight })
+        React.cloneElement(child, { ...child.props, index })
       )}
     </div>
   );

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -10,7 +10,16 @@ import Pages from './Pages';
 import Page from './Page';
 
 const Tabs = ({ children, initialTab, stacked }) => {
-  const tabState = useState(initialTab);
+  const [currentTab, setCurrentTab] = useState(initialTab);
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  const updateHeight = (pageHeight) => {
+    if (pageHeight > containerHeight) {
+      const maxHeight = Math.min(pageHeight, 500);
+      setContainerHeight(maxHeight);
+    }
+  };
+
   const {
     site: {
       layout: { mobileBreakpoint },
@@ -25,8 +34,17 @@ const Tabs = ({ children, initialTab, stacked }) => {
     }
   `);
 
+  const context = {
+    containerHeight,
+    currentTab,
+    mobileBreakpoint,
+    setCurrentTab,
+    stacked,
+    updateHeight,
+  };
+
   return (
-    <TabsContext.Provider value={[tabState, stacked, mobileBreakpoint]}>
+    <TabsContext.Provider value={context}>
       <div
         css={css`
           ${stacked &&


### PR DESCRIPTION
## testing

- check out this branch in the theme repo
- in the docs repo:
  - run `cp -r <theme-repo-dir>/packages/gatsby-theme-newrelic/src/components/Tabs/ node_modules/@newrelic/gatsby-theme-newrelic/src/components/Tabs/`
  - `yarn clean`
  - `BUILD_FOLDERS=synthetics yarn start`
  - go to http://localhost:8000/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/