### PR TITLE
Step headers styles

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/TutorialSteps/TutorialStep.js
+++ b/packages/gatsby-theme-newrelic/src/components/TutorialSteps/TutorialStep.js
@@ -25,6 +25,11 @@ const TutorialStep = ({ children, stepNumber, totalSteps }) => {
         &:last-child {
           border-bottom: 1px solid var(--divider-color);
         }
+
+        h2,
+        h3 {
+          font-size: 1.17em;
+        }
       `}
     >
       <StepCounter stepNumber={stepNumber} total={totalSteps} />


### PR DESCRIPTION
Sets h2 and h3 to have the same styling within Steps
- visually, the h3s look better in mdx pages within Steps, but h2s show in the PageTools.
- this gives writers the option to add these headers to the TOC without sacrificing styling or requiring a refactor in our components
- we don't seem to be setting our own header font sizes anywhere. the inherited user agent style for h3s is 1.17em

<img width="555" alt="Screenshot 2023-08-15 at 2 37 36 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/595134e2-3906-4109-bc62-72dd887f0254">
