### PR TITLE
feat: save selected tab in URL hash

### DIFF
--- a/demo/src/pages/index.js
+++ b/demo/src/pages/index.js
@@ -165,15 +165,15 @@ const IndexPage = () => {
           <section>
             <Tabs>
               <Tabs.Bar>
-                <Tabs.BarItem id="text">Lotsa text</Tabs.BarItem>
-                <Tabs.BarItem id="Codeblock">A code block</Tabs.BarItem>
-                <Tabs.BarItem id="Live-edit">
+                <Tabs.BarItem id="lotsa-text">Lotsa text</Tabs.BarItem>
+                <Tabs.BarItem id="first-codeblock">A code block</Tabs.BarItem>
+                <Tabs.BarItem id="first-live-edit">
                   A live editable code block w/ preview
                 </Tabs.BarItem>
-                <Tabs.BarItem id="embedded">var/mark/links</Tabs.BarItem>
+                <Tabs.BarItem id="first-embedded">var/mark/links</Tabs.BarItem>
               </Tabs.Bar>
               <Tabs.Pages>
-                <Tabs.Page id="text">
+                <Tabs.Page id="lotsa-text">
                   <h2>Lorem ipsum dolor sit amet.</h2>
                   <p>
                     Consectetur adipiscing elit, sed do eiusmod tempor
@@ -235,7 +235,7 @@ const IndexPage = () => {
                   </p>
                 </Tabs.Page>
 
-                <Tabs.Page id="codeblock">
+                <Tabs.Page id="first-codeblock">
                   <CodeBlock
                     copyable
                     lineNumbers
@@ -249,7 +249,7 @@ const IndexPage = () => {
                     {codeSample}
                   </CodeBlock>
                 </Tabs.Page>
-                <Tabs.Page id="live-edit">
+                <Tabs.Page id="first-live-edit">
                   <CodeBlock
                     copyable
                     lineNumbers
@@ -265,7 +265,7 @@ const IndexPage = () => {
                     {liveCodeSample}
                   </CodeBlock>
                 </Tabs.Page>
-                <Tabs.Page id="embedded">
+                <Tabs.Page id="first-embedded">
                   <CodeBlock
                     language="graphql"
                     css={css`

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Bar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
+import { navigate } from '@reach/router';
 import useTabs from './useTabs';
 import Select from '../Select';
 
@@ -47,17 +48,18 @@ const MobileTabControl = ({ children, className }) => {
           (child) => child.props.id === selectedId
         );
         setCurrentTabIndex(index);
+        navigate(`#${selectedId}`);
       }}
       css={css`
         margin-bottom: 1rem;
       `}
       className={className}
     >
-      {React.Children.map(children, ({ props }) => (
+      {React.Children.map(children, ({ props }, index) => (
         <option
           key={props.id}
           value={props.id}
-          selected={props.index === currentTabIndex}
+          selected={index === currentTabIndex}
           disabled={props.disabled}
         >
           {getDeepestChild(props.children)}

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/BarItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { css } from '@emotion/react';
+import { navigate } from '@reach/router';
 import useTabs from './useTabs';
 import useInstrumentedHandler from '../../hooks/useInstrumentedHandler';
 
@@ -13,6 +14,7 @@ const BarItem = ({ className, index, children, id, disabled }) => {
   const handleTabClick = useInstrumentedHandler(
     () => {
       !disabled && setCurrentTabIndex(index);
+      navigate(`#${id}`);
     },
     {
       eventName: 'tabClick',

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -58,6 +58,13 @@ const Tabs = ({ children, initialTab }) => {
         const index = pages.findIndex((page) => page.props.id === hash);
         if (index !== -1) {
           setTab(index);
+          const y =
+            tabsContainer.current.getBoundingClientRect().top +
+            window.pageYOffset +
+            // header height
+            72;
+
+          window.scrollTo({ top: y, behavior: 'smooth' });
           tabsContainer.current.scrollIntoView();
         }
       }

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -9,7 +9,7 @@ import BarItem from './BarItem';
 import Pages from './Pages';
 import Page from './Page';
 
-const Tabs = ({ children, initialTab }) => {
+const Tabs = ({ children, initialTab = 0 }) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(initialTab);
   const [previousTabIndex, setPreviousTabIndex] = useState(initialTab);
   const tabsContainer = useRef(null);

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
+import { useLocation } from '@reach/router';
 
 import TabsContext from '../Context';
 import Bar from './Bar';
@@ -29,6 +30,37 @@ const Tabs = ({ children, initialTab }) => {
       setContainerHeight(maxHeight);
     }
   };
+
+  const location = useLocation();
+
+  // this needs to run in a useEffect since the hash
+  // isn't available on the server during SSG.
+  // to put it another way, in order to have this work with SSG
+  // we'd hypothetically need to render a separate HTML file
+  // for every single tab id on the page.
+  // i don't think we can do this with Gatsby.
+  useEffect(() => {
+    const hash = location.hash.replace('#', '');
+    if (hash !== '') {
+      const [_tabBar, tabPages] = children;
+      // Tabs should always look like this:
+      // ```
+      // <Tabs>
+      //   <Tabs.Bar>...</Tabs.Bar>
+      //   <Tabs.Pages>...</Tabs.Pages>
+      // </Tabs>
+      // ```
+      // if not, something is wrong and we'll only break the page
+      // by trying further.
+      if (tabPages.type === Pages) {
+        const pages = tabPages.props.children;
+        const index = pages.findIndex((page) => page.props.id === hash);
+        if (index !== -1) {
+          setTab(index);
+        }
+      }
+    }
+  }, []);
 
   const {
     site: {

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -57,7 +57,11 @@ const Tabs = ({ children, initialTab }) => {
         const pages = tabPages.props.children;
         const index = pages.findIndex((page) => page.props.id === hash);
         if (index !== -1) {
-          setTab(index);
+          // this is so the animation doesn't play on page load
+          // if the first tab is selected.
+          if (index !== 0) {
+            setTab(index);
+          }
           const y =
             tabsContainer.current.getBoundingClientRect().top +
             window.scrollY -

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
 import { useLocation } from '@reach/router';
@@ -12,6 +12,7 @@ import Page from './Page';
 const Tabs = ({ children, initialTab }) => {
   const [currentTabIndex, setCurrentTabIndex] = useState(initialTab);
   const [previousTabIndex, setPreviousTabIndex] = useState(initialTab);
+  const tabsContainer = useRef(null);
   let transitionDirection = 'none';
 
   if (previousTabIndex !== currentTabIndex) {
@@ -57,6 +58,7 @@ const Tabs = ({ children, initialTab }) => {
         const index = pages.findIndex((page) => page.props.id === hash);
         if (index !== -1) {
           setTab(index);
+          tabsContainer.current.scrollIntoView();
         }
       }
     }
@@ -89,7 +91,7 @@ const Tabs = ({ children, initialTab }) => {
 
   return (
     <TabsContext.Provider value={context}>
-      <div>{children}</div>
+      <div ref={tabsContainer}>{children}</div>
     </TabsContext.Provider>
   );
 };

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -60,12 +60,11 @@ const Tabs = ({ children, initialTab }) => {
           setTab(index);
           const y =
             tabsContainer.current.getBoundingClientRect().top +
-            window.pageYOffset +
+            window.scrollY -
             // header height
             72;
 
           window.scrollTo({ top: y, behavior: 'smooth' });
-          tabsContainer.current.scrollIntoView();
         }
       }
     }


### PR DESCRIPTION
when selecting a tab, the URL will update with the tab id. going to a URL with a hash will automatically select that tab

## testing

- go to theme demo
- try clicking different tabs
- ensure the URL updates with the tab id
- reload the page or copy-paste the URL to a different tab
- make sure the page switches to that tab on load