### PR TITLE
feat(search): proxy-aware SearchGPT client + debounced suggest

### DIFF
--- a/packages/gatsby-theme-newrelic/README.md
+++ b/packages/gatsby-theme-newrelic/README.md
@@ -145,16 +145,36 @@ yarn add @newrelic/gatsby-theme-newrelic @emotion/core @emotion/styled @mdx-js/m
 Search is powered by the SearchGPT REST API and is configured via environment
 variables:
 
-- `GATSBY_SEARCHGPT_API_KEY` _(required)_: New Relic API key used to authenticate
-  search requests. Because it is `GATSBY_`-prefixed, it is inlined into the
-  client bundle and used by the global search dropdown, the search results page,
-  and the 404 page.
-- `GATSBY_SEARCHGPT_BASE_URL` _(optional)_: Base URL of the SearchGPT service.
-  Defaults to `https://support-search.service.newrelic.com`. Point this at a
-  proxy or staging endpoint to override it without code changes.
-- `SEARCHGPT_API_KEY` / `SEARCHGPT_BASE_URL` _(optional)_: Server-side fallbacks
-  used by the build-time related-resources lookup. If unset, the `GATSBY_`
-  variables above are used.
+There are two ways to authenticate. **Production sites should use the proxy
+model** so that no API key is ever shipped to browsers.
+
+**Recommended — backend proxy (no key in the client):**
+
+- `GATSBY_SEARCHGPT_BASE_URL="/"`: routes search through a same-origin proxy. A
+  value starting with `/` is resolved against the current origin, so the client
+  calls `<origin>/v2/*` with **no** credentials. Stand up a proxy that answers
+  `/v2/*`, injects the `api-key` header server-side, and forwards to the
+  SearchGPT service. See `netlify/functions/searchgpt-proxy.mjs` in docs-website
+  for the reference implementation, and `demo/gatsby-node.js` (`onCreateDevServer`)
+  for the local-dev equivalent. Leave `GATSBY_SEARCHGPT_API_KEY` **unset** here.
+- `SEARCHGPT_API_KEY` _(server-side)_: the key the proxy — and the build-time
+  related-resources lookup — use. Set it in your deploy platform's env UI; never
+  commit it. It is **not** `GATSBY_`-prefixed, so it is never inlined into the
+  client bundle.
+
+**Direct-to-service (local development only):**
+
+- `GATSBY_SEARCHGPT_API_KEY`: API key used to authenticate search requests
+  directly from the browser (global search dropdown, search results page, 404
+  page). ⚠️ Because it is `GATSBY_`-prefixed, Gatsby inlines it into the **public
+  client bundle** at build time — anyone can read it. Do not use this in
+  production; prefer the proxy model above. If you must, use only a scoped,
+  non-personal, public-safe key.
+- `GATSBY_SEARCHGPT_BASE_URL` _(optional)_: absolute base URL of the SearchGPT
+  service. Defaults to `https://support-search.service.newrelic.com`.
+- `SEARCHGPT_BASE_URL` _(optional)_: server-side base URL override for the
+  build-time related-resources lookup. Falls back to `GATSBY_SEARCHGPT_BASE_URL`,
+  then the default.
 
 ## Configuration
 

--- a/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/GlobalSearch.js
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { navigate } from '@reach/router';
 import { css } from '@emotion/react';
-import { useThrottle } from 'react-use';
 
 import useKeyPress from '../hooks/useKeyPress';
 import useLocale from '../hooks/useLocale';
