### PR TITLE
feat: add privacy icon

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -4,6 +4,7 @@ import ExternalLink from './ExternalLink';
 import { graphql, useStaticQuery } from 'gatsby';
 import { css } from '@emotion/react';
 import useThemeTranslation from '../hooks/useThemeTranslation';
+import PrivacySwitch from '../icons/PrivacySwitch';
 import Trans from './Trans';
 import Link from './Link';
 import RecaptchaFooter from './SignupModal/RecaptchaFooter';
@@ -35,6 +36,7 @@ const GlobalFooter = ({ className }) => {
   const handlePrivacyClick = () => {
     window.Osano.cm.showDrawer('osano-cm-dom-info-dialog-open');
   };
+  const osanoPresent = hasOsano();
 
   return (
     <footer
@@ -98,8 +100,9 @@ const GlobalFooter = ({ className }) => {
               css={css`
                 display: flex;
                 flex-wrap: wrap;
-                justify-content: center;
+                justify-content: flex-end;
                 grid-area: legal;
+                max-width: ${osanoPresent ? '29rem' : '32rem'};
 
                 a {
                   margin-left: 0.75rem;
@@ -124,7 +127,7 @@ const GlobalFooter = ({ className }) => {
               <ExternalLink href="https://newrelic.com/termsandconditions/services-notices">
                 {t('footer.privacyNotice', 'Privacy Notice')}
               </ExternalLink>
-              {hasOsano() && (
+              {osanoPresent && (
                 <Button
                   variant={Button.VARIANT.LINK}
                   css={css`
@@ -134,10 +137,21 @@ const GlobalFooter = ({ className }) => {
                     text-decoration: underline;
                     white-space: nowrap;
                     color: var(--system-text-primary-dark);
+
+                    &:hover svg {
+                      filter: invert(100%);
+                    }
                   `}
                   onClick={handlePrivacyClick}
                 >
                   {t('footer.privacyChoices')}
+                  <PrivacySwitch
+                    css={css`
+                      height: 1em;
+                      margin-left: 0.5em;
+                    `}
+                    size="2em"
+                  />
                 </Button>
               )}
 

--- a/packages/gatsby-theme-newrelic/src/icons/PrivacySwitch.js
+++ b/packages/gatsby-theme-newrelic/src/icons/PrivacySwitch.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import SVG from '../components/SVG';
+
+const PrivacySwitch = (props) => (
+  <SVG {...props} viewBox="0 0 30 14">
+    <path
+      d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"
+      style={{
+        'fill-rule': 'evenodd',
+        'clip-rule': 'evenodd',
+        fill: '#1d252c',
+      }}
+    />
+    <path
+      d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z"
+      style={{
+        'fill-rule': 'evenodd',
+        'clip-rule': 'evenodd',
+        fill: '#898e91',
+      }}
+    />
+    <path
+      d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z"
+      style={{ fill: '#1d252c' }}
+    />
+    <path
+      d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z"
+      style={{ fill: '#898e91' }}
+    />
+  </SVG>
+);
+
+export default PrivacySwitch;


### PR DESCRIPTION
i added a conditional max-width, because otherwise the last item in the list of links is on a line by itself and it looks weird at larger font sizes/smaller screen sizes

## screenshots

### with Your Privacy Choices
![Screenshot 2023-12-07 at 2 44 00 PM](https://github.com/newrelic/gatsby-theme-newrelic/assets/14365008/fd264d58-4319-4700-b742-f68400ad89f0)

### without
![Screenshot 2023-12-07 at 2 45 24 PM](https://github.com/newrelic/gatsby-theme-newrelic/assets/14365008/5f9472b1-ccc7-492a-98fb-af35a053137a)


## testing
the theme demo doesn't have Osano, so the link we're adding the icon to doesn't show up normally. in GlobalFooter.js, change the `hasOsano` function to always return `true`. then the "Your Privacy Choices" link and the new icon will show up

the behavior of the icon (invert on hover) should match the behavior on newrelic.com. clicking the link will throw an error since Osano isn't defined