### PR TITLE
fix: unscrollable when focus is on search , t&c content

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -67,7 +67,7 @@ const GlobalFooter = ({ className }) => {
             margin: 0 auto;
 
             @media screen and (max-width: 760px) {
-              font-size: 0.50rem;
+              font-size: 0.5rem;
               justify-content: center;
               text-align: center;
               grid-template-columns: auto;
@@ -144,7 +144,7 @@ const GlobalFooter = ({ className }) => {
                     }
 
                     @media screen and (max-width: 760px) {
-                      font-size: 0.50rem;
+                      font-size: 0.5rem;
                     }
                   `}
                   onClick={handlePrivacyClick}

--- a/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalFooter.js
@@ -67,6 +67,7 @@ const GlobalFooter = ({ className }) => {
             margin: 0 auto;
 
             @media screen and (max-width: 760px) {
+              font-size: 0.50rem;
               justify-content: center;
               text-align: center;
               grid-template-columns: auto;
@@ -102,7 +103,7 @@ const GlobalFooter = ({ className }) => {
                 flex-wrap: wrap;
                 justify-content: flex-end;
                 grid-area: legal;
-                max-width: ${osanoPresent ? '29rem' : '32rem'};
+                max-width: ${osanoPresent ? 'fit-content' : '32rem'};
 
                 a {
                   margin-left: 0.75rem;
@@ -140,6 +141,10 @@ const GlobalFooter = ({ className }) => {
 
                     &:hover svg {
                       filter: invert(100%);
+                    }
+
+                    @media screen and (max-width: 760px) {
+                      font-size: 0.50rem;
                     }
                   `}
                   onClick={handlePrivacyClick}

--- a/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
@@ -32,8 +32,6 @@ const GlobalSearch = ({ onClose }) => {
   const [selected, setSelected] = useState(null);
   const possibleSelections = results.length + recentQueries.length;
 
-  useScrollFreeze(open);
-
   const moveUp = () =>
     setSelected((s) => {
       if (s == null) return possibleSelections - 1;
@@ -69,6 +67,7 @@ const GlobalSearch = ({ onClose }) => {
   });
 
   const showSearchDropdown = query.length > 1 && open;
+  useScrollFreeze(showSearchDropdown);
 
   return (
     <>


### PR DESCRIPTION
- https://new-relic.atlassian.net/browse/NR-367012 
    Clicking on search button makes docs page unscrollable, this has happened because we are using a hook called 
    useScrollFreeze , which adds the style of overflow: hidden to the global parent div of the page, this hook is being 
    triggered when the search box is focused instead it should get triggered when the searchdropdown is open, made the 
    fixes for desirable behaviour  

        
- https://new-relic.atlassian.net/browse/NR-367023
   The content in footer is getting trimmed increased the width of the content which was getting trimmed and took care of 
   responsiveness 