### PR TITLE
fix: update gatsby-plugin-newrelic config

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -47,21 +47,20 @@ module.exports = {
           sidebarWidth: '340px',
           mobileBreakpoint: '760px',
         },
+        // New Relic Gatsby Theme - Demo Site
         newrelic: {
-          configs: {
-            development: {
-              instrumentationType: 'proAndSPA',
-              accountId: '10956800',
-              trustKey: '1',
-              agentID: '35094665',
-              licenseKey: 'NRJS-649173eb1a7b28cd6ab',
-              // New Relic Gatsby Theme - Demo Site
-              applicationID: '35094665',
-              beacon: 'staging-bam.nr-data.net',
-              errorBeacon: 'staging-bam.nr-data.net',
-            },
+          config: {
+            instrumentationType: 'proAndSPA',
+            accountId: '10956800',
+            trustKey: '1',
+            agentID: '35094665',
+            licenseKey: 'NRJS-649173eb1a7b28cd6ab',
+            applicationID: '35094665',
+            beacon: 'staging-bam.nr-data.net',
+            errorBeacon: 'staging-bam.nr-data.net',
           },
         },
+
         segment: {
           segmentWriteKey: 'n9T9St8geATEFC1tmc0XH7XzEsOSVZCK',
           section: 'theme_demo',

--- a/demo/package.json
+++ b/demo/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn clean && gatsby build",
-    "develop": "GATSBY_NEWRELIC_ENV=development gatsby develop -p 8001",
+    "develop": "gatsby develop -p 8001",
     "clean": "gatsby clean",
     "lint": "eslint src/ --ext .js --ext .mjs"
   },

--- a/packages/gatsby-theme-newrelic/package.json
+++ b/packages/gatsby-theme-newrelic/package.json
@@ -7,9 +7,9 @@
     "access": "public"
   },
   "scripts": {
-    "build": "GATSBY_NEWRELIC_ENV=production gatsby build",
+    "build": "gatsby build",
     "clean": "gatsby clean",
-    "develop": "GATSBY_NEWRELIC_ENV=production gatsby develop",
+    "develop": "gatsby develop",
     "extract-i18n": "i18next",
     "lint": "eslint gatsby-*.js gatsby/ src/ --ext .js"
   },


### PR DESCRIPTION
- update config format for `gatsby-plugin-newrelic`
- remove deprecated use of `GATSBY_NEWRELIC_ENV` build variable to determine multiple environments