### PR TITLE
fix: add custom attributes to browser agent events

### DIFF
--- a/packages/gatsby-theme-newrelic/gatsby/on-route-update.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-route-update.js
@@ -22,9 +22,8 @@ const onRouteUpdate = ({ location, prevLocation }, themeOptions) => {
       locale !== getLocale({ location: prevLocation }, themeOptions)
     ) {
       window.newrelic.setCustomAttribute('locale', locale);
-
-      // third param: persist = true - maintains the attribute value through the whole session
     }
+    // third param: persist = true - maintains the attribute value through the whole session
     window.newrelic.setCustomAttribute('loggedIn', loggedIn, true);
     window.newrelic.setCustomAttribute(
       'customer_user_id',

--- a/packages/gatsby-theme-newrelic/gatsby/on-route-update.js
+++ b/packages/gatsby-theme-newrelic/gatsby/on-route-update.js
@@ -1,8 +1,18 @@
+import Cookies from 'js-cookie';
+
 import trackViaSegment from '../src/utils/page-tracking/segment';
 import getLocale from './utils/getLocale';
+import {
+  checkIfUserLoggedIn,
+  getSavedStatus as getSavedLoggedInStatus,
+} from '../src/hooks/useLoggedIn';
 
 const onRouteUpdate = ({ location, prevLocation }, themeOptions) => {
   trackViaSegment({ location, prevLocation }, themeOptions);
+  const getCookie = (key) => Cookies.get(key)?.replace(/%22/g, '') || null;
+  const loggedIn = getSavedLoggedInStatus() ?? checkIfUserLoggedIn();
+
+  const customer_user_id = getCookie('ajs_user_id');
 
   if (window.newrelic) {
     const locale = getLocale({ location }, themeOptions);
@@ -12,7 +22,15 @@ const onRouteUpdate = ({ location, prevLocation }, themeOptions) => {
       locale !== getLocale({ location: prevLocation }, themeOptions)
     ) {
       window.newrelic.setCustomAttribute('locale', locale);
+
+      // third param: persist = true - maintains the attribute value through the whole session
     }
+    window.newrelic.setCustomAttribute('loggedIn', loggedIn, true);
+    window.newrelic.setCustomAttribute(
+      'customer_user_id',
+      customer_user_id,
+      true
+    );
   }
 };
 


### PR DESCRIPTION
Add `customer_user_is` and `loggedIn` attributes to NR Browser Agent events

You can see the data being reported [here](https://staging.onenr.io/0gbRKxreOjE).
(_`loggedIn` NRQL query will always return `false` outside of `*.newrelic.com` or `localhost`_)