### PR TITLE
fix(search): preserve locale when navigating to search-results

### DIFF
--- a/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
@@ -5,9 +5,11 @@ import { css } from '@emotion/react';
 import { useThrottle } from 'react-use';
 
 import useKeyPress from '../hooks/useKeyPress';
+import useLocale from '../hooks/useLocale';
 import useThemeTranslation from '../hooks/useThemeTranslation';
 import useScrollFreeze from '../hooks/useScrollFreeze';
 import { addPageAction } from '../utils/nrBrowserAgent';
+import { localizePath } from '../utils/localization';
 
 import useSearch from './SearchModal/useSearch';
 import SearchInput from './SearchInput';
@@ -58,6 +60,7 @@ const GlobalSearch = ({ onClose }) => {
 
   const searchRef = useRef(null);
   const { t } = useThemeTranslation();
+  const locale = useLocale();
 
   useKeyPress('/', (e) => {
     // prevent quick search from opening in Firefox
@@ -114,7 +117,12 @@ const GlobalSearch = ({ onClose }) => {
                 position,
                 searchType: 'globalSearch',
               });
-              navigate(`/search-results/?query=${recentQuery}&page=1`);
+              navigate(
+                localizePath({
+                  path: `/search-results/?query=${recentQuery}&page=1`,
+                  locale,
+                })
+              );
             }
           } else {
             saveSearch(value);
@@ -126,7 +134,12 @@ const GlobalSearch = ({ onClose }) => {
               searchTerm: query,
               searchType: 'globalSearch',
             });
-            navigate(`/search-results/?query=${value}&page=1`);
+            navigate(
+              localizePath({
+                path: `/search-results/?query=${value}&page=1`,
+                locale,
+              })
+            );
           }
         }}
         placeholder={t('searchInput.placeholder')}

--- a/packages/gatsby-theme-newrelic/src/components/SearchDropdown/SearchDropdown.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchDropdown/SearchDropdown.js
@@ -7,6 +7,8 @@ import cx from 'classnames';
 import KeyboardLegend from './KeyboardLegend';
 import Results, { ResultType } from './Results';
 import Skeleton from './Skeleton';
+import useLocale from '../../hooks/useLocale';
+import { localizePath } from '../../utils/localization';
 
 const SearchDropdown = ({
   onViewMore,
@@ -22,6 +24,7 @@ const SearchDropdown = ({
   ...rest
 }) => {
   const loading = status === 'loading';
+  const locale = useLocale();
   const error = status === 'error';
   return (
     <>
@@ -33,7 +36,10 @@ const SearchDropdown = ({
               {recentQueries.map((query, i) => (
                 <li key={query} className={cx({ selected: selected === i })}>
                   <a
-                    href={`/search-results/?query=${query}&page=1`}
+                    href={localizePath({
+                      path: `/search-results/?query=${query}&page=1`,
+                      locale,
+                    })}
                     onClick={() => onRecentClick(query, i)}
                   >
                     {query}

--- a/packages/gatsby-theme-newrelic/src/pages/404.js
+++ b/packages/gatsby-theme-newrelic/src/pages/404.js
@@ -12,9 +12,11 @@ import Tag from '../components/Tag';
 import CreateIssueButton from '../components/CreateIssueButton';
 import Button from '../components/Button';
 import getLocale from '../../gatsby/utils/getLocale';
+import useLocale from '../hooks/useLocale';
 import useThemeTranslation from '../hooks/useThemeTranslation';
 import Trans from '../components/Trans';
 import { addPageAction } from '../utils/nrBrowserAgent.js';
+import { localizePath } from '../utils/localization';
 import { suggest, localeToSearchLanguage } from '../utils/searchGPT';
 
 const NotFoundPage = ({ location, pageContext: { themeOptions } }) => {
@@ -32,6 +34,7 @@ const NotFoundPage = ({ location, pageContext: { themeOptions } }) => {
     }
   `);
   const { t: translate } = useThemeTranslation();
+  const locale = useLocale();
   const [searchTerm, setSearchTerm] = useState(null);
   const [searchResult, setSearchResult] = useState(null);
 
@@ -204,10 +207,13 @@ const NotFoundPage = ({ location, pageContext: { themeOptions } }) => {
                 placeholder={searchTerm}
                 onFocus={() =>
                   navigate(
-                    `search-results/?query=${searchTerm.replaceAll(
-                      ' ',
-                      '+'
-                    )}&page=1`
+                    localizePath({
+                      path: `/search-results/?query=${searchTerm.replaceAll(
+                        ' ',
+                        '+'
+                      )}&page=1`,
+                      locale,
+                    })
                   )
                 }
                 css={css`


### PR DESCRIPTION
## Summary

Fixes a locale-drop bug in search navigation. On localized sites (e.g. `/fr/`), the header search typeahead correctly calls the SearchGPT `suggest` API with `language=fr`, but pressing **Enter** navigated to an absolute `/search-results/` path **with no locale prefix**. That dropped the `/fr/`, landed the user on the English results page, and — because the results page derives its language from `useLocale()` on the URL — scoped the actual `search` query to `language=en`. The wrong language was a downstream symptom; the real bug was the unlocalized navigation.

## Root cause

Three navigations built an absolute `/search-results/?query=…` string and passed it straight to `navigate()` / an `<a href>`, bypassing the theme's locale prefixing:

- `GlobalSearch.js` — header search `onSubmit` (both the fresh-query and selected-recent-query branches)
- `SearchDropdown.js` — the "Recent search terms" links
- `404.js` — the 404-page search input `onFocus`

## Fix

Route all three through the existing `localizePath({ path, locale })` helper (`utils/localization.js`), with `locale` from `useLocale()`. `localizePath` is a **no-op on the default English site** and prefixes the locale otherwise, so:

- `docs.newrelic.com/search-results/…` is unchanged.
- `docs.newrelic.com/fr/…` → `/fr/search-results/…`, preserving the locale and letting the results page resolve `language=fr`.

This matches how the theme `Link` component already localizes internal paths.

## Release

Conventional-commit `fix:` → **patch** bump (9.17.0 → **9.17.1**).

## Verification

- `eslint` passes on all three changed files.
- Behavior to confirm on a deploy preview: on `/fr/`, Enter from the header search (and clicking a recent term) navigates to `/fr/search-results/…` and the results call goes out with `language=fr`; on the default English site the URLs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
