### PR TITLE
fix: update Tabs when clicking link on same page

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -72,7 +72,7 @@ const Tabs = ({ children, initialTab = 0 }) => {
         }
       }
     }
-  }, []);
+  }, [location.hash]);
 
   const {
     site: {


### PR DESCRIPTION
the `useEffect` in Tabs.js was only running on page load, so linking to a tab on the same page wouldn't update the Tabs. rerunning the effect when `location.hash` changes fixes this