@@ -18,9 +17,10 @@ import SearchDropdown, { DEFAULT_FILTER_TYPES } from './SearchDropdown';
 const GlobalSearch = ({ onClose }) => {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const throttledQuery = useThrottle(query, 300);
+  // useSearch debounces internally, so the raw query is passed straight through
+  // — no throttle needed here (that would just add a second, redundant limiter).
   const { results, status, fetchNextPage, hasMore } = useSearch({
-    searchTerm: throttledQuery,
+    searchTerm: query,
     filters: DEFAULT_FILTER_TYPES,
   });
   // a const assignment here is causing the dev server to fail to build

--- a/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearch.js
+++ b/packages/gatsby-theme-newrelic/src/components/SearchModal/useSearch.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDebounce } from 'react-use';
 import { useQuery } from 'react-query';
 import {
   suggest,
@@ -13,6 +14,15 @@ import useLocale from '../../hooks/useLocale';
 // limit and re-queries — appending the next page of results inline. Because
 // suggest isn't rate limited, re-fetching a slightly larger list is cheap.
 const PAGE_SIZE = 5;
+
+// Wait for the user to pause typing before firing a request, rather than firing
+// on every keystroke. This is the single point where suggest() is called, so
+// debouncing here rate-limits every consumer (header dropdown, search modal) and
+// can't be bypassed. It collapses a burst of keystrokes into one request, which
+// cuts both the load on the search service and — behind the same-origin proxy —
+// the number of proxy (Netlify function) invocations. 300ms is imperceptible
+// while typing but eliminates the intermediate requests a throttle would send.
+const DEBOUNCE_MS = 300;
 
 const useSearch = ({ searchTerm, filters }) => {
   // `filters` is retained for API compatibility. SearchGPT queries a single
@@ -30,23 +40,39 @@ const useSearch = ({ searchTerm, filters }) => {
 
   const [limit, setLimit] = useState(PAGE_SIZE);
 
+  // The debounced term is what actually drives the query. It trails `searchTerm`
+  // by DEBOUNCE_MS and only settles once typing pauses, so intermediate
+  // keystrokes never reach suggest(). Seeded with searchTerm so a term that's
+  // present on mount (e.g. the modal opened with a `q` param) searches
+  // immediately rather than after a delay.
+  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState(searchTerm);
+  useDebounce(() => setDebouncedSearchTerm(searchTerm), DEBOUNCE_MS, [
+    searchTerm,
+  ]);
+
   // Scope suggestions to the site's language (jp→ja, kr→ko, pt→pt-br); on the
   // default English site this is `en`. undefined for an unmapped locale, which
   // omits the param and searches across all languages.
   const { locale } = useLocale() || {};
   const language = localeToSearchLanguage(locale);
 
-  // reset back to the first page whenever the query or filters change
+  // reset back to the first page whenever the (settled) query or filters change
   useEffect(() => {
     setLimit(PAGE_SIZE);
-  }, [searchTerm, tags]);
+  }, [debouncedSearchTerm, tags]);
 
   const { status, data } = useQuery(
-    ['searchSuggest', searchTerm, tags, limit, language],
+    ['searchSuggest', debouncedSearchTerm, tags, limit, language],
     () =>
-      suggest({ searchTerm, sources: DEFAULT_SOURCES, tags, limit, language }),
+      suggest({
+        searchTerm: debouncedSearchTerm,
+        sources: DEFAULT_SOURCES,
+        tags,
+        limit,
+        language,
+      }),
     {
-      enabled: Boolean(searchTerm),
+      enabled: Boolean(debouncedSearchTerm),
       select: ({ results }) => results,
       // keep the current results visible while the larger page loads, so
       // growing the limit reads as an append rather than a reload

--- a/packages/gatsby-theme-newrelic/src/utils/searchGPT.js
+++ b/packages/gatsby-theme-newrelic/src/utils/searchGPT.js
@@ -34,9 +34,28 @@ const LOCALE_TO_SEARCH_LANGUAGE = {
 export const localeToSearchLanguage = (locale) =>
   LOCALE_TO_SEARCH_LANGUAGE[locale] || undefined;
 
-const getBaseUrl = () =>
-  process.env.GATSBY_SEARCHGPT_BASE_URL || DEFAULT_BASE_URL;
+// When GATSBY_SEARCHGPT_BASE_URL is a relative path (e.g. "/"), search runs
+// through a same-origin backend proxy: it is resolved against the current origin
+// so the browser calls <origin>/v2/* — and deploy previews hit their own proxy
+// rather than production. The proxy injects the api-key server-side, so no key
+// ships to the client. An absolute URL is used verbatim; when unset we call the
+// service directly. There is no `window` during SSR/build, so fall back to the
+// default there (the build-time related-resources path has its own server-side
+// key and does not go through this).
+const getBaseUrl = () => {
+  const configured = process.env.GATSBY_SEARCHGPT_BASE_URL;
+  if (!configured) return DEFAULT_BASE_URL;
+  if (configured.startsWith('/')) {
+    return typeof window !== 'undefined'
+      ? window.location.origin
+      : DEFAULT_BASE_URL;
+  }
+  return configured;
+};
 
+// Undefined when proxying: the key lives only in the proxy's server env, never
+// in the client bundle. request() then omits the api-key header and the proxy
+// adds it.
 const getApiKey = () => process.env.GATSBY_SEARCHGPT_API_KEY;
 
 // Thrown on HTTP 429 so callers can surface a "try again" state and read the
@@ -70,8 +89,12 @@ const buildUrl = (path, params) => {
 };
 
 const request = async (path, params) => {
+  const apiKey = getApiKey();
   const res = await fetch(buildUrl(path, params), {
-    headers: { 'api-key': getApiKey() },
+    // Only send the api-key when we have one (direct-to-service mode). Behind a
+    // same-origin proxy the browser has no key and the proxy injects it, so we
+    // send no header rather than an empty one.
+    headers: apiKey ? { 'api-key': apiKey } : undefined,
   });
 
   const body = await res.json();


### PR DESCRIPTION
## Summary
- Resolve `GATSBY_SEARCHGPT_BASE_URL` relative values (e.g. `/`) against the current origin so search runs through a same-origin backend proxy — the browser calls `<origin>/v2/*` with no credentials and the proxy injects the `api-key` header server-side, so production never inlines a real key into the public client bundle.
- Debounce `suggest()` (300ms) inside `useSearch` instead of a separate throttle in `GlobalSearch`, covering every caller (header dropdown + search modal) at the single point where the query fires, cutting load on the search service and on the proxy.

## Test plan
- [ ] `yarn workspace demo develop` — verify search suggestions and results still work locally (direct-to-service mode via `.env.development`)
- [ ] Confirm `api-key` header is omitted when `GATSBY_SEARCHGPT_BASE_URL` is unset/relative and no `GATSBY_SEARCHGPT_API_KEY` is present
- [ ] Type quickly in the search box/modal and confirm suggestions debounce (no request per keystroke) with no regression in responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)