### PR TITLE
feat(search): migrate from Swiftype to SearchGPT REST API

### DIFF
--- a/demo/gatsby-node.js
+++ b/demo/gatsby-node.js
@@ -72,3 +72,31 @@ exports.onCreateWebpackConfig = ({ actions }) => {
     },
   });
 };
+
+// TEMPORARY dev-only proxy for local SearchGPT testing.
+// The SearchGPT service whitelists docs.newrelic.com for CORS but NOT localhost
+// (preflight from localhost 307-redirects to SSO login), so direct browser
+// calls from the dev server are blocked. This forwards /v2/* to the service
+// from the Node side (no CORS) and injects the api-key server-side — which also
+// mirrors the production proxy pattern. Remove with the rest of the test setup.
+exports.onCreateDevServer = ({ app }) => {
+  app.use('/v2', async (req, res) => {
+    const apiKey = process.env.GATSBY_SEARCHGPT_API_KEY;
+    const target = `https://support-search.service.newrelic.com/v2${req.url}`;
+
+    try {
+      const upstream = await fetch(target, { headers: { 'api-key': apiKey } });
+      const body = await upstream.text();
+
+      res
+        .status(upstream.status)
+        .set(
+          'content-type',
+          upstream.headers.get('content-type') || 'application/json'
+        )
+        .send(body);
+    } catch (err) {
+      res.status(502).json({ error: { message: String(err) } });
+    }
+  });
+};

