### PR TITLE
fix: add exclusion to external sites icon for i18n preview sites

### DIFF
--- a/demo/src/content/build-apps/this-is-a-404.mdx
+++ b/demo/src/content/build-apps/this-is-a-404.mdx
@@ -11,6 +11,16 @@ resources:
 
 # 404 page?
 
+### What is an external link?
+
+[https://newrelic.com/signup/](https://newrelic.com/signup/)
+
+[/build-apps/this-is-a-404/](/build-apps/this-is-a-404/)
+
+[https://docs-website-kr.netlify.app/kr/docs/new-relic-solutions/get-started/intro-new-relic/](https://docs-website-kr.netlify.app/kr/docs/new-relic-solutions/get-started/intro-new-relic/)
+
+[https://google.com](https://google.com)
+
 To get started, make sure you have accounts in GitHub and [New Relic](https://newrelic.com/signup/).
 
 To develop projects, you need the New Relic One CLI (command line interface).

--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -17,6 +17,16 @@ const isSignup = (to) => to.startsWith('https://newrelic.com/signup');
 const isImageLink = (className) => className === 'gatsby-resp-image-link';
 const isRelativePath = (to) => !to.startsWith('http') && to.startsWith('/');
 
+// Prevents our rewrites to our i18n Netlify sites showing external link icons
+const i18nNetlifySites = [
+  'docs-website-kr.netlify.app/kr/',
+  'docs-website-pt.netlify.app/jp/',
+  'docs-website-es.netlify.app/es/',
+  'docs-website-pt.netlify.app/pt/',
+];
+const isI18nNetlifySite = (to) =>
+  i18nNetlifySites.some((site) => to.includes(site));
+
 const Link = forwardRef(
   (
     {
@@ -85,7 +95,7 @@ const Link = forwardRef(
       );
     }
 
-    if (isExternal(to) || isEmbedPageLink) {
+    if ((isExternal(to) || isEmbedPageLink) && !isI18nNetlifySite(to)) {
       if (isRelativePath(to)) {
         to = siteUrl + to;
       }

--- a/packages/gatsby-theme-newrelic/src/components/MDX.js
+++ b/packages/gatsby-theme-newrelic/src/components/MDX.js
@@ -17,7 +17,7 @@ import SideBySide from './SideBySide';
 import Walkthrough from './Walkthrough';
 
 const defaultComponents = {
-  a: MDXLink,
+  a: (props) => <MDXLink {...props} displayExternalIcon />,
   code: MDXCodeBlock,
   pre: (props) => props.children,
   Button,


### PR DESCRIPTION
Adds an exclusion to our `isExternal()` conditional to prevent our i18n Netlify sites rendering with an external link icon.

https://deploy-preview-1012--newrelic-gatbsy-theme-demo.netlify.app/build-apps/this-is-a-404/

before
<img width="521" alt="Screenshot 2024-03-05 at 12 32 22 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/f6bf4d00-03fb-4e6d-a02e-c39c4305d8c5">

after
<img width="521" alt="Screenshot 2024-03-05 at 12 32 14 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/49bcbab2-0b64-4741-8272-a6fad24b6d12">
