### PR TITLE
Remove the old support URL

### DIFF
--- a/packages/gatsby-theme-newrelic/src/utils/constants.js
+++ b/packages/gatsby-theme-newrelic/src/utils/constants.js
@@ -41,7 +41,7 @@ HEADER_LINKS.set(NR_SITES.DOCS, {
 })
   .set(NR_SITES.COMMUNITY, {
     text: 'Community',
-    href: 'https://discuss.newrelic.com/',
+    href: 'https://support.newrelic.com/',
   })
   .set(NR_SITES.LEARN, {
     text: 'Learn',


### PR DESCRIPTION
This PR removes the old support url that directs from discuss.newrelic.com to forum.newrelic.com to support.newrelic.com

I have added the new URL as support.newrelic.com

