### PR TITLE
feat: update gatsby plugin newrelic

### DIFF
--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -57,7 +57,7 @@
     "gatsby-plugin-emotion": "^8.12.0",
     "gatsby-plugin-layout": "^4.11.0",
     "gatsby-plugin-mdx": "^5.11.0",
-    "gatsby-plugin-newrelic": "2.3.0",
+    "gatsby-plugin-newrelic": "2.4.0",
     "gatsby-plugin-portal": "^1.0.7",
     "gatsby-plugin-react-helmet": "^6.11.0",
     "gatsby-plugin-robots-txt": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9158,10 +9158,10 @@ gatsby-plugin-mdx@^5.11.0:
     unist-util-visit "^4.1.2"
     vfile "^5.3.7"
 
-gatsby-plugin-newrelic@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-2.3.0.tgz#6e0f08fc9b7081bab905551d47af2df55909efb2"
-  integrity sha512-Q7IIc6XKCGAr8AeYYNzFl3FjFxeJNaM6S3vBQwDgeCUF0svs4qj2zsWTCwshSZiZdb3wwI12uJYzmB/gqW3O7w==
+gatsby-plugin-newrelic@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-2.4.0.tgz#9361b49db19cbbe4e6f17aa2f81d9c68535f62fe"
+  integrity sha512-BOZko4EHIphlA/fDZaTXtJu2E/7BQFt5kWz1ps2F8QpbcRmO7RpzSU0Mwh/sNWp3nAPcfPsAvFVKesZNNWHpOQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION

![Screenshot 2023-11-07 at 10 19 15 AM](https://github.com/newrelic/gatsby-theme-newrelic/assets/26727669/7e832887-2901-4bc3-b315-12904f8e20d8)

Updates `gatsby-plugin-newrelic` to use a version that will install the latest NR browser agent