--- a/demo/src/pages/search-results.js
+++ b/demo/src/pages/search-results.js
@@ -1,0 +1,257 @@
+// TEMPORARY replica of the docs-website /search-results page, adapted to the
+// SearchGPT search() contract so we can test the "press Enter" full-search
+// experience locally (the header dropdown's submit navigates here).
+//
+// This mirrors docs-website/src/pages/search-results.js in look, with two
+// migration-driven changes that the real page will also need (Task #10):
+//   1. New result shape: result.title (plain) + result.summary (highlighted
+//      with <span class='highlight'>), instead of result.highlight.title/body.
+//   2. Cursor pagination (Prev/Next) instead of numbered pages — SearchGPT
+//      cursors don't support random access to an arbitrary page number.
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import {
+  Icon,
+  Button,
+  Link,
+  search,
+  Spinner,
+  Surface,
+  highlightText,
+} from '@newrelic/gatsby-theme-newrelic';
+import { useLocation, navigate } from '@reach/router';
+
+const SearchResultPageView = () => {
+  const location = useLocation();
+  const query = new URLSearchParams(location.search).get('query');
+
+  const [state, setState] = useState({ loading: true });
+  // cursorStack holds the cursors for pages already visited; cursor is the one
+  // used for the current page (undefined => first page).
+  const [cursor, setCursor] = useState(undefined);
+  const [cursorStack, setCursorStack] = useState([]);
+
+  const { results, totalCount, nextCursor, loading, error } = state;
+
+  // reset pagination whenever the query changes
+  useEffect(() => {
+    setCursor(undefined);
+    setCursorStack([]);
+  }, [query]);
+
+  useEffect(() => {
+    if (!query) {
+      navigate('/');
+      return;
+    }
+
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+
+    (async () => {
+      try {
+        const res = await search({ searchTerm: query, cursor });
+        if (cancelled) return;
+        setState({
+          results: res.results,
+          totalCount: res.totalCount,
+          nextCursor: res.nextCursor,
+          loading: false,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          error:
+            err.name === 'RateLimitError'
+              ? `Rate limited. Try again in ${err.rateLimit?.resetInSeconds}s.`
+              : 'Unable to get search results, an error has occurred',
+          loading: false,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [query, cursor]);
+
+  const goNext = () => {
+    if (!nextCursor) return;
+    setCursorStack((stack) => [...stack, cursor]);
+    setCursor(nextCursor);
+  };
+
+  const goPrev = () => {
+    setCursorStack((stack) => {
+      const next = stack.slice(0, -1);
+      setCursor(stack[stack.length - 1]);
+      return next;
+    });
+  };
+
+  const hasPrevPage = cursorStack.length > 0;
+  const hasNextPage = Boolean(nextCursor);
+
+  return (
+    <PageContainer>
+      {loading && (
+        <LoadingContainer>
+          <h2>Loading results</h2>
+          <Spinner
+            size="2rem"
+            css={css`
+              margin-top: 1rem;
+              height: 50px;
+            `}
+          />
+        </LoadingContainer>
+      )}
+      {results && !loading && (
+        <>
+          <h2>
+            {totalCount} results for "{query}"
+          </h2>
+          {results.map((result, i) => (
+            <Result
+              key={`${i}-${result.title}`}
+              result={result}
+              query={query}
+            />
+          ))}
+          <PaginationContainer>
+            <PaginationButton
+              disabled={!hasPrevPage}
+              onClick={goPrev}
+              css={css`
+                padding: 0.25rem 0.35rem;
+                margin-right: 0.5rem;
+              `}
+            >
+              <Icon
+                name="fe-arrow-left"
+                css={css`
+                  margin-right: 0.25rem;
+                `}
+              />
+              Previous
+            </PaginationButton>
+            <PaginationButton
+              disabled={!hasNextPage}
+              onClick={goNext}
+              css={css`
+                padding: 0.25rem 0.35rem;
+                margin-left: 0.5rem;
+              `}
+            >
+              Next
+              <Icon
+                name="fe-arrow-right"
+                css={css`
+                  margin-left: 0.25rem;
+                `}
+              />
+            </PaginationButton>
+          </PaginationContainer>
+        </>
+      )}
+      {error && !loading && <LoadingContainer>{error}</LoadingContainer>}
+    </PageContainer>
+  );
+};
+
+const PageContainer = styled.div`
+  font-size: 1.125rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  h2 {
+    font-weight: normal;
+    margin-bottom: 1rem;
+  }
+`;
+
+const LoadingContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PaginationContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  margin: 3rem auto 0;
+`;
+
+const PaginationButton = ({ children, ...props }) => (
+  <Button {...props} variant={Button.VARIANT.OUTLINE} size={Button.SIZE.SMALL}>
+    {children}
+  </Button>
+);
+
+PaginationButton.propTypes = {
+  children: PropTypes.node,
+};
+
+const Result = ({ result, query }) => {
+  return (
+    <Surface
+      as={Link}
+      to={result.url}
+      css={css`
+        .highlight {
+          color: #00ac69;
+          font-style: normal;
+        }
+        margin-bottom: 2rem;
+        box-shadow: none;
+        color: var(--primary-font-color);
+        &:hover {
+          color: var(--primary-font-color);
+          h3 {
+            text-decoration: underline;
+          }
+        }
+      `}
+    >
+      <p
+        css={css`
+          margin-bottom: 0;
+          color: var(--secondary-text-color);
+          font-size: 0.875rem;
+        `}
+      >
+        {result.url.replace('https://docs.newrelic.com/docs/', '')}
+      </p>
+      <h3
+        css={css`
+          margin-bottom: 0;
+          font-weight: 500;
+        `}
+        dangerouslySetInnerHTML={{
+          __html: highlightText(result.title, query),
+        }}
+      />
+      <p dangerouslySetInnerHTML={{ __html: result.summary }} />
+    </Surface>
+  );
+};
+
+Result.propTypes = {
+  query: PropTypes.string,
+  result: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    summary: PropTypes.string,
+  }).isRequired,
+};
+
+export default SearchResultPageView;

--- a/demo/src/pages/search-test.js
+++ b/demo/src/pages/search-test.js
@@ -1,0 +1,168 @@
+/* eslint-disable no-console */
+// TEMPORARY manual-test page for the SearchGPT REST integration.
+// Visit http://localhost:8001/search-test
+// Remove this file before merging (tracked under the SearchGPT migration cleanup).
+import React, { useState } from 'react';
+import { css } from '@emotion/react';
+import {
+  search,
+  suggest,
+} from '../../../packages/gatsby-theme-newrelic/src/utils/searchGPT';
+
+const SearchTest = () => {
+  const [term, setTerm] = useState('infrastructure');
+  const [mode, setMode] = useState(null); // 'search' | 'suggest'
+  const [state, setState] = useState({ status: 'idle' });
+  const [results, setResults] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [totalCount, setTotalCount] = useState(null);
+
+  const run = async (which, { append = false } = {}) => {
+    setMode(which);
+    setState({ status: 'loading' });
+    try {
+      if (which === 'suggest') {
+        const res = await suggest({ searchTerm: term, limit: 5 });
+        console.log('[suggest] response', res);
+        setResults(res.results);
+        setCursor(null);
+        setTotalCount(null);
+      } else {
+        const res = await search({
+          searchTerm: term,
+          cursor: append ? cursor : undefined,
+        });
+        console.log('[search] response', res);
+        setResults((prev) => (append ? prev.concat(res.results) : res.results));
+        setCursor(res.nextCursor);
+        setTotalCount(res.totalCount);
+      }
+      setState({ status: 'success' });
+    } catch (err) {
+      console.error(err);
+      setState({
+        status: 'error',
+        message: err.message,
+        rateLimit: err.rateLimit,
+      });
+    }
+  };
+
+  return (
+    <div
+      css={css`
+        max-width: 820px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        font-family: system-ui, sans-serif;
+
+        .highlight {
+          background: #fff3a3;
+          font-weight: 600;
+        }
+        .meta {
+          color: #666;
+          font-size: 0.75rem;
+        }
+        button {
+          margin-right: 0.5rem;
+        }
+        input {
+          padding: 0.4rem 0.6rem;
+          width: 320px;
+          margin-right: 0.5rem;
+        }
+        li {
+          margin-bottom: 1.25rem;
+          list-style: none;
+        }
+        ul {
+          padding: 0;
+        }
+        pre {
+          background: #f4f4f4;
+          padding: 0.75rem;
+          overflow: auto;
+          font-size: 0.7rem;
+        }
+      `}
+    >
+      <h1>SearchGPT REST — manual test</h1>
+      <p className="meta">
+        TEMPORARY page. Tests the new client directly. Open DevTools → Network
+        to confirm calls hit /v2/search and /v2/search/suggest (and watch for
+        CORS).
+      </p>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          run('search');
+        }}
+      >
+        <input
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          placeholder="search term"
+        />
+        <button type="submit">Search (/v2/search)</button>
+        <button type="button" onClick={() => run('suggest')}>
+          Suggest (/v2/search/suggest)
+        </button>
+      </form>
+
+      <p className="meta">
+        status: <strong>{state.status}</strong>
+        {mode && ` · mode: ${mode}`}
+        {totalCount != null && ` · totalCount: ${totalCount}`}
+        {` · showing: ${results.length}`}
+      </p>
+
+      {state.status === 'error' && (
+        <div
+          css={css`
+            color: #b00;
+          `}
+        >
+          Error: {state.message}
+          {state.rateLimit && (
+            <pre>{JSON.stringify(state.rateLimit, null, 2)}</pre>
+          )}
+        </div>
+      )}
+
+      <ul>
+        {results.map((r) => (
+          <li key={r.id || r.url}>
+            <div className="meta">
+              {r.sourceLabel} · score {r.score?.toFixed?.(3) ?? r.score}
+            </div>
+            <a href={r.url} target="_blank" rel="noreferrer">
+              <strong>{r.title}</strong>
+            </a>
+            <div className="meta">{r.url}</div>
+            {/* summary is highlighted with <span class='highlight'> */}
+            <p dangerouslySetInnerHTML={{ __html: r.summary }} />
+            {r.bodyHighlights && (
+              <details>
+                <summary className="meta">bodyHighlights (search only)</summary>
+                <pre>{r.bodyHighlights}</pre>
+              </details>
+            )}
+            {r.tags?.length > 0 && (
+              <div className="meta">tags: {r.tags.join(', ')}</div>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {mode === 'search' && cursor && (
+        <button type="button" onClick={() => run('search', { append: true })}>
+          Load more (cursor: {cursor})
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default SearchTest;

--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -140,6 +140,22 @@ yarn:
 yarn add @newrelic/gatsby-theme-newrelic @emotion/core @emotion/styled @mdx-js/mdx @mdx-js/react @splitsoftware/splitio-react gatsby-plugin-mdx
 ```
 
+## Environment variables
+
+Search is powered by the SearchGPT REST API and is configured via environment
+variables:
+
+- `GATSBY_SEARCHGPT_API_KEY` _(required)_: New Relic API key used to authenticate
+  search requests. Because it is `GATSBY_`-prefixed, it is inlined into the
+  client bundle and used by the global search dropdown, the search results page,
+  and the 404 page.
+- `GATSBY_SEARCHGPT_BASE_URL` _(optional)_: Base URL of the SearchGPT service.
+  Defaults to `https://support-search.service.newrelic.com`. Point this at a
+  proxy or staging endpoint to override it without code changes.
+- `SEARCHGPT_API_KEY` / `SEARCHGPT_BASE_URL` _(optional)_: Server-side fallbacks
+  used by the build-time related-resources lookup. If unset, the `GATSBY_`
+  variables above are used.
+
 ## Configuration
 
 You can configure `gatsby-theme-newrelic` using the following configuration
@@ -258,13 +274,18 @@ only `Mdx` nodes are supported.
 The related resources component is controlled by specific front matter slugs
 that are defined on a page by setting the front matter for `resources`. If no
 resources are available in the page front matter, the component will backfill
-use the related resource items using Swiftype. See the `swiftype` options below
-for more information on customizing the search behavior.
+the related resource items using a SearchGPT search. See the `swiftype` options
+below for more information on customizing the search behavior.
+
+> **Note:** related resources are now sourced from the SearchGPT REST API. The
+> option key is still named `swiftype` for backward compatibility. Authentication
+> is configured via the `SEARCHGPT_API_KEY` environment variable (see
+> [Environment variables](#environment-variables)), not a per-engine key.
 
 In short, the order of priority for populating content is driven by:
 
 1. Resources defined via the `resources` front matter item.
-2. Resources defined from executing a Swiftype search for the page.
+2. Resources defined from executing a SearchGPT search for the page.
 
 **Options:**
 
@@ -273,26 +294,23 @@ In short, the order of priority for populating content is driven by:
   underneath the link. Use this to add additional labels not covered by the
   default set of labels.
 
-- `swiftype` _(object | false)_: Configuration used for fetching results from
-  Swiftype for an `Mdx` node. Set this to `false` (the default) to disable
-  fetching related resources through Swiftype. If this is disabled, related
-  resources can only be sourced via front matter. If enabled, this takes the
-  following configuration:
+- `swiftype` _(object | false)_: Configuration used for fetching related
+  resources for an `Mdx` node via SearchGPT. Set this to `false` (the default)
+  to disable fetching related resources through search. If this is disabled,
+  related resources can only be sourced via front matter. If enabled, this takes
+  the following configuration:
 
-  - `resultsPath` _(string)_ **required**: Path to the file where Swiftype
+  - `resultsPath` _(string)_ **required**: Path to the file where search
     results will be stored. If the `refetch` option is set to `false` (the
     default), this file will be used to read related resource values for each
     `Mdx` node. This file is only written to when `refetch` is set to `true`.
 
-  - `refetch` _(boolean)_: Determines whether to refetch results from Swiftype
+  - `refetch` _(boolean)_: Determines whether to refetch results from SearchGPT
     for every `Mdx` node during a build. It's a good idea to only set this on a
-    special build (e.g. a build that happens on a cron job) so that Swiftype is
-    not searched on development or every build on the site.
+    special build (e.g. a build that happens on a cron job) so that search is
+    not run on development or every build on the site.
 
     - **Default**: `false`
-
-  - `engineKey` _(string)_ **required**: Swiftype's engine key used to fetch
-    results from a Swiftype search engine.
 
   - `getSlug` _(function)_: Function to get the slug for an `Mdx` node.
     Useful if the slug is set from something other than the filesystem. By
@@ -307,12 +325,12 @@ In short, the order of priority for populating content is driven by:
     `node` and a key of `slug` (i.e. `filter: ({ node, slug }) => { /* do something */ }`).
 
   - `getParams` _(function)_: Function that allows you to specify additional
-    params passed to Swiftype when running a search query. Useful if you want to
-    provide additional filters or field boosts. This function should accept an
-    object as its only argument with a key of `node` and a key of `slug`.
+    params passed to the search query (e.g. `q`). This function should accept an
+    object as its only argument with a key of `node` and a key of `slug`. Note
+    that SearchGPT does not support field boosting.
 
   - `limit` _(integer)_: The limit of related resources that should be fetched
-    from Swiftype.
+    from the search.
 
     - **Default**: `5`
 

--- a/packages/gatsby-theme-newrelic/gatsby-node.js
+++ b/packages/gatsby-theme-newrelic/gatsby-node.js
@@ -8,7 +8,6 @@ const { getResolvedEnv, getI18nConfig } = require('./src/utils/config');
 const pageTransforms = require('./gatsby/page-transforms');
 const { getFileRelativePath } = require('./gatsby/utils/fs');
 const { SCHEMA_CUSTOMIZATION_TYPES } = require('./gatsby/type-defs');
-const { SWIFTYPE_ENGINE_KEY } = require('./src/utils/constants');
 
 let writeableRelatedResourceData = {};
 
@@ -300,7 +299,6 @@ exports.onCreatePage = (helpers, themeOptions) => {
         ...page.context,
         layout: 'basic',
         themeOptions,
-        swiftypeEngineKey: SWIFTYPE_ENGINE_KEY,
       },
     });
   }
@@ -446,19 +444,16 @@ const createRelatedResources = async (
 };
 
 const validateSwiftypeOptions = (swiftypeOptions) => {
-  const { resultsPath, engineKey } = swiftypeOptions;
+  const { resultsPath } = swiftypeOptions;
 
   if (!resultsPath) {
     throw new Error(
-      "You have enabled swiftype searches, but the 'resultsPath' is not defined. Please define a 'relatedResources.swiftype.resultsPath' option"
+      "You have enabled related-resources search, but the 'resultsPath' is not defined. Please define a 'relatedResources.swiftype.resultsPath' option"
     );
   }
 
-  if (!engineKey) {
-    throw new Error(
-      "You have enabled swiftype searches, but the 'engineKey' is missing. Please define a 'relatedResources.swiftype.engineKey' option"
-    );
-  }
+  // engineKey is no longer required: related-resources now use the SearchGPT
+  // REST API (auth via the SEARCHGPT_API_KEY env var), not a Swiftype engine key.
 };
 
 const validateSignupOptions = (signupOptions) => {

--- a/packages/gatsby-theme-newrelic/index.js
+++ b/packages/gatsby-theme-newrelic/index.js
@@ -66,6 +66,7 @@ export { default as Video } from './src/components/Video';
 export { default as Walkthrough } from './src/components/Walkthrough';
 
 export { default as formatCode } from './src/utils/formatCode';
+export { default as highlightText } from './src/utils/highlightText';
 export { default as search } from './src/components/SearchModal/search';
 export { default as useActiveHash } from './src/hooks/useActiveHash';
 export { default as useClipboard } from './src/hooks/useClipboard';

--- a/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
@@ -17,7 +17,7 @@ const GlobalSearch = ({ onClose }) => {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const throttledQuery = useThrottle(query, 300);
-  const { fetchNextPage, results, status } = useSearch({
+  const { results, status, fetchNextPage, hasMore } = useSearch({
     searchTerm: throttledQuery,
     filters: DEFAULT_FILTER_TYPES,
   });
@@ -114,7 +114,7 @@ const GlobalSearch = ({ onClose }) => {
                 position,
                 searchType: 'globalSearch',
               });
-              navigate(`/search-results?query=${recentQuery}&page=1`);
+              navigate(`/search-results/?query=${recentQuery}&page=1`);
             }
           } else {
             saveSearch(value);
@@ -126,7 +126,7 @@ const GlobalSearch = ({ onClose }) => {
               searchTerm: query,
               searchType: 'globalSearch',
             });
-            navigate(`/search-results?query=${value}&page=1`);
+            navigate(`/search-results/?query=${value}&page=1`);
           }
         }}
         placeholder={t('searchInput.placeholder')}
@@ -168,7 +168,8 @@ const GlobalSearch = ({ onClose }) => {
       />
       {showSearchDropdown && (
         <SearchDropdown
-          fetchNextPage={fetchNextPage}
+          hasMore={hasMore}
+          onViewMore={fetchNextPage}
           onClose={() => setOpen(false)}
           onRecentClick={(query, i) => {
             addPageAction({

--- a/packages/gatsby-theme-newrelic/src/components/SearchDropdown/Results.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchDropdown/Results.js
@@ -5,8 +5,16 @@ import PropTypes from 'prop-types';
 import cx from 'classnames';
 
 import Icon from '../Icon';
+import highlightText from '../../utils/highlightText';
 
-const Results = ({ onResultClick, onViewMore, results, selected }) => {
+const Results = ({
+  onResultClick,
+  onViewMore,
+  hasMore,
+  query,
+  results,
+  selected,
+}) => {
   return (
     <>
       <List>
@@ -39,7 +47,9 @@ const Results = ({ onResultClick, onViewMore, results, selected }) => {
                   line-height: 1.25;
                   margin-bottom: 0.25rem;
                 `}
-                dangerouslySetInnerHTML={{ __html: result.highlight.title }}
+                dangerouslySetInnerHTML={{
+                  __html: highlightText(result.title, query),
+                }}
               />
               <p
                 css={css`
@@ -51,7 +61,7 @@ const Results = ({ onResultClick, onViewMore, results, selected }) => {
                   overflow: hidden;
                 `}
                 dangerouslySetInnerHTML={{
-                  __html: result.highlight.body,
+                  __html: result.summary,
                 }}
               />
             </a>
@@ -59,15 +69,17 @@ const Results = ({ onResultClick, onViewMore, results, selected }) => {
         ))}
       </List>
 
-      <ViewMore onClick={onViewMore}>
-        View more{' '}
-        <Icon
-          css={css`
-            padding-top: 2px;
-          `}
-          name="fe-chevron-down"
-        />
-      </ViewMore>
+      {hasMore && (
+        <ViewMore onClick={onViewMore}>
+          View more{' '}
+          <Icon
+            css={css`
+              padding-top: 2px;
+            `}
+            name="fe-chevron-down"
+          />
+        </ViewMore>
+      )}
     </>
   );
 };
@@ -79,7 +91,7 @@ const List = styled.ul`
   overflow-y: scroll;
   padding: 0.25rem 0 0;
 
-  & em {
+  & .highlight {
     color: var(--search-dropdown-emphasis);
     font-style: normal;
   }
@@ -127,16 +139,20 @@ const ViewMore = styled.button`
 `;
 
 export const ResultType = PropTypes.shape({
-  highlight: PropTypes.shape({
-    body: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-  }).isRequired,
   url: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  // highlighted snippet containing <span class='highlight'>…</span>
+  summary: PropTypes.string,
+  sourceLabel: PropTypes.string,
+  score: PropTypes.number,
+  tags: PropTypes.arrayOf(PropTypes.string),
 });
 
 Results.propTypes = {
   onViewMore: PropTypes.func.isRequired,
+  hasMore: PropTypes.bool,
   onResultClick: PropTypes.func.isRequired,
+  query: PropTypes.string,
   selected: PropTypes.number,
   results: PropTypes.arrayOf(ResultType),
 };

--- a/packages/gatsby-theme-newrelic/src/components/SearchDropdown/SearchDropdown.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchDropdown/SearchDropdown.js
@@ -9,10 +9,12 @@ import Results, { ResultType } from './Results';
 import Skeleton from './Skeleton';
 
 const SearchDropdown = ({
-  fetchNextPage,
+  onViewMore,
+  hasMore,
   onClose,
   onRecentClick,
   onResultClick,
+  query,
   recentQueries,
   results,
   selected,
@@ -31,7 +33,7 @@ const SearchDropdown = ({
               {recentQueries.map((query, i) => (
                 <li key={query} className={cx({ selected: selected === i })}>
                   <a
-                    href={`/search-results?query=${query}&page=1`}
+                    href={`/search-results/?query=${query}&page=1`}
                     onClick={() => onRecentClick(query, i)}
                   >
                     {query}
@@ -53,8 +55,10 @@ const SearchDropdown = ({
                 : selected - (recentQueries.length ?? 0)
             }
             results={results}
+            query={query}
+            hasMore={hasMore}
             onResultClick={onResultClick}
-            onViewMore={fetchNextPage}
+            onViewMore={onViewMore}
           />
         )}
         <KeyboardLegend />
@@ -65,10 +69,12 @@ const SearchDropdown = ({
 };
 
 SearchDropdown.propTypes = {
-  fetchNextPage: PropTypes.func.isRequired,
+  onViewMore: PropTypes.func.isRequired,
+  hasMore: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onRecentClick: PropTypes.func.isRequired,
   onResultClick: PropTypes.func.isRequired,
+  query: PropTypes.string,
   recentQueries: PropTypes.arrayOf(PropTypes.string).isRequired,
   results: PropTypes.arrayOf(ResultType),
   selected: PropTypes.number,

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/search.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/search.js
@@ -1,61 +1,17 @@
-const ENDPOINT =
-  'https://search-api.swiftype.com/api/v1/public/engines/search.json';
+// Public package export (see index.js). Thin wrapper over the SearchGPT REST
+// client so the existing `search` import path keeps working for consumers
+// (e.g. the docs-website /search-results page).
+//
+// Returns the normalized hybrid-search shape:
+//   { results, nextCursor, prevCursor, totalCount }
+// Each result: { id, url, title, summary, bodyHighlights, sourceLabel, score,
+//                tags, createdDate, lastModifiedDate }.
+//
+// NOTE: this is a breaking change from the Swiftype shape ({ records: { page }}
+// with result.highlight.title/body). Consumers must update accordingly.
+import { search as searchGPT } from '../../utils/searchGPT';
 
-const search = async ({
-  searchTerm,
-  filters = [],
-  defaultSources,
-  perPage = 10,
-  page = 1,
-}) => {
-  const { searchBy, source } = filters.reduce(
-    (acc, { type, defaultFilters }) => ({
-      ...acc,
-      [type]: defaultFilters,
-    }),
-    {}
-  );
-
-  const searchByFilters = searchBy?.map((filter) =>
-    filter.isSelected ? `${filter.name}^10` : `${filter.name}^0`
-  );
-
-  const sourceFilters = { type: source.length > 0 ? source : defaultSources };
-  const res = await fetch(ENDPOINT, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      q: searchTerm,
-      engine_key: 'Ad9HfGjDw4GRkcmJjUut',
-      page,
-      per_page: perPage,
-      search_fields: {
-        page: searchByFilters,
-      },
-      highlight_fields: {
-        page: {
-          title: {
-            size: 100,
-            fallback: true,
-          },
-          body: {
-            size: 400,
-            fallback: true,
-          },
-        },
-      },
-      filters: {
-        page: {
-          ...sourceFilters,
-          document_type: ['!views_page_menu', '!views_page_content'],
-        },
-      },
-    }),
-  });
-
-  return res.json();
-};
+const search = ({ searchTerm, sources, cursor, sort, since, until, tags }) =>
+  searchGPT({ searchTerm, sources, cursor, sort, since, until, tags });
 
 export default search;

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearch.js
@@ -1,101 +1,55 @@
-import { useCallback, useEffect, useReducer, useMemo } from 'react';
-import search from './search';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
-import useLocale from '../../hooks/useLocale';
+import { suggest, DEFAULT_SOURCES } from '../../utils/searchGPT';
 
-const ACTIONS = {
-  NEXT_PAGE: 'nextPage',
-  RECEIVE_PAGE_DATA: 'receivePageData',
-  RESET: 'reset',
-};
-
-const initialState = {
-  page: 1,
-  results: [],
-};
-
-const reducer = (state, action) => {
-  switch (action.type) {
-    case ACTIONS.NEXT_PAGE:
-      return { ...state, page: state.page + 1 };
-    case ACTIONS.RECEIVE_PAGE_DATA: {
-      const { page, data } = action.payload;
-
-      return {
-        ...state,
-        results: page === 1 ? data : state.results.concat(data),
-      };
-    }
-    case ACTIONS.RESET:
-      return { ...state, page: 1 };
-    default:
-      return state;
-  }
-};
+// The header dropdown is an as-you-type surface, so it uses the lexical
+// /v2/search/suggest endpoint: not rate limited and safe on every keystroke.
+// suggest() has no cursor, but it honors `limit`, so "View more" grows the
+// limit and re-queries — appending the next page of results inline. Because
+// suggest isn't rate limited, re-fetching a slightly larger list is cheap.
+const PAGE_SIZE = 5;
 
 const useSearch = ({ searchTerm, filters }) => {
-  const locale = useLocale();
-  const [{ page, results }, dispatch] = useReducer(reducer, initialState);
-  const defaultSources = locale.isDefault
-    ? ['developer', 'docs', 'opensource', 'quickstarts']
-    : [
-        `developer-${locale.locale}`,
-        `docs-${locale.locale}`,
-        `opensource-${locale.locale}`,
-        `quickstarts`,
-      ];
+  // `filters` is retained for API compatibility. SearchGPT queries a single
+  // source (developer/opensource/quickstarts were deprecated and redirect to
+  // docs) and does not support field boosting (title/body), so those legacy
+  // filters no longer alter the query. Tag filtering can be layered on later.
+  const tags = useMemo(() => {
+    const tagFilter = filters?.find(({ type }) => type === 'tags');
+    const selected = tagFilter?.defaultFilters
+      ?.filter((filter) => filter.isSelected)
+      .map((filter) => filter.name);
 
-  const swiftypeFilters = useMemo(() => {
-    const selectedFilters = filters.map(({ defaultFilters, type }) => {
-      const updatedDefaultFilters = defaultFilters?.filter(
-        (filter) => filter.isSelected
-      );
-      return { defaultFilters: updatedDefaultFilters, type };
-    });
-    const allFilters = selectedFilters.length === 0 ? filters : selectedFilters;
+    return selected?.length ? selected : undefined;
+  }, [filters]);
 
-    return allFilters.map(({ defaultFilters, type }) => {
-      if (type === 'source') {
-        const filters = defaultFilters.map((filter) =>
-          locale.isDefault ? filter.name : `${filter.name}-${locale.locale}`
-        );
-        return { defaultFilters: filters, type };
-      }
-      return { defaultFilters, type };
-    });
-  }, [filters, locale]);
+  const [limit, setLimit] = useState(PAGE_SIZE);
 
-  const queryKey = useMemo(
-    () => ['searchResults', searchTerm, page, swiftypeFilters],
-    [searchTerm, page, swiftypeFilters]
-  );
+  // reset back to the first page whenever the query or filters change
+  useEffect(() => {
+    setLimit(PAGE_SIZE);
+  }, [searchTerm, tags]);
 
-  const { status } = useQuery(
-    queryKey,
-    ({ queryKey: [, searchTerm, page, filters] }) =>
-      search({
-        searchTerm,
-        defaultSources,
-        filters,
-        page,
-        perPage: 5,
-      }),
+  const { status, data } = useQuery(
+    ['searchSuggest', searchTerm, tags, limit],
+    () => suggest({ searchTerm, sources: DEFAULT_SOURCES, tags, limit }),
     {
       enabled: Boolean(searchTerm),
-      onSuccess: (data) =>
-        dispatch({ type: ACTIONS.RECEIVE_PAGE_DATA, payload: { page, data } }),
-      select: ({ records }) => records.page,
+      select: ({ results }) => results,
+      // keep the current results visible while the larger page loads, so
+      // growing the limit reads as an append rather than a reload
+      keepPreviousData: true,
     }
   );
 
-  useEffect(() => {
-    dispatch({ type: ACTIONS.RESET });
-  }, [searchTerm, filters]);
+  const results = data || [];
 
   return {
     status,
     results,
-    fetchNextPage: useCallback(() => dispatch({ type: ACTIONS.NEXT_PAGE }), []),
+    // if we asked for `limit` and got fewer back, there are no more results
+    hasMore: results.length >= limit,
+    fetchNextPage: useCallback(() => setLimit((l) => l + PAGE_SIZE), []),
   };
 };
 

--- a/packages/gatsby-theme-newrelic/src/pages/404.js
+++ b/packages/gatsby-theme-newrelic/src/pages/404.js
@@ -15,11 +15,9 @@ import getLocale from '../../gatsby/utils/getLocale';
 import useThemeTranslation from '../hooks/useThemeTranslation';
 import Trans from '../components/Trans';
 import { addPageAction } from '../utils/nrBrowserAgent.js';
+import { suggest } from '../utils/searchGPT';
 
-const NotFoundPage = ({
-  location,
-  pageContext: { themeOptions, swiftypeEngineKey },
-}) => {
+const NotFoundPage = ({ location, pageContext: { themeOptions } }) => {
   const {
     site: {
       siteMetadata: { siteUrl },
@@ -54,57 +52,27 @@ const NotFoundPage = ({
   );
 
   const getSearchResults = useCallback(async () => {
-    const localePostFix = () => {
-      return pageLocale === 'en' ? '' : `-${pageLocale}`;
-    };
+    if (searchTerm === null) {
+      return;
+    }
 
-    const search = async () => {
-      const res = await fetch(
-        'https://search-api.swiftype.com/api/v1/public/engines/search.json',
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            q: searchTerm,
-            engine_key: swiftypeEngineKey,
-            per_page: 5,
-            filters: {
-              page: {
-                type: [
-                  `docs${localePostFix()}`,
-                  `developers${localePostFix()}`,
-                  `opensource${localePostFix()}`,
-                  `quickstarts${localePostFix()}`,
-                ],
-                document_type: [
-                  '!views_page_menu',
-                  '!term_page_api_menu',
-                  '!term_page_landing_page',
-                ],
-              },
-            },
-          }),
-        }
-      );
-
-      const { records } = await res.json();
-
-      return records.page;
-    };
-
-    if (searchTerm !== null) {
-      const results = await search();
-      const trimmedResults = results.map((r) => {
-        return { url: r.url, title: r.title, type: r.type };
-      });
+    try {
+      // suggest() is the lexical typeahead endpoint: not rate limited and
+      // lightweight, which suits 404 path-based suggestions.
+      const { results } = await suggest({ searchTerm, limit: 5 });
+      const trimmedResults = results.map((r) => ({
+        url: r.url,
+        title: r.title,
+        sourceLabel: r.sourceLabel,
+      }));
 
       setSearchResult(trimmedResults);
+    } catch {
+      setSearchResult([]);
     }
-  }, [pageLocale, searchTerm, swiftypeEngineKey]);
+  }, [searchTerm]);
 
-  const displaySearchResults = (locale) => {
+  const displaySearchResults = () => {
     if (!searchResult || searchResult.length === 0) {
       return null;
     }
@@ -148,7 +116,7 @@ const NotFoundPage = ({
                   `}
                   uppercase
                 >
-                  {result.type?.replace(`-${locale}`, '').replace('_', ' ')}
+                  {result.sourceLabel}
                 </Tag>
               </li>
             );
@@ -244,7 +212,7 @@ const NotFoundPage = ({
                 `}
               />
             </div>
-            {displaySearchResults(pageLocale)}
+            {displaySearchResults()}
 
             <div
               css={css`
@@ -295,7 +263,6 @@ NotFoundPage.propTypes = {
   }).isRequired,
   pageContext: PropTypes.shape({
     themeOptions: PropTypes.object.isRequired,
-    swiftypeEngineKey: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/packages/gatsby-theme-newrelic/src/utils/constants.js
+++ b/packages/gatsby-theme-newrelic/src/utils/constants.js
@@ -10,8 +10,6 @@ const TRACKING_COOKIE_NAME = 'newrelic-gdpr-consent';
 // Commented out to disable segment tracking and avoid edge function costs
 // const DEV_SEGMENT_WRITE_KEY = 'n9T9St8geATEFC1tmc0XH7XzEsOSVZCK';
 
-const SWIFTYPE_ENGINE_KEY = 'Ad9HfGjDw4GRkcmJjUut';
-
 const CAMEL_CASE = /^[a-z][a-zA-Z0-9]*$/;
 const TITLE_CASE = /^[A-Z\d][\w-]+( [A-Z\d][\w-]+)*$/;
 const SPLITS = {
@@ -57,7 +55,6 @@ module.exports = {
   SPLITS,
   SPLIT_TRACKING_EVENTS,
   STORAGE_KEYS,
-  SWIFTYPE_ENGINE_KEY,
   TITLE_CASE,
   TRACKING_COOKIE_NAME,
 };

--- a/packages/gatsby-theme-newrelic/src/utils/highlightText.js
+++ b/packages/gatsby-theme-newrelic/src/utils/highlightText.js
@@ -1,0 +1,41 @@
+// Client-side term highlighting for fields the SearchGPT API returns plain
+// (notably `title` — the API only highlights `summary`/`bodyHighlights`).
+// Wraps occurrences of the query terms with <span class='highlight'>, matching
+// the markup the server uses, so the same `.highlight` CSS styles both.
+//
+// `text` is HTML-escaped before matching, so the result is safe to pass to
+// dangerouslySetInnerHTML. Matching is a naive case-insensitive term match and
+// will not mirror the server's stemming/semantic matching exactly.
+
+const HTML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+const escapeHtml = (str) =>
+  str.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+
+const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const highlightText = (text, query) => {
+  const safe = escapeHtml(text ?? '');
+
+  if (!query) return safe;
+
+  const terms = query
+    .trim()
+    .split(/\s+/)
+    .filter((term) => term.length > 1)
+    .map(escapeRegExp);
+
+  if (terms.length === 0) return safe;
+
+  const regex = new RegExp(`(${terms.join('|')})`, 'gi');
+
+  return safe.replace(regex, "<span class='highlight'>$1</span>");
+};
+
+export default highlightText;

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/fetchRelatedResources.js
@@ -15,7 +15,7 @@ const getExcludedUrls = (node, siteUrl) => {
 
 const warn = once((reporter) => {
   reporter.warn(
-    '[@newrelic/gatsby-theme-newrelic] You are attempting to fetch Swiftype ' +
+    '[@newrelic/gatsby-theme-newrelic] You are attempting to fetch search ' +
       'results for related resources in development mode. As a precaution, ' +
       'this has been disabled to prevent the accidental execution of queries ' +
       'for large sites. Please disable the `relatedResources.swiftype.refetch` ' +
@@ -23,8 +23,8 @@ const warn = once((reporter) => {
   );
 });
 
-const getResultsFromSwiftype = ({ node, siteUrl, slug }, swiftypeOptions) => {
-  const { engineKey, limit, getParams = () => ({}) } = swiftypeOptions;
+const getResultsFromSearch = ({ node, siteUrl, slug }, swiftypeOptions) => {
+  const { limit, getParams = () => ({}) } = swiftypeOptions;
   const { frontmatter = {} } = node;
   const defaultParams = { q: frontmatter.title };
   const params = getParams({ node, slug });
@@ -33,7 +33,6 @@ const getResultsFromSwiftype = ({ node, siteUrl, slug }, swiftypeOptions) => {
     siteUrl + slug,
     { ...defaultParams, ...params },
     {
-      engineKey,
       limit,
       excludedUrls: getExcludedUrls(node, siteUrl),
     }
@@ -57,7 +56,7 @@ module.exports = async (helpers, swiftypeOptions) => {
 
   if (refetch) {
     if (isProdEnv) {
-      return getResultsFromSwiftype(helpers, swiftypeOptions);
+      return getResultsFromSearch(helpers, swiftypeOptions);
     }
 
     warn(reporter);

--- a/packages/gatsby-theme-newrelic/src/utils/related-resources/search.js
+++ b/packages/gatsby-theme-newrelic/src/utils/related-resources/search.js
@@ -1,52 +1,59 @@
 const fetch = require('node-fetch');
-const { appendTrailingSlash, stripTrailingSlash } = require('./url');
+const { stripTrailingSlash } = require('./url');
 
-const normalizeUrl = (url) => {
-  const prefix = url.startsWith('!') ? '!' : '';
-  const plainUrl = url.replace(/^!/, '');
+// Build-time related-resources lookup against SearchGPT.
+//
+// This runs across many pages during the build, so it uses the lexical
+// /v2/search/suggest endpoint: per the SearchGPT docs it is the recommended
+// path for related-content lookups and is NOT rate limited (unlike /v2/search).
+const BASE_URL =
+  process.env.SEARCHGPT_BASE_URL ||
+  process.env.GATSBY_SEARCHGPT_BASE_URL ||
+  'https://support-search.service.newrelic.com';
 
-  return [
-    prefix + appendTrailingSlash(plainUrl),
-    prefix + stripTrailingSlash(plainUrl),
-  ];
-};
+const API_KEY =
+  process.env.SEARCHGPT_API_KEY || process.env.GATSBY_SEARCHGPT_API_KEY;
 
-const uniq = (arr) => [...new Set(arr)];
+const SOURCES = ['nr-docs'];
 
-module.exports = async (
-  url,
-  params = {},
-  { engineKey, limit, excludedUrls }
-) => {
-  const { page: pageFilters = {} } = params.filters || {};
+module.exports = async (url, params = {}, { limit = 5, excludedUrls = [] }) => {
+  const searchTerm = params.q;
 
-  const res = await fetch(
-    'https://search-api.swiftype.com/api/v1/public/engines/search.json',
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        ...params,
-        engine_key: engineKey,
-        per_page: limit,
-        filters: {
-          ...params.filters,
-          page: {
-            ...pageFilters,
-            url: uniq([
-              ...excludedUrls.flatMap((url) => normalizeUrl(`!${url}`)),
-              ...normalizeUrl(`!${url}`),
-              ...(pageFilters.url || []).flatMap(normalizeUrl),
-            ]),
-          },
-        },
-      }),
-    }
-  );
+  if (!searchTerm) {
+    return [];
+  }
 
-  const { records } = await res.json();
+  // urls to drop from results: the page itself plus its declared
+  // resources/redirects, compared without trailing slashes
+  const excluded = new Set([url, ...excludedUrls].map(stripTrailingSlash));
 
-  return records.page;
+  // request extra so we still have `limit` results after filtering excludes
+  const query = new URLSearchParams({
+    q: searchTerm,
+    sources: JSON.stringify(SOURCES),
+    limit: String(limit + excluded.size + 5),
+  });
+
+  try {
+    const res = await fetch(`${BASE_URL}/v2/search/suggest?${query}`, {
+      headers: { 'api-key': API_KEY },
+    });
+
+    const { results = [] } = await res.json();
+
+    return results
+      .map((result) => ({
+        title: result.title,
+        url: result.url || result.href,
+      }))
+      .filter((result) => !excluded.has(stripTrailingSlash(result.url)))
+      .slice(0, limit);
+  } catch (err) {
+    // related resources are non-critical enrichment; never fail the build
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[gatsby-theme-newrelic] related-resources lookup failed: ${err.message}`
+    );
+    return [];
+  }
 };

--- a/packages/gatsby-theme-newrelic/src/utils/searchGPT.js
+++ b/packages/gatsby-theme-newrelic/src/utils/searchGPT.js
@@ -1,0 +1,151 @@
+// Client for the SearchGPT REST API (v2), which replaces Swiftype.
+//
+// Two endpoints back two different UI surfaces:
+//   - suggest(): GET /v2/search/suggest — lexical typeahead. NOT rate limited,
+//     safe to call on every keystroke, returns no body.
+//   - search():  GET /v2/search — hybrid semantic search with cursor pagination
+//     and full bodies. Rate limited per principal, but cached/identical queries
+//     and pagination requests do not count against the limit.
+//
+// The base URL is env-driven so we can move from direct-browser calls to a
+// backend proxy later without touching any callers — only the env var changes.
+
+const DEFAULT_BASE_URL = 'https://support-search.service.newrelic.com';
+
+// developer/opensource/quickstarts were deprecated and redirect to docs, so a
+// single source covers everything we previously queried in Swiftype.
+const DEFAULT_SOURCES = ['nr-docs'];
+
+const getBaseUrl = () =>
+  process.env.GATSBY_SEARCHGPT_BASE_URL || DEFAULT_BASE_URL;
+
+const getApiKey = () => process.env.GATSBY_SEARCHGPT_API_KEY;
+
+// Thrown on HTTP 429 so callers can surface a "try again" state and read the
+// reset window. rateLimit shape: { limit, remaining, resetInSeconds }.
+export class RateLimitError extends Error {
+  constructor(rateLimit) {
+    super('SearchGPT rate limit exceeded');
+    this.name = 'RateLimitError';
+    this.rateLimit = rateLimit;
+  }
+}
+
+const buildUrl = (path, params) => {
+  const url = new URL(path, getBaseUrl());
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value == null || value === '') return;
+    // array params (sources, tags) are passed as a JSON-encoded string
+    url.searchParams.set(
+      key,
+      Array.isArray(value) ? JSON.stringify(value) : value
+    );
+  });
+
+  return url.toString();
+};
+
+const request = async (path, params) => {
+  const res = await fetch(buildUrl(path, params), {
+    headers: { 'api-key': getApiKey() },
+  });
+
+  const body = await res.json();
+
+  if (res.status === 429) {
+    throw new RateLimitError(body?.error?.rateLimit);
+  }
+
+  if (!res.ok || body.success === false) {
+    throw new Error(
+      body?.error?.message || `Search request failed (${res.status})`
+    );
+  }
+
+  return body;
+};
+
+// href/url and sourceName/sourceLabel are duplicate fields kept for historical
+// client shapes; we normalize to a single canonical key for each.
+const normalizeResult = (result) => ({
+  id: result.id,
+  url: result.url || result.href,
+  title: result.title,
+  // highlighted (contains <span class='highlight'>…</span>)
+  summary: result.summary,
+  // longer highlighted body — only present on /v2/search, not suggest
+  bodyHighlights: result.bodyHighlights,
+  sourceLabel: result.sourceLabel || result.sourceName,
+  score: result.score,
+  tags: result.tags || [],
+  createdDate: result.createdDate,
+  lastModifiedDate: result.lastModifiedDate,
+});
+
+/**
+ * Hybrid search with full bodies and cursor pagination. Rate limited.
+ * Use on submit / results page, not on keystroke.
+ */
+export const search = async ({
+  searchTerm,
+  sources = DEFAULT_SOURCES,
+  cursor,
+  sort,
+  since,
+  until,
+  tags,
+}) => {
+  const body = await request('/v2/search', {
+    q: searchTerm,
+    sources,
+    cursor,
+    sort,
+    since,
+    until,
+    tags,
+  });
+
+  const results = (body.results || []).map(normalizeResult);
+
+  return {
+    results,
+    nextCursor: body.nextCursor || null,
+    prevCursor: body.prevCursor || null,
+    // top-level totalCount isn't present in every response shape; each result
+    // also carries resultsTotal, so fall back to that.
+    totalCount: body.totalCount ?? body.results?.[0]?.resultsTotal ?? null,
+  };
+};
+
+/**
+ * Lexical (FTS) typeahead. NOT rate limited and returns no body, so it is safe
+ * to call on every keystroke. Results differ from search() because suggest is
+ * lexical-only while search is hybrid/semantic.
+ */
+export const suggest = async ({
+  searchTerm,
+  sources = DEFAULT_SOURCES,
+  tags,
+  limit,
+}) => {
+  const body = await request('/v2/search/suggest', {
+    q: searchTerm,
+    sources,
+    tags,
+    limit,
+  });
+
+  return {
+    results: (body.results || []).map(normalizeResult),
+  };
+};
+
+/** Available tag values for the given sources, for building filter UI. */
+export const fetchTags = async ({ sources = DEFAULT_SOURCES } = {}) => {
+  const body = await request('/v2/search/tags', { sources });
+
+  return body.tags || [];
+};
+
+export { DEFAULT_SOURCES, DEFAULT_BASE_URL };


### PR DESCRIPTION
## Summary

Replaces the Swiftype search integration with New Relic's **SearchGPT REST API (v2)** across all theme-side search surfaces. Part of [NR-580466](https://new-relic.atlassian.net/browse/NR-580466) (FY27Q2: Docs Engineering — AI-Native Search).

REST was chosen over NerdGraph/GraphQL because its two-tier model fits our two UI surfaces and sidesteps the rate-limit problem on a public, single-key site:
- **`/v2/search/suggest`** — lexical typeahead, **not rate limited** → powers the as-you-type dropdown.
- **`/v2/search`** — hybrid, cursor-paginated, full bodies (cache-aware, rate-limited) → powers the results page.

## What changed

- **New `src/utils/searchGPT.js` client** — `search()`, `suggest()`, `fetchTags()`, `RateLimitError`. Base URL + api-key are env-driven (`GATSBY_SEARCHGPT_BASE_URL` / `GATSBY_SEARCHGPT_API_KEY`) so a backend proxy can slot in later with no code change.
- **Header dropdown** (`useSearch` + `GlobalSearch`) → `/v2/search/suggest`; "View more" grows the suggest `limit` to append results inline (same UX as before).
- **Public `search()` export** → re-points at `/v2/search` with a normalized shape `{ results, nextCursor, prevCursor, totalCount }`. **Breaking shape change** for consumers — see follow-ups.
- **404 page** suggestions → `suggest()`.
- **Build-time related-resources** → `/v2/search/suggest` (unthrottled, per SearchGPT docs guidance), excluded URLs filtered client-side.
- **New `src/utils/highlightText.js`** — client-side highlighting of query terms in titles (SearchGPT only highlights `summary`/`bodyHighlights`); HTML-escaped (XSS-safe).
- Removed unused `SWIFTYPE_ENGINE_KEY`; updated README (env vars + relatedResources docs).

## Testing

- `yarn test` — 90/90 passing; lint clean on all changed files.
- Client validated against the live API (cursor pagination, suggest-has-no-body, encoding).
- Locally smoke-tested via the demo (`/search-test` + `/search-results`) behind a dev proxy.

## Intentionally retained / deferred

- **`data-swiftype-index` attributes kept** — Swiftype is still live during cutover; removing them would pollute its index. Remove only after Swiftype is decommissioned.
- **Analytics event names** (`swiftypeSearchInput`/`swiftypeSearchResult`) **not renamed** — queried by existing NR dashboards; needs analytics-owner coordination.
- **SearchModal dead code** left in place pending team confirmation (unused/unexported, still on old shape).
- **Temp demo scaffolding** (`demo/src/pages/search-test.js`, `search-results.js`, dev proxy in `demo/gatsby-node.js`) — to be removed before final merge.

## Follow-ups (separate)

- **docs-website `/search-results` page** must be updated for the new `search()` shape + cursor pagination (demo `search-results.js` is the reference).
- Open questions for the SearchGPT team: public/anonymous auth + CORS `api-key` header, page-size param for `/v2/search`, server-side title highlighting, locale handling.


[NR-580466]: https://new-relic.atlassian.net/browse/NR-580466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