### PR TITLE
feat: adjust line-height and margins for shape up

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -51,7 +51,7 @@ const GlobalStyles = ({ layout }) => (
       p {
         margin-top: 0;
         margin-bottom: var(--paragraph-spacing);
-        line-height: 1.75;
+        line-height: 1.969rem;
 
         &:last-child {
           margin-bottom: 0;
@@ -102,13 +102,13 @@ const GlobalStyles = ({ layout }) => (
       }
 
       h1 {
-        line-height: 1.15;
+        line-height: 1.5rem;
         font-weight: bold;
         margin-bottom: 1rem;
       }
 
       h2 {
-        line-height: 1.25;
+        line-height: 1.125rem;
         margin-bottom: 0.75rem;
         font-weight: 600;
       }
@@ -131,7 +131,8 @@ const GlobalStyles = ({ layout }) => (
         padding-left: 1.75rem;
 
         > li {
-          margin: 0.5rem 0;
+          line-height: 1.969rem;
+          margin: 0.344rem 0;
         }
       }
 

--- a/packages/gatsby-theme-newrelic/src/components/Lightbox.js
+++ b/packages/gatsby-theme-newrelic/src/components/Lightbox.js
@@ -39,6 +39,7 @@ const Lightbox = ({ children }) => {
           width: 100%;
           padding: 0;
           background: none;
+          margin-top: 0.5rem;
           img {
             cursor: -moz-zoom-in;
             cursor: -webkit-zoom-in;


### PR DESCRIPTION
adjusts the spacing of list items and images and adjusts the line heights of paragraph, h1, and h2 text

the spacing around the main content is changed in [newrelic/docs-website#16583](https://github.com/newrelic/docs-website/pull/16583)

### before
<img width="1728" alt="Screenshot 2024-03-19 at 3 08 26 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/14365008/1984a5b2-fa54-4a89-bdb1-9d3ea1fce2ee">


### after
<img width="1727" alt="Screenshot 2024-03-19 at 3 08 20 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/14365008/af73e5d8-0059-4db1-90c1-dfa27291b1c7">
