### PR TITLE
Tabs UX refresh

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -163,6 +163,127 @@ const IndexPage = () => {
           <h1>{t('home.welcome')}</h1>
           <p>{t('home.intro')}</p>
           <section>
+            <Tabs>
+              <Tabs.Bar>
+                <Tabs.BarItem id="codeblock">A code block</Tabs.BarItem>
+                <Tabs.BarItem id="live-edit">
+                  A live editable code block w/ preview
+                </Tabs.BarItem>
+                <Tabs.BarItem id="embedded">var/mark/links</Tabs.BarItem>
+                <Tabs.BarItem id="text">lotsa text</Tabs.BarItem>
+              </Tabs.Bar>
+              <Tabs.Pages>
+                <Tabs.Page id="codeblock">
+                  <CodeBlock
+                    copyable
+                    lineNumbers
+                    highlightedLines="5-7,12"
+                    fileName="src/components/Button.js"
+                    language="jsx"
+                    css={css`
+                      margin-bottom: 2rem;
+                    `}
+                  >
+                    {codeSample}
+                  </CodeBlock>
+                </Tabs.Page>
+                <Tabs.Page id="live-edit">
+                  <CodeBlock
+                    copyable
+                    lineNumbers
+                    live
+                    preview
+                    fileName="src/components/Button.js"
+                    language="jsx"
+                    scope={{ Button }}
+                    css={css`
+                      margin-bottom: 2rem;
+                    `}
+                  >
+                    {liveCodeSample}
+                  </CodeBlock>
+                </Tabs.Page>
+                <Tabs.Page id="embedded">
+                  <CodeBlock
+                    language="graphql"
+                    css={css`
+                      margin-bottom: 1rem;
+                    `}
+                  >
+                    {codeSampleWithAdditionalTags}
+                  </CodeBlock>
+                  <CodeBlock
+                    language="yaml"
+                    css={css`
+                      margin-bottom: 1rem;
+                    `}
+                  >
+                    {anotherSample}
+                  </CodeBlock>
+                </Tabs.Page>
+                <Tabs.Page id="text">
+                  <h2>Lorem ipsum dolor sit amet.</h2>
+                  <p>
+                    Consectetur adipiscing elit, sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua. Id venenatis a
+                    condimentum vitae sapien pellentesque habitant. Mi quis
+                    hendrerit dolor magna eget. Tortor vitae purus faucibus
+                    ornare suspendisse sed. Eget mi proin sed libero enim sed
+                    faucibus. Odio facilisis mauris sit amet massa vitae tortor.
+                    Tempus urna et pharetra pharetra massa massa ultricies mi
+                    quis. Ac orci phasellus egestas tellus rutrum tellus
+                    pellentesque eu tincidunt. Fringilla urna porttitor rhoncus
+                    dolor purus non. Laoreet suspendisse interdum consectetur
+                    libero id. Nunc consequat interdum varius sit amet.
+                    Elementum facilisis leo vel fringilla est ullamcorper. Urna
+                    molestie at elementum eu facilisis sed odio morbi. Turpis
+                    egestas maecenas pharetra convallis. Rhoncus aenean vel elit
+                    scelerisque mauris pellentesque. Euismod nisi porta lorem
+                    mollis aliquam ut porttitor leo. Aliquet eget sit amet
+                    tellus cras adipiscing enim eu. Amet consectetur adipiscing
+                    elit duis tristique. Egestas quis ipsum suspendisse
+                    ultrices. Congue eu consequat ac felis donec et odio. Vitae
+                    auctor eu augue ut lectus.
+                  </p>
+                  <p>
+                    Et netus et malesuada fames. Vitae tortor condimentum
+                    lacinia quis vel eros donec ac odio. Purus viverra accumsan
+                    in nisl nisi scelerisque eu ultrices vitae. A arcu cursus
+                    vitae congue mauris rhoncus. Habitasse platea dictumst
+                    quisque sagittis purus sit amet. Massa id neque aliquam
+                    vestibulum morbi blandit cursus risus. Posuere ac ut
+                    consequat semper viverra nam libero justo laoreet.
+                  </p>
+                  <ul>
+                    <li>
+                      Purus viverra accumsan in nisl nisi scelerisque eu
+                      ultrices vitae.
+                    </li>
+                    <li>
+                      Ac auctor augue mauris augue neque gravida in fermentum.
+                    </li>
+                    <li>
+                      Purus viverra accumsan in nisl nisi scelerisque eu
+                      ultrices vitae.
+                    </li>
+                    <li>
+                      Ac auctor augue mauris augue neque gravida in fermentum.
+                    </li>
+                  </ul>
+                  <p>
+                    Tincidunt eget nullam non nisi. Interdum posuere lorem ipsum
+                    dolor sit amet. Eu lobortis elementum nibh tellus molestie
+                    nunc non. Blandit libero volutpat sed cras ornare arcu dui
+                    vivamus. At volutpat diam ut venenatis tellus in metus.
+                    Platea dictumst vestibulum rhoncus est pellentesque elit
+                    ullamcorper dignissim cras. Aliquet eget sit amet tellus
+                    cras adipiscing. Et pharetra pharetra massa massa ultricies
+                    mi. Enim nulla aliquet porttitor lacus luctus accumsan
+                    tortor posuere ac.
+                  </p>
+                </Tabs.Page>
+              </Tabs.Pages>
+            </Tabs>
             <h2>Lists</h2>
             <ul>
               <li>List item one</li>

--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -165,62 +165,14 @@ const IndexPage = () => {
           <section>
             <Tabs>
               <Tabs.Bar>
-                <Tabs.BarItem id="codeblock">A code block</Tabs.BarItem>
-                <Tabs.BarItem id="live-edit">
+                <Tabs.BarItem id="text">Lotsa text</Tabs.BarItem>
+                <Tabs.BarItem id="Codeblock">A code block</Tabs.BarItem>
+                <Tabs.BarItem id="Live-edit">
                   A live editable code block w/ preview
                 </Tabs.BarItem>
                 <Tabs.BarItem id="embedded">var/mark/links</Tabs.BarItem>
-                <Tabs.BarItem id="text">lotsa text</Tabs.BarItem>
               </Tabs.Bar>
               <Tabs.Pages>
-                <Tabs.Page id="codeblock">
-                  <CodeBlock
-                    copyable
-                    lineNumbers
-                    highlightedLines="5-7,12"
-                    fileName="src/components/Button.js"
-                    language="jsx"
-                    css={css`
-                      margin-bottom: 2rem;
-                    `}
-                  >
-                    {codeSample}
-                  </CodeBlock>
-                </Tabs.Page>
-                <Tabs.Page id="live-edit">
-                  <CodeBlock
-                    copyable
-                    lineNumbers
-                    live
-                    preview
-                    fileName="src/components/Button.js"
-                    language="jsx"
-                    scope={{ Button }}
-                    css={css`
-                      margin-bottom: 2rem;
-                    `}
-                  >
-                    {liveCodeSample}
-                  </CodeBlock>
-                </Tabs.Page>
-                <Tabs.Page id="embedded">
-                  <CodeBlock
-                    language="graphql"
-                    css={css`
-                      margin-bottom: 1rem;
-                    `}
-                  >
-                    {codeSampleWithAdditionalTags}
-                  </CodeBlock>
-                  <CodeBlock
-                    language="yaml"
-                    css={css`
-                      margin-bottom: 1rem;
-                    `}
-                  >
-                    {anotherSample}
-                  </CodeBlock>
-                </Tabs.Page>
                 <Tabs.Page id="text">
                   <h2>Lorem ipsum dolor sit amet.</h2>
                   <p>
@@ -281,6 +233,55 @@ const IndexPage = () => {
                     mi. Enim nulla aliquet porttitor lacus luctus accumsan
                     tortor posuere ac.
                   </p>
+                </Tabs.Page>
+
+                <Tabs.Page id="codeblock">
+                  <CodeBlock
+                    copyable
+                    lineNumbers
+                    highlightedLines="5-7,12"
+                    fileName="src/components/Button.js"
+                    language="jsx"
+                    css={css`
+                      margin-bottom: 2rem;
+                    `}
+                  >
+                    {codeSample}
+                  </CodeBlock>
+                </Tabs.Page>
+                <Tabs.Page id="live-edit">
+                  <CodeBlock
+                    copyable
+                    lineNumbers
+                    live
+                    preview
+                    fileName="src/components/Button.js"
+                    language="jsx"
+                    scope={{ Button }}
+                    css={css`
+                      margin-bottom: 2rem;
+                    `}
+                  >
+                    {liveCodeSample}
+                  </CodeBlock>
+                </Tabs.Page>
+                <Tabs.Page id="embedded">
+                  <CodeBlock
+                    language="graphql"
+                    css={css`
+                      margin-bottom: 1rem;
+                    `}
+                  >
+                    {codeSampleWithAdditionalTags}
+                  </CodeBlock>
+                  <CodeBlock
+                    language="yaml"
+                    css={css`
+                      margin-bottom: 1rem;
+                    `}
+                  >
+                    {anotherSample}
+                  </CodeBlock>
                 </Tabs.Page>
               </Tabs.Pages>
             </Tabs>

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
@@ -35,14 +35,18 @@ const getDeepestChild = (child) => {
 };
 
 const MobileTabControl = ({ children, className }) => {
-  const { currentTab, setCurrentTab } = useTabs();
+  const { currentTabIndex, setCurrentTabIndex } = useTabs();
 
   // eslint gets angry about using props from React.Children.map
   /* eslint-disable react/prop-types */
   return (
     <Select
       onChange={(e) => {
-        setCurrentTab(e.target.value);
+        const selectedId = e.currentTarget.value;
+        const index = children.findIndex(
+          (child) => child.props.id === selectedId
+        );
+        setCurrentTabIndex(index);
       }}
       css={css`
         margin-bottom: 1rem;
@@ -53,7 +57,7 @@ const MobileTabControl = ({ children, className }) => {
         <option
           key={props.id}
           value={props.id}
-          selected={props.id === currentTab}
+          selected={props.index === currentTabIndex}
           disabled={props.disabled}
         >
           {getDeepestChild(props.children)}

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
@@ -62,7 +62,6 @@ const MobileTabControl = ({ children, className }) => {
       ))}
     </Select>
   );
-  /* eslint-enable react/prop-types */
 };
 
 MobileTabControl.propTypes = {
@@ -92,7 +91,6 @@ const Bar = ({ children, className }) => {
           border: none;
           display: flex;
           width: 100%;
-          margin-bottom: 1em;
           overflow: auto;
           ${stacked &&
           css`

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
@@ -68,6 +68,7 @@ const MobileTabControl = ({ children, className }) => {
   );
 };
 
+/* eslint-enable react/prop-types */
 MobileTabControl.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -28,20 +28,17 @@ const BarItem = ({ className, index, children, id, disabled }) => {
       type="button"
       onClick={handleTabClick}
       css={css`
-        border: none;
-        border-top: var(--primary-background-color) solid 1px;
-        border-bottom: #afe2e3 solid 1px;
-
-        transition: 0.5s ease-in;
-        transition-property: background;
-
         background: none;
+        border: none;
+        border-bottom: #afe2e3 solid 1px;
+        border-top: var(--primary-background-color) solid 1px;
         color: var(--primary-text-color);
-        flex-grow: 1;
-        text-align: left;
-        font-weight: bold;
-        padding: 0.75em 0.5em 0.75em 01em;
         cursor: pointer;
+        flex-grow: 1;
+        font-weight: bold;
+        padding: 0.75em 0.5em 0.75em 1em;
+        text-align: left;
+        transition: 500ms background ease-in;
         user-select: none;
         white-space: nowrap;
 

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -29,8 +29,8 @@ const BarItem = ({ className, index, children, id, disabled }) => {
       onClick={handleTabClick}
       css={css`
         border: none;
-        border-top: var(--primary-background-color) solid 2px;
-        border-bottom: #1dcad3 solid 2px;
+        border-top: var(--primary-background-color) solid 1px;
+        border-bottom: #afe2e3 solid 1px;
 
         transition: 0.5s ease-in;
         transition-property: background;
@@ -38,8 +38,9 @@ const BarItem = ({ className, index, children, id, disabled }) => {
         background: none;
         color: var(--primary-text-color);
         flex-grow: 1;
-        text-align: center;
-        padding: 0.5em;
+        text-align: left;
+        font-weight: bold;
+        padding: 0.75em 0.5em 0.75em 01em;
         cursor: pointer;
         user-select: none;
         white-space: nowrap;
@@ -53,11 +54,12 @@ const BarItem = ({ className, index, children, id, disabled }) => {
           border-top-right-radius: 4px;
           background: var(--secondary-background-color);
 
-          border: #1dcad3 solid 2px;
-          border-bottom: var(--secondary-background-color) solid 2px;
+          border: var(--border-color) solid 1px;
+          border: #afe2e3 solid 1px;
+          border-bottom: var(--secondary-background-color) solid 1px;
 
           .dark-mode & {
-            border-bottom: var(--secondary-background-color) solid 2px;
+            border-bottom: var(--secondary-background-color) solid 1px;
           }
         }
 

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -5,31 +5,14 @@ import { css } from '@emotion/react';
 import useTabs from './useTabs';
 import useInstrumentedHandler from '../../hooks/useInstrumentedHandler';
 
-const BarItem = ({
-  className,
-  index,
-  children,
-  id,
-  disabled,
-  onClick: onTabClick,
-}) => {
-  const {
-    currentTab,
-    previousTabId,
-    setCurrentTab,
-    setPreviousTabId,
-    setTransitionDirection,
-    stacked,
-  } = useTabs();
+const BarItem = ({ className, index, children, id, disabled }) => {
+  const { currentTabIndex, setCurrentTabIndex, stacked } = useTabs();
   const isSelected =
-    id === currentTab || (currentTab === undefined && index === 0);
+    index === currentTabIndex || (currentTabIndex === undefined && index === 0);
 
   const handleTabClick = useInstrumentedHandler(
     () => {
-      !disabled && setCurrentTab(id);
-      onTabClick && onTabClick(id);
-      setTransitionDirection(previousTabId > index ? 'left' : 'right');
-      setPreviousTabId(index);
+      !disabled && setCurrentTabIndex(index);
     },
     {
       eventName: 'tabClick',
@@ -46,7 +29,9 @@ const BarItem = ({
       onClick={handleTabClick}
       css={css`
         border: none;
-        border-bottom: var(--border-color) solid 1px;
+        border-top: var(--primary-background-color) solid 2px;
+        border-bottom: var(--border-color) solid 2px;
+
         background: none;
         color: var(--primary-text-color);
         flex-grow: 1;
@@ -61,31 +46,33 @@ const BarItem = ({
         }
 
         &.isSelected {
-          border: var(--brand-button-primary-accent) solid 1px;
-          border-bottom: none;
           border-top-left-radius: 4px;
           border-top-right-radius: 4px;
 
+          border: #1dcad3 solid 2px;
+          border-bottom: var(--primary-background-color) solid 2px;
+
           .dark-mode & {
-            border-top: var(--brand-button-primary-accent-hover) solid 1px;
+            border: #1dcad3 solid 2px;
+            border-bottom: var(--primary-background-color) solid 2px;
           }
         }
 
         ${stacked &&
         css`
           border-bottom: none;
-          border-left: var(--divider-color) solid 1px;
+          border-left: var(--divider-color) solid 2px;
           white-space: normal;
           text-align: left;
 
           &.isSelected {
             color: var(--primary-text-color);
             border-bottom: none;
-            border-left: var(--brand-button-primary-accent) solid 1px;
+            border-left: var(--brand-button-primary-accent) solid 2px;
 
             .dark-mode & {
               border-bottom: none;
-              border-left: var(--brand-button-primary-accent-hover) solid 1px;
+              border-left: var(--brand-button-primary-accent-hover) solid 2px;
             }
           }
         `}
@@ -106,7 +93,6 @@ BarItem.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
-  onClick: PropTypes.func,
 };
 
 export default BarItem;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -13,7 +13,14 @@ const BarItem = ({
   disabled,
   onClick: onTabClick,
 }) => {
-  const { currentTab, setCurrentTab, stacked } = useTabs();
+  const {
+    currentTab,
+    previousTabId,
+    setCurrentTab,
+    setPreviousTabId,
+    setTransitionDirection,
+    stacked,
+  } = useTabs();
   const isSelected =
     id === currentTab || (currentTab === undefined && index === 0);
 
@@ -21,6 +28,8 @@ const BarItem = ({
     () => {
       !disabled && setCurrentTab(id);
       onTabClick && onTabClick(id);
+      setTransitionDirection(previousTabId > index ? 'left' : 'right');
+      setPreviousTabId(index);
     },
     {
       eventName: 'tabClick',
@@ -37,9 +46,9 @@ const BarItem = ({
       onClick={handleTabClick}
       css={css`
         border: none;
-        border-bottom: var(--divider-color) solid 3px;
+        border-bottom: var(--border-color) solid 1px;
         background: none;
-        color: var(--muted-text);
+        color: var(--primary-text-color);
         flex-grow: 1;
         text-align: center;
         padding: 0.5em;
@@ -52,29 +61,31 @@ const BarItem = ({
         }
 
         &.isSelected {
-          color: var(--primary-text-color);
-          border-bottom: var(--brand-button-primary-accent) solid 3px;
+          border: var(--brand-button-primary-accent) solid 1px;
+          border-bottom: none;
+          border-top-left-radius: 4px;
+          border-top-right-radius: 4px;
 
           .dark-mode & {
-            border-bottom: var(--brand-button-primary-accent-hover) solid 3px;
+            border-top: var(--brand-button-primary-accent-hover) solid 1px;
           }
         }
 
         ${stacked &&
         css`
           border-bottom: none;
-          border-left: var(--divider-color) solid 3px;
+          border-left: var(--divider-color) solid 1px;
           white-space: normal;
           text-align: left;
 
           &.isSelected {
             color: var(--primary-text-color);
             border-bottom: none;
-            border-left: var(--brand-button-primary-accent) solid 3px;
+            border-left: var(--brand-button-primary-accent) solid 1px;
 
             .dark-mode & {
               border-bottom: none;
-              border-left: var(--brand-button-primary-accent-hover) solid 3px;
+              border-left: var(--brand-button-primary-accent-hover) solid 1px;
             }
           }
         `}

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -30,7 +30,10 @@ const BarItem = ({ className, index, children, id, disabled }) => {
       css={css`
         border: none;
         border-top: var(--primary-background-color) solid 2px;
-        border-bottom: var(--border-color) solid 2px;
+        border-bottom: #1dcad3 solid 2px;
+
+        transition: 0.5s ease-in;
+        transition-property: background;
 
         background: none;
         color: var(--primary-text-color);
@@ -48,13 +51,13 @@ const BarItem = ({ className, index, children, id, disabled }) => {
         &.isSelected {
           border-top-left-radius: 4px;
           border-top-right-radius: 4px;
+          background: var(--secondary-background-color);
 
           border: #1dcad3 solid 2px;
-          border-bottom: var(--primary-background-color) solid 2px;
+          border-bottom: var(--secondary-background-color) solid 2px;
 
           .dark-mode & {
-            border: #1dcad3 solid 2px;
-            border-bottom: var(--primary-background-color) solid 2px;
+            border-bottom: var(--secondary-background-color) solid 2px;
           }
         }
 

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -1,17 +1,13 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
 import useTabs from './useTabs';
 
 const Page = ({ index, children, id, className }) => {
-  const {
-    currentTabIndex,
-    transitionDirection,
-    previousTabIndex,
-    updateHeight,
-    stacked,
-  } = useTabs();
+  const { currentTabIndex, transitionDirection, updateHeight, stacked } =
+    useTabs();
+  const tabpanel = useRef(null);
 
   const page = useCallback(
     (div) => {
@@ -25,17 +21,29 @@ const Page = ({ index, children, id, className }) => {
   const isSelected =
     index === currentTabIndex || (currentTabIndex === undefined && index === 0);
 
-  console.log('🔮🔮🔮🔮', transitionDirection, previousTabIndex, index);
+  useEffect(() => {
+    if (tabpanel.current == null) return;
+    if (isSelected) {
+      console.log(tabpanel.current);
+      const amount = transitionDirection === 'left' ? '100%' : '-100%';
+      tabpanel.current.style.transform = `translateX(${amount})`;
+      requestAnimationFrame(() => {
+        tabpanel.current.style.transform = 'translateX(0%)';
+      });
+    } else {
+      const amount = transitionDirection === 'left' ? '-100%' : '100%';
+      tabpanel.current.style.transform = `translateX(${amount})`;
+    }
+  }, [isSelected]);
 
   return (
     <div
       role="tabpanel"
       aria-labelledby={id}
+      ref={tabpanel}
       css={css`
         opacity: 1;
         background: var(--secondary-background-color);
-
-        transform: translateX(0);
 
         transition: 0.75s ease-in;
         transition-property: visibility, transform, opacity;
@@ -57,20 +65,11 @@ const Page = ({ index, children, id, className }) => {
           visibility: hidden;
           position: absolute;
           opacity: 0;
-
-          ${transitionDirection === 'left'
-            ? css`
-                transform: translateX(100%);
-              `
-            : css`
-                transform: translateX(-100%);
-              `}
         `}
       `}
       className={className}
-      ref={page}
     >
-      {children}
+      <div ref={page}>{children}</div>
     </div>
   );
 };

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -57,7 +57,7 @@ const Page = ({ index, children, id, className }) => {
         });
       });
     }
-  }, [isSelected, hasMounted]);
+  }, [isSelected, hasMounted, prefersReducedMotion, transitionDirection]);
 
   return (
     <div

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
+import useMedia from 'use-media';
 
 import useTabs from './useTabs';
 import useHasMounted from '../../hooks/useHasMounted';
@@ -8,6 +9,7 @@ import useHasMounted from '../../hooks/useHasMounted';
 const Page = ({ index, children, id, className }) => {
   const { currentTabIndex, transitionDirection, updateHeight, stacked } =
     useTabs();
+  const prefersReducedMotion = useMedia({ prefersReducedMotion: 'reduce' });
   const tabpanel = useRef(null);
 
   const hasMounted = useHasMounted();
@@ -25,7 +27,7 @@ const Page = ({ index, children, id, className }) => {
     index === currentTabIndex || (currentTabIndex === undefined && index === 0);
 
   useEffect(() => {
-    if (tabpanel.current == null || !hasMounted) return;
+    if (tabpanel.current == null || !hasMounted || prefersReducedMotion) return;
     if (isSelected) {
       console.log(tabpanel.current);
       const amount = transitionDirection === 'left' ? '100%' : '-100%';

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -27,7 +27,13 @@ const Page = ({ index, children, id, className }) => {
     index === currentTabIndex || (currentTabIndex === undefined && index === 0);
 
   useEffect(() => {
-    if (tabpanel.current == null || !hasMounted || prefersReducedMotion) return;
+    if (
+      tabpanel.current == null ||
+      !hasMounted ||
+      prefersReducedMotion ||
+      transitionDirection === 'none'
+    )
+      return;
     if (isSelected) {
       const amount = transitionDirection === 'left' ? '100%' : '-100%';
       tabpanel.current.style.transitionProperty = `none`;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -29,17 +29,27 @@ const Page = ({ index, children, id, className }) => {
   useEffect(() => {
     if (tabpanel.current == null || !hasMounted || prefersReducedMotion) return;
     if (isSelected) {
-      console.log(tabpanel.current);
       const amount = transitionDirection === 'left' ? '100%' : '-100%';
-      tabpanel.current.style.transform = `translateX(${amount})`;
       tabpanel.current.style.transitionProperty = `none`;
+      tabpanel.current.style.transform = `translateX(${amount})`;
+      // one `rAF` here doesn't properly wait for the initial transform
+      // to be applied before adding the end state.
+      // https://stackoverflow.com/questions/44145740
       requestAnimationFrame(() => {
-        tabpanel.current.style.transform = 'translateX(0%)';
-        tabpanel.current.style.transitionProperty = `visibility, transform, opacity`;
+        requestAnimationFrame(() => {
+          tabpanel.current.style.transitionProperty = `visibility, transform, opacity`;
+          tabpanel.current.style.transform = 'translateX(0%)';
+        });
       });
     } else {
-      const amount = transitionDirection === 'left' ? '-100%' : '100%';
-      tabpanel.current.style.transform = `translateX(${amount})`;
+      // these `rAF`s are so the animation for the exiting tab is synced
+      // with the animation for the entering tab.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const amount = transitionDirection === 'left' ? '-100%' : '100%';
+          tabpanel.current.style.transform = `translateX(${amount})`;
+        });
+      });
     }
   }, [isSelected, hasMounted]);
 

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 
 import useTabs from './useTabs';
+import useHasMounted from '../../hooks/useHasMounted';
 
 const Page = ({ index, children, id, className }) => {
   const { currentTabIndex, transitionDirection, updateHeight, stacked } =
     useTabs();
   const tabpanel = useRef(null);
+
+  const hasMounted = useHasMounted();
 
   const page = useCallback(
     (div) => {
@@ -22,19 +25,21 @@ const Page = ({ index, children, id, className }) => {
     index === currentTabIndex || (currentTabIndex === undefined && index === 0);
 
   useEffect(() => {
-    if (tabpanel.current == null) return;
+    if (tabpanel.current == null || !hasMounted) return;
     if (isSelected) {
       console.log(tabpanel.current);
       const amount = transitionDirection === 'left' ? '100%' : '-100%';
       tabpanel.current.style.transform = `translateX(${amount})`;
+      tabpanel.current.style.transition = `none`;
       requestAnimationFrame(() => {
         tabpanel.current.style.transform = 'translateX(0%)';
+        tabpanel.current.style.transition = `0.75s ease-in`;
       });
     } else {
       const amount = transitionDirection === 'left' ? '-100%' : '100%';
       tabpanel.current.style.transform = `translateX(${amount})`;
     }
-  }, [isSelected]);
+  }, [isSelected, hasMounted]);
 
   return (
     <div

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -6,9 +6,9 @@ import useTabs from './useTabs';
 
 const Page = ({ index, children, id, className }) => {
   const {
-    currentTab,
+    currentTabIndex,
     transitionDirection,
-    previousTabId,
+    previousTabIndex,
     updateHeight,
     stacked,
   } = useTabs();
@@ -23,9 +23,9 @@ const Page = ({ index, children, id, className }) => {
   );
 
   const isSelected =
-    id === currentTab || (currentTab === undefined && index === 0);
+    index === currentTabIndex || (currentTabIndex === undefined && index === 0);
 
-  console.log('🔮🔮🔮🔮', transitionDirection, previousTabId, index);
+  console.log('🔮🔮🔮🔮', transitionDirection, previousTabIndex, index);
 
   return (
     <div

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -30,10 +30,10 @@ const Page = ({ index, children, id, className }) => {
       console.log(tabpanel.current);
       const amount = transitionDirection === 'left' ? '100%' : '-100%';
       tabpanel.current.style.transform = `translateX(${amount})`;
-      tabpanel.current.style.transition = `none`;
+      tabpanel.current.style.transitionProperty = `none`;
       requestAnimationFrame(() => {
         tabpanel.current.style.transform = 'translateX(0%)';
-        tabpanel.current.style.transition = `0.75s ease-in`;
+        tabpanel.current.style.transitionProperty = `visibility, transform, opacity`;
       });
     } else {
       const amount = transitionDirection === 'left' ? '-100%' : '100%';
@@ -49,28 +49,35 @@ const Page = ({ index, children, id, className }) => {
       css={css`
         opacity: 1;
         background: var(--secondary-background-color);
+        top: 1em;
+        left: 0.5em;
 
-        transition: 0.75s ease-in;
+        transition-duration: 750ms;
+        transition-timing-function: ease-in
         transition-property: visibility, transform, opacity;
 
-        ${stacked &&
-        css`
-          height: 100%;
-          max-height: 500px;
-          width: 100%;
-          overflow-y: scroll;
-          -ms-overflow-style: none; /* for Internet Explorer, Edge */
-          scrollbar-width: none; /* for Firefox */
-          &::-webkit-scrollbar {
-            display: none; /* for Chrome, Safari, and Opera */
-          }
-        `}
-        ${!isSelected &&
-        css`
-          visibility: hidden;
-          position: absolute;
-          opacity: 0;
-        `}
+        ${
+          stacked &&
+          css`
+            height: 100%;
+            max-height: 500px;
+            width: 100%;
+            overflow-y: scroll;
+            -ms-overflow-style: none; /* for Internet Explorer, Edge */
+            scrollbar-width: none; /* for Firefox */
+            &::-webkit-scrollbar {
+              display: none; /* for Chrome, Safari, and Opera */
+            }
+          `
+        }
+        ${
+          !isSelected &&
+          css`
+            visibility: hidden;
+            position: absolute;
+            opacity: 0;
+          `
+        }
       `}
       className={className}
     >

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -33,15 +33,12 @@ const Page = ({ index, children, id, className }) => {
       aria-labelledby={id}
       css={css`
         opacity: 1;
-        background: var(--primary-background-color);
+        background: var(--secondary-background-color);
 
         transform: translateX(0);
 
-        -webkit-transition: all 0.9s ease-in-out;
-        -moz-transition: all 0.9s ease-in-out;
-        -ms-transition: all 0.9s ease-in-out;
-        -o-transition: all 0.9s ease-in-out;
-        transition: all 0.9s ease-in-out;
+        transition: 0.75s ease-in;
+        transition-property: visibility, transform, opacity;
 
         ${stacked &&
         css`
@@ -64,11 +61,9 @@ const Page = ({ index, children, id, className }) => {
           ${transitionDirection === 'left'
             ? css`
                 transform: translateX(100%);
-                border: blue dotted 4px;
               `
             : css`
                 transform: translateX(-100%);
-                border: red dotted 4px;
               `}
         `}
       `}

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -62,34 +62,37 @@ const Page = ({ index, children, id, className }) => {
         opacity: 1;
         background: var(--secondary-background-color);
         top: 1em;
-        left: 0.5em;
+        left: 1em;
 
-        transition-duration: 750ms;
-        transition-timing-function: ease-in
+        transition-delay: 0ms, 0ms, 170ms;
+        transition-duration: 620ms, 620ms, 340ms;
+        transition-timing-function: cubic-bezier(0.55, 0, 0.45, 1);
         transition-property: visibility, transform, opacity;
 
-        ${
-          stacked &&
-          css`
-            height: 100%;
-            max-height: 500px;
-            width: 100%;
-            overflow-y: scroll;
-            -ms-overflow-style: none; /* for Internet Explorer, Edge */
-            scrollbar-width: none; /* for Firefox */
-            &::-webkit-scrollbar {
-              display: none; /* for Chrome, Safari, and Opera */
-            }
-          `
-        }
-        ${
-          !isSelected &&
-          css`
-            visibility: hidden;
-            position: absolute;
-            opacity: 0;
-          `
-        }
+        ${stacked &&
+        css`
+          height: 100%;
+          max-height: 500px;
+          width: 100%;
+          overflow-y: scroll;
+          -ms-overflow-style: none; /* for Internet Explorer, Edge */
+          scrollbar-width: none; /* for Firefox */
+          &::-webkit-scrollbar {
+            display: none; /* for Chrome, Safari, and Opera */
+          }
+        `}
+        ${!isSelected &&
+        css`
+          transition-delay: 0ms;
+          visibility: hidden;
+          position: absolute;
+          opacity: 0;
+
+          & * {
+            /* this hides scrollbar pop-ins on exiting tabs */
+            overflow: hidden !important;
+          }
+        `}
       `}
       className={className}
     >

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Page.js
@@ -5,7 +5,13 @@ import { css } from '@emotion/react';
 import useTabs from './useTabs';
 
 const Page = ({ index, children, id, className }) => {
-  const { currentTab, updateHeight, stacked } = useTabs();
+  const {
+    currentTab,
+    transitionDirection,
+    previousTabId,
+    updateHeight,
+    stacked,
+  } = useTabs();
 
   const page = useCallback(
     (div) => {
@@ -19,17 +25,30 @@ const Page = ({ index, children, id, className }) => {
   const isSelected =
     id === currentTab || (currentTab === undefined && index === 0);
 
+  console.log('🔮🔮🔮🔮', transitionDirection, previousTabId, index);
+
   return (
     <div
       role="tabpanel"
       aria-labelledby={id}
       css={css`
+        opacity: 1;
+        background: var(--primary-background-color);
+
+        transform: translateX(0);
+
+        -webkit-transition: all 0.9s ease-in-out;
+        -moz-transition: all 0.9s ease-in-out;
+        -ms-transition: all 0.9s ease-in-out;
+        -o-transition: all 0.9s ease-in-out;
+        transition: all 0.9s ease-in-out;
+
         ${stacked &&
         css`
           height: 100%;
           max-height: 500px;
-          overflow-y: scroll;
           width: 100%;
+          overflow-y: scroll;
           -ms-overflow-style: none; /* for Internet Explorer, Edge */
           scrollbar-width: none; /* for Firefox */
           &::-webkit-scrollbar {
@@ -38,8 +57,19 @@ const Page = ({ index, children, id, className }) => {
         `}
         ${!isSelected &&
         css`
-          position: absolute;
           visibility: hidden;
+          position: absolute;
+          opacity: 0;
+
+          ${transitionDirection === 'left'
+            ? css`
+                transform: translateX(100%);
+                border: blue dotted 4px;
+              `
+            : css`
+                transform: translateX(-100%);
+                border: red dotted 4px;
+              `}
         `}
       `}
       className={className}

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
@@ -12,11 +12,12 @@ const Pages = ({ children }) => {
       css={css`
         padding: 1em 0.5em;
         margin-bottom: 1em;
-        border: 1px var(--border-color) solid;
+        border: var(--border-color) solid 2px;
         border-top: none;
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;
-        overflow-y: hidden;
+        overflow: hidden;
+        position: relative;
 
         ${stacked &&
         css`

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
@@ -9,8 +9,16 @@ const Pages = ({ children }) => {
 
   return (
     <div
-      css={
-        stacked &&
+      css={css`
+        padding: 1em 0.5em;
+        margin-bottom: 1em;
+        border: 1px var(--border-color) solid;
+        border-top: none;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        overflow-y: hidden;
+
+        ${stacked &&
         css`
           align-items: start;
           display: flex;
@@ -20,8 +28,8 @@ const Pages = ({ children }) => {
           @media screen and (max-width: ${mobileBreakPoint}) {
             width: 100%;
           }
-        `
-      }
+        `}
+      `}
     >
       {React.Children.map(children, (child, index) =>
         React.cloneElement(child, { ...child.props, index })

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
@@ -12,7 +12,8 @@ const Pages = ({ children }) => {
       css={css`
         padding: 1em 0.5em;
         margin-bottom: 1em;
-        border: var(--border-color) solid 2px;
+        background: var(--secondary-background-color);
+        border: #1dcad3 solid 2px;
         border-top: none;
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import useTabs from './useTabs';
 
 const Pages = ({ children }) => {
-  const { containerHeight, stacked, mobileBreakPoint } = useTabs();
+  const { containerHeight, stacked, mobileBreakpoint } = useTabs();
 
   return (
     <div
@@ -20,6 +20,10 @@ const Pages = ({ children }) => {
         overflow: hidden;
         position: relative;
 
+        @media screen and (max-width: ${mobileBreakpoint}) {
+          border-top: #afe2e3 solid 1px;
+        }
+
         ${stacked &&
         css`
           align-items: start;
@@ -27,7 +31,7 @@ const Pages = ({ children }) => {
           height: ${containerHeight}px;
           justify-content: center;
           width: 70%;
-          @media screen and (max-width: ${mobileBreakPoint}) {
+          @media screen and (max-width: ${mobileBreakpoint}) {
             width: 100%;
           }
         `}

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Pages.js
@@ -10,10 +10,10 @@ const Pages = ({ children }) => {
   return (
     <div
       css={css`
-        padding: 1em 0.5em;
+        padding: 1em;
         margin-bottom: 1em;
         background: var(--secondary-background-color);
-        border: #1dcad3 solid 2px;
+        border: #afe2e3 solid 1px;
         border-top: none;
         border-bottom-left-radius: 4px;
         border-bottom-right-radius: 4px;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -11,6 +11,8 @@ import Page from './Page';
 
 const Tabs = ({ children, initialTab, stacked }) => {
   const [currentTab, setCurrentTab] = useState(initialTab);
+  const [previousTabId, setPreviousTabId] = useState();
+  const [transitionDirection, setTransitionDirection] = useState('hi');
   const [containerHeight, setContainerHeight] = useState(0);
 
   const updateHeight = (pageHeight) => {
@@ -37,8 +39,12 @@ const Tabs = ({ children, initialTab, stacked }) => {
   const context = {
     containerHeight,
     currentTab,
+    previousTabId,
+    transitionDirection,
     mobileBreakpoint,
     setCurrentTab,
+    setPreviousTabId,
+    setTransitionDirection,
     stacked,
     updateHeight,
   };
@@ -47,6 +53,8 @@ const Tabs = ({ children, initialTab, stacked }) => {
     <TabsContext.Provider value={context}>
       <div
         css={css`
+          overflow-x: hidden;
+          overflow-y: hidden;
           ${stacked &&
           css`
             display: flex;

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -11,9 +11,12 @@ import Page from './Page';
 
 const Tabs = ({ children, initialTab, stacked }) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(initialTab);
-  const [previousTabIndex, setPreviousTabIndex] = useState();
-  const transitionDirection =
-    previousTabIndex > currentTabIndex ? 'right' : 'left';
+  const [previousTabIndex, setPreviousTabIndex] = useState(initialTab);
+  let transitionDirection = 'none';
+
+  if (previousTabIndex !== currentTabIndex) {
+    transitionDirection = previousTabIndex > currentTabIndex ? 'right' : 'left';
+  }
   const [containerHeight, setContainerHeight] = useState(0);
 
   const setTab = (tab) => {

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -10,10 +10,16 @@ import Pages from './Pages';
 import Page from './Page';
 
 const Tabs = ({ children, initialTab, stacked }) => {
-  const [currentTab, setCurrentTab] = useState(initialTab);
-  const [previousTabId, setPreviousTabId] = useState();
-  const [transitionDirection, setTransitionDirection] = useState('hi');
+  const [currentTabIndex, setCurrentTabIndex] = useState(initialTab);
+  const [previousTabIndex, setPreviousTabIndex] = useState();
+  const transitionDirection =
+    previousTabIndex > currentTabIndex ? 'right' : 'left';
   const [containerHeight, setContainerHeight] = useState(0);
+
+  const setTab = (tab) => {
+    setPreviousTabIndex(currentTabIndex);
+    setCurrentTabIndex(tab);
+  };
 
   const updateHeight = (pageHeight) => {
     if (pageHeight > containerHeight) {
@@ -38,13 +44,12 @@ const Tabs = ({ children, initialTab, stacked }) => {
 
   const context = {
     containerHeight,
-    currentTab,
-    previousTabId,
+    currentTabIndex,
+    previousTabIndex,
     transitionDirection,
     mobileBreakpoint,
-    setCurrentTab,
-    setPreviousTabId,
-    setTransitionDirection,
+    setCurrentTabIndex: setTab,
+    setPreviousTabIndex,
     stacked,
     updateHeight,
   };
@@ -53,8 +58,6 @@ const Tabs = ({ children, initialTab, stacked }) => {
     <TabsContext.Provider value={context}>
       <div
         css={css`
-          overflow-x: hidden;
-          overflow-y: hidden;
           ${stacked &&
           css`
             display: flex;


### PR DESCRIPTION
this PR adds transition animations to the Tabs component and improves their styling. it also updates `useTabs` to use the index for the currently selected tab instead of the id to make some of the logic easier

## video

[tabs animations.webm](https://github.com/newrelic/gatsby-theme-newrelic/assets/14365008/83897e9b-0ef7-4db1-b0dc-e3bbb26ac17f)

## testing

- go to demo page
- click tabs
- animations should **_NEVER_** criss-cross (the exiting panel goes one way and the entering panel comes in from another)
- to test the reduced motion version, Firefox is easiest because you can change the setting in `about:config`. to test in Chrome, you need to change the OS setting for it
  - in Firefox's `about:config` change the `ui.prefersReducedMotion` field to `1` and refresh the page
  - for Chrome, open Mac's Settings > Accessibility > Reduce motion