### PR TITLE
Add codeblock contents to tessen tracking

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -87,15 +87,14 @@ const CodeBlock = ({
     code: formattedCode,
     modified: false,
   });
+  const copiedCode = containsEmbeddedHTML ? normalizedCode : code;
 
-  const handleCopyClick = useInstrumentedHandler(
-    () => copy(containsEmbeddedHTML ? normalizedCode : code),
-    {
-      eventName: 'copyCodeBlockClick',
-      category: 'CodeBlock',
-      modified,
-    }
-  );
+  const handleCopyClick = useInstrumentedHandler(() => copy(copiedCode), {
+    eventName: 'copyCodeBlockClick',
+    category: 'CodeBlock',
+    modified,
+    contents: copiedCode.replace(/[\r\n]+/gm, '').substring(0, 200),
+  });
 
   const handleDownloadClick = useInstrumentedHandler(
     () => {


### PR DESCRIPTION
Adds some of the code block content to the tessen event to help identify which codeblock is being copied
<img width="543" alt="Screenshot 2023-12-19 at 3 16 30 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/39655074/7eb30f9a-8f14-4e26-9000-c8be6ba0aa43">
