### PR TITLE
Change explorers hub name

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ New Relic hosts and moderates an online forum where customers can interact with
 New Relic employees as well as other customers to get help and share best
 practices. Like all official New Relic open source projects, there's a related
 [Community topic](https://discuss.newrelic.com/t/announcing-a-new-relic-gatsby-site-theme/109814)
-in the New Relic Explorers Hub.
+in the New Relic Support Forum.
 
 ## Contributing
 

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/NoResults.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/NoResults.js
@@ -33,7 +33,7 @@ const NoResults = () => (
       `}
     >
       Try searching for different keywords or start a conversation on our{' '}
-      <Link to="https://discuss.newrelic.com/">Explorers Hub</Link>.
+      <Link to="https://discuss.newrelic.com/">Support Forum</Link>.
     </p>
   </div>
 );


### PR DESCRIPTION
Swapping `explorer's hub` to `support forum`