### PR TITLE
Add padding to walkthrough container

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Walkthrough/Walkthrough.js
+++ b/packages/gatsby-theme-newrelic/src/components/Walkthrough/Walkthrough.js
@@ -17,7 +17,7 @@ const Walkthrough = ({ className, children }) => {
 
         display: flex;
         flex-direction: column;
-        padding: 1rem 0;
+        padding: 1rem;
 
         @media screen and (max-width: 1000px) {
           grid-template-columns: 100%;


### PR DESCRIPTION
This adds a bit of padding to the walkthrough container to avoid the step numbers spilling out. Here are some screenshots of this change in a tab and standalone in a doc:


<img width="900" alt="Screenshot 2024-01-19 at 1 28 14 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/39655074/dabe9d1d-bcbc-465f-80c8-3488de8f174f">
<img width="900" alt="Screenshot 2024-01-19 at 1 28 48 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/39655074/b6de14fb-c5ec-4da1-aaab-911df532ca98">
