### PR TITLE
fix: spacing in table of contents and h2s

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalStyles/GlobalStyles.js
@@ -108,7 +108,7 @@ const GlobalStyles = ({ layout }) => (
       }
 
       h2 {
-        line-height: 1.125rem;
+        line-height: 1.75rem;
         margin-bottom: 0.75rem;
         font-weight: 600;
       }

--- a/packages/gatsby-theme-newrelic/src/components/TableOfContents.js
+++ b/packages/gatsby-theme-newrelic/src/components/TableOfContents.js
@@ -50,7 +50,8 @@ const TableOfContents = ({ headings }) => {
               <li
                 key={id}
                 css={css`
-                  margin: 0;
+                  margin: 5px 0 0;
+                  line-height: 1.33rem;
                 `}
               >
                 <a


### PR DESCRIPTION
Some spacing tweaks:

## Table of Contents `li`s

before / after
<img width="224" alt="Screenshot 2024-04-04 at 1 30 04 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/3328ee37-37d2-4329-bf96-0ae79af2c5bc"><img width="224" alt="Screenshot 2024-04-04 at 1 29 53 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/c7bb0ea8-0c68-4396-bfd5-aa4abd9b751d">

## `h2`s

before / after 
<img width="224" alt="Screenshot 2024-04-04 at 1 30 58 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/c5e1e561-53ea-4dd8-987b-207d439bb90f"><img width="257" alt="Screenshot 2024-04-04 at 1 26 03 PM" src="https://github.com/newrelic/gatsby-theme-newrelic/assets/47728020/865903ef-c72e-464a-9a87-057689391e9d">
