### PR TITLE
Fix copied link for collapser headers

### DIFF
--- a/demo/src/content/build-apps/build-hello-world-app.mdx
+++ b/demo/src/content/build-apps/build-hello-world-app.mdx
@@ -11,6 +11,10 @@ resources:
 
 Here's how you can quickly build a "Hello, World!" application in New Relic One. In these steps, you create a local version of the New Relic One site where you can prototype your application. Then, when you're ready to share the application with others, you can publish it to New Relic One.
 
+<Collapser id="example-1" title="Check out this cool collapser">
+  This is a pretty neat little utility. I can show all kinds of stuff in here.
+</Collapser>
+
 See the video, which demonstrates the steps in this guide in five minutes.
 
 <Video id="7omo0qHxku8" type="youtube" />

--- a/packages/gatsby-theme-newrelic/src/components/Collapser.js
+++ b/packages/gatsby-theme-newrelic/src/components/Collapser.js
@@ -144,7 +144,7 @@ const Collapser = ({ title, id, defaultOpen, children }) => {
                   color: inherit !important;
                 `}
                 onClick={() => {
-                  copy(`${location.origin}#${id}`);
+                  copy(`${location.origin}${location.pathname}#${id}`);
                 }}
               />
               {copied && <CopiedMessage>Copied!</CopiedMessage>}


### PR DESCRIPTION
The collapser header button was only copying the site url and the header hash (not the pathname), this adds the pathname when building the url to be copied

You can test this in the demo by going to the mdx page at `/build-apps/build-hello-world-app/` and clicking the collapser anchor link in the beginning of the doc