### PR TITLE
fix: remove scroll from lightbox

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Lightbox.js
+++ b/packages/gatsby-theme-newrelic/src/components/Lightbox.js
@@ -108,7 +108,8 @@ const Lightbox = ({ children }) => {
                     </Button>
                     <div
                       css={css`
-                        overflow: hidden;
+                        overflow-y: scroll;
+                        overflow-x: hidden;
                       `}
                     >
                       {children}

--- a/packages/gatsby-theme-newrelic/src/components/Lightbox.js
+++ b/packages/gatsby-theme-newrelic/src/components/Lightbox.js
@@ -70,6 +70,8 @@ const Lightbox = ({ children }) => {
                     img {
                       max-height: unset;
                       max-width: unset;
+                      // removes any manually set img width from mdx when opened in lightbox
+                      width: 100%;
                     }
                   `}
                   onClick={() => setLightboxOpen(false)}
@@ -106,7 +108,7 @@ const Lightbox = ({ children }) => {
                     </Button>
                     <div
                       css={css`
-                        overflow-y: scroll;
+                        overflow: hidden;
                       `}
                     >
                       {children}


### PR DESCRIPTION
removes horizontal scroll from lightbox

Also fixes bug where width set in mdx tags in docs-website carries over to lightbox and creates unnecessary whitespace

before:
<img width="1399" alt="Screenshot 2024-03-12 at 4 52 27 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/ff15088d-df7f-4e66-b589-9b23ed54ae8f">

after:
made the window teeny tiny and the image shrinks horizontally with the page, but turns on the scroll bar for vertical shrinking
<img width="1012" alt="Screenshot 2024-03-18 at 11 10 36 AM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/53a1874a-c005-473a-8989-a17bb032e9fd">
