### PR TITLE
fix: tabs not linking on MDX pages

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
+++ b/packages/gatsby-theme-newrelic/src/components/CodeBlock.js
@@ -219,7 +219,8 @@ const CodeBlock = ({
             </div>
           )}
           <div
-            id={containerId ?? 'codeblock'}
+            className="codeblock"
+            id={containerId}
             css={css`
               max-height: 26em;
               overflow: auto;

--- a/packages/gatsby-theme-newrelic/src/components/InteractiveForm.js
+++ b/packages/gatsby-theme-newrelic/src/components/InteractiveForm.js
@@ -39,7 +39,7 @@ const InteractiveForm = ({ children, inputs, config, containerId }) => {
             width: 100%;
           }
 
-          #codeblock {
+          .codeblock {
             // removing the height of the buttons at the top or it overflows
             max-height: calc(100% - 50px);
           }

--- a/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
+++ b/packages/gatsby-theme-newrelic/src/components/Tabs/Tabs.js
@@ -51,25 +51,21 @@ const Tabs = ({ children, initialTab = 0 }) => {
       //   <Tabs.Pages>...</Tabs.Pages>
       // </Tabs>
       // ```
-      // if not, something is wrong and we'll only break the page
-      // by trying further.
-      if (tabPages.type === Pages) {
-        const pages = tabPages.props.children;
-        const index = pages.findIndex((page) => page.props.id === hash);
-        if (index !== -1) {
-          // this is so the animation doesn't play on page load
-          // if the first tab is selected.
-          if (index !== 0) {
-            setTab(index);
-          }
-          const y =
-            tabsContainer.current.getBoundingClientRect().top +
-            window.scrollY -
-            // header height
-            72;
-
-          window.scrollTo({ top: y, behavior: 'smooth' });
+      const pages = tabPages.props.children;
+      const index = pages.findIndex((page) => page.props.id === hash);
+      if (index !== -1) {
+        // this is so the animation doesn't play on page load
+        // if the first tab is selected.
+        if (index !== 0) {
+          setTab(index);
         }
+        const y =
+          tabsContainer.current.getBoundingClientRect().top +
+          window.scrollY -
+          // header height
+          72;
+
+        window.scrollTo({ top: y, behavior: 'smooth' });
       }
     }
   }, [location.hash]);


### PR DESCRIPTION
this check worked fine on the index page in the demo site. but MDX pages have slightly different element types, so this check was failing, causing the linking to not work at all.
the check isn't really necessary, i was just trying to be extra safe and it ended up breaking things 🙃