### PR TITLE
fix: removing extra slug portion of redirect urls

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/Link.js
+++ b/packages/gatsby-theme-newrelic/src/components/Link.js
@@ -19,10 +19,10 @@ const isRelativePath = (to) => !to.startsWith('http') && to.startsWith('/');
 
 // Prevents our rewrites to our i18n Netlify sites showing external link icons
 const i18nNetlifySites = [
-  'docs-website-kr.netlify.app/kr/',
-  'docs-website-jp.netlify.app/jp/',
-  'docs-website-es.netlify.app/es/',
-  'docs-website-pt.netlify.app/pt/',
+  'docs-website-kr.netlify.app/',
+  'docs-website-jp.netlify.app/',
+  'docs-website-es.netlify.app/',
+  'docs-website-pt.netlify.app/',
 ];
 const isI18nNetlifySite = (to) =>
   i18nNetlifySites.some((site) => to.includes(site));


### PR DESCRIPTION
<img width="1463" alt="Screenshot 2024-03-28 at 9 58 37 AM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/26727669/0c5bb6e3-2cb4-489a-8b69-f2993f186eeb">
