### PR TITLE
add `sideEffects: false` for tree-shaking

### DIFF
--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -22,6 +22,7 @@
     "react",
     "newrelic"
   ],
+  "sideEffects": false,
   "peerDependencies": {
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.3.0",


### PR DESCRIPTION
on the opensource site, this reduces the build output by about a third (3.27MB before vs 1.91MB after)