### PR TITLE
fix: reset ordered list counter on listitems

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
+++ b/packages/gatsby-theme-newrelic/src/components/MarkdownContainer.js
@@ -21,6 +21,7 @@ const MarkdownContainer = ({
 
         ul,
         ol {
+          counter-reset: listitem;
           &:not(:last-child) {
             margin-bottom: var(--text-spacing);
           }


### PR DESCRIPTION
- fixes bug that would continue to increment li number on all children even in a separate ol's

before:

```
1. li
  2. li
  3. li
    4. li
    5. li
  6. li
7. li
```

after:
```
1. li
  1. li
  2. li
    1. li
    2. li
  3. li
3. li
```