### PR TITLE
Add apache to languages

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -230,7 +230,7 @@ exports.onCreateBabelConfig = ({ actions }, themeOptions) => {
     options: {
       languages: uniq([
         'markup',
-        'apache',
+        'apacheconf',
         'bash',
         'clike',
         'c',

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -230,6 +230,7 @@ exports.onCreateBabelConfig = ({ actions }, themeOptions) => {
     options: {
       languages: uniq([
         'markup',
+        'apache',
         'bash',
         'clike',
         'c',


### PR DESCRIPTION
We have a couple PHP docs using apache syntax, which works on github, so I know it's a valid language identifier

Here's an example:
- https://github.com/newrelic/docs-website/blob/develop/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx

related PR adding apache code blocks:
- https://github.com/newrelic/docs-website/pull/12932