### PR TITLE
fix: use `fileAbsolutePath` for `MarkdownRemark` nodes

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -300,8 +300,12 @@ exports.onCreateNode = async (utils, themeOptions) => {
   const slugify = (str) => str.replace('src/content/', '').replace('.mdx', '');
 
   if (MDX_NODE_TYPES.has(node.internal.type)) {
+    const absolutePath =
+      node.internal.type === 'MarkdownRemark'
+        ? node.fileAbsolutePath
+        : node.internal.contentFilePath;
     const fileRelativePath = getFileRelativePath(
-      node.internal.contentFilePath,
+      absolutePath,
       program.directory
     );
 


### PR DESCRIPTION
there aren't any `MarkdownRemark` nodes in the demo, but there are in the docs-website, so we didn't see this before