### PR TITLE
Use normal line height for codeblocks in OLs

### DIFF
--- a/demo/src/content/steps.mdx
+++ b/demo/src/content/steps.mdx
@@ -10,7 +10,17 @@ resources:
 ---
 
 Here are some steps
+
 1. Look at the Steps
+   Et netus et malesuada fames. Vitae tortor condimentum
+   consequat semper viverra nam libero justo laoreet.
+
+  ```
+  some code
+  it's really code i swear
+  yippeeeee!
+  ```
+
 2. REALLY look at the Steps
 3. Watch your step
 

--- a/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
@@ -52,6 +52,10 @@ const MarkdownContainer = ({
             top: 6px;
             width: 20px;
           }
+
+          code {
+            line-height: normal;
+          }
         }
 
         blockquote:not(:last-child) {


### PR DESCRIPTION
before: <img width="815" alt="Screenshot 2024-03-28 at 4 03 06 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/39655074/515118da-3710-4642-9d09-6023ecfea2c5">

after: <img width="810" alt="Screenshot 2024-03-28 at 4 08 56 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/39655074/6c465907-c045-4c9d-8235-d5cb81ca0916">